### PR TITLE
fix gcc warning message in public header when using c++11

### DIFF
--- a/src/LinearMath/btScalar.h
+++ b/src/LinearMath/btScalar.h
@@ -97,7 +97,7 @@ inline int	btGetVersion()
 #ifdef BT_DEBUG
 	#ifdef _MSC_VER
 		#include <stdio.h>
-		#define btAssert(x) { if(!(x)){printf("Assert "__FILE__ ":%u ("#x")\n", __LINE__);__debugbreak();	}}
+		#define btAssert(x) { if(!(x)){printf("Assert " __FILE__  ":%u ("#x")\n", __LINE__);__debugbreak();	}}
 	#else//_MSC_VER
 		#include <assert.h>
 		#define btAssert assert
@@ -125,7 +125,7 @@ inline int	btGetVersion()
 #ifdef __SPU__
 #include <spu_printf.h>
 #define printf spu_printf
-	#define btAssert(x) {if(!(x)){printf("Assert "__FILE__ ":%u ("#x")\n", __LINE__);spu_hcmpeq(0,0);}}
+	#define btAssert(x) {if(!(x)){printf("Assert " __FILE__  ":%u ("#x")\n", __LINE__);spu_hcmpeq(0,0);}}
 #else
 	#define btAssert assert
 #endif


### PR DESCRIPTION
When using bullet in a project using GCC in C++11 mode and using -Wall, a warning message gets generated numerous times:

include/bullet/LinearMath/btScalar.h:100:41:
warning: invalid suffix on literal; C++11 requires a space between
literal and string macro [-Wliteral-suffix]
