### PR TITLE
No system headers when cross-compiling.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,7 +214,7 @@ IF (USE_GLUT)
 		ENDIF (GLUT_FOUND)
 	ENDIF (MSVC)
 
-	IF(NOT WIN32 AND NOT APPLE)	
+	IF(NOT WIN32 AND NOT APPLE AND NOT CMAKE_CROSSCOMPILING)
 		# This is added for linux. This should always work if everything is installed and working fine.
 		SET(GLUT_INCLUDE_DIR /usr/include /usr/local/include)
 	ENDIF()


### PR DESCRIPTION
Fix CMakeLists.txt to not unconditionally add include paths to native system headers in /usr/include and /usr/local/include, which contain include files for the host architecture, and not the target architecture that is being compiled for.
