### PR TITLE
Compile fix for parallelLinearBvh.cl on OS X Intel HD 5000

### DIFF
--- a/src/Bullet3OpenCL/BroadphaseCollision/kernels/parallelLinearBvh.cl
+++ b/src/Bullet3OpenCL/BroadphaseCollision/kernels/parallelLinearBvh.cl
@@ -276,7 +276,7 @@ int rayIntersectsAabb(b3Vector3 rayOrigin, b3Scalar rayLength, b3Vector3 rayNorm
 	//In order for there to be a collision, the t_min and t_max of each pair must overlap.
 	//This can be tested for by selecting the highest t_min and lowest t_max and comparing them.
 	
-	int4 isNegative = isless( rayNormalizedDirection, (b3Vector3){0.0f, 0.0f, 0.0f, 0.0f} );	//isless(x,y) returns (x < y)
+	int4 isNegative = isless( rayNormalizedDirection, ((b3Vector3){0.0f, 0.0f, 0.0f, 0.0f}) );	//isless(x,y) returns (x < y)
 	
 	//When using vector types, the select() function checks the most signficant bit, 
 	//but isless() sets the least significant bit.

--- a/src/Bullet3OpenCL/BroadphaseCollision/kernels/parallelLinearBvhKernels.h
+++ b/src/Bullet3OpenCL/BroadphaseCollision/kernels/parallelLinearBvhKernels.h
@@ -258,7 +258,7 @@ static const char* parallelLinearBvhCL= \
 "	//In order for there to be a collision, the t_min and t_max of each pair must overlap.\n"
 "	//This can be tested for by selecting the highest t_min and lowest t_max and comparing them.\n"
 "	\n"
-"	int4 isNegative = isless( rayNormalizedDirection, (b3Vector3){0.0f, 0.0f, 0.0f, 0.0f} );	//isless(x,y) returns (x < y)\n"
+"	int4 isNegative = isless( rayNormalizedDirection, ((b3Vector3){0.0f, 0.0f, 0.0f, 0.0f}) );	//isless(x,y) returns (x < y)\n"
 "	\n"
 "	//When using vector types, the select() function checks the most signficant bit, \n"
 "	//but isless() sets the least significant bit.\n"


### PR DESCRIPTION
It seems that there is an issue with the CL parser on my Mac's HD 5000. The first comma in the vector literal is parsed as a third argument to `isless`. A grouping fixed it right away
