### PR TITLE
Add .travis.yml for continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,7 @@ script:
   - cmake . -G "Unix Makefiles" #-DCMAKE_CXX_FLAGS=-Werror
   - make -j8
   - sudo make install
+  # Test again with double precision
+  - cmake . -G "Unix Makefiles" -DUSE_DOUBLE_PRECISION=ON #-DCMAKE_CXX_FLAGS=-Werror
+  - make -j8
+  - sudo make install


### PR DESCRIPTION
Travis provides a pretty easy way to do continuous integration with Linux builds. I set it up on my fork with the included configuration file ([here's an example build report](https://travis-ci.org/scpeters/bullet3/builds/25625105)). It can be expanded to include regression tests or static code analysis if you wish. It can also be used to flag compiler warnings with the `-Werror` compiler flag, though I disabled that for now, since there are many compiler warnings.

In order to enable the builds, you have to login with your credentials to travis and give them some permissions. It's up to you, but I have found this to be a very useful development tool.
