### PR TITLE
Fix OSX build, link to Cocoa framework

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -226,6 +226,10 @@ ENDIF(USE_GLUT)
 	ENDIF()
 ENDIF(BUILD_BULLET2_DEMOS)
 
+IF (APPLE)
+  FIND_LIBRARY(COCOA_LIBRARY Cocoa)
+ENDIF()
+
 OPTION(BUILD_BULLET3 "Set when you want to build Bullet 3" ON)
 IF(BUILD_BULLET3)
 	OPTION(BUILD_BULLET3_DEMOS "Set when you want to build the Bullet 3 demos" ON)

--- a/btgui/OpenGLWindow/CMakeLists.txt
+++ b/btgui/OpenGLWindow/CMakeLists.txt
@@ -40,6 +40,8 @@ ENDIF()
 ADD_LIBRARY(OpenGLWindow ${OpenGLWindow_SRCS} ${OpenGLWindow_HDRS})
 if (UNIX AND NOT APPLE)
   target_link_libraries(OpenGLWindow X11)
+elseif (APPLE)
+  target_link_libraries(OpenGLWindow ${COCOA_LIBRARY})
 endif ()
 
 if (BUILD_SHARED_LIBS)


### PR DESCRIPTION
I've been getting linking errors when trying to build on osx. This fixes it.
