### PR TITLE
Replaced the collision states defines

### DIFF
--- a/Demos/OpenGL/DemoApplication.cpp
+++ b/Demos/OpenGL/DemoApplication.cpp
@@ -1240,8 +1240,8 @@ void	DemoApplication::renderscene(int pass)
 		}
 		btVector3 wireColor(1.f,1.0f,0.5f); //wants deactivation
 		if(i&1) wireColor=btVector3(0.f,0.0f,1.f);
-		///color differently for active, sleeping, wantsdeactivation states
-		if (colObj->getActivationState() == 1) //active
+		///color differently for active, sleeping, wants deactivation states
+		if (colObj->getActivationState() == ACTIVE_TAG) //active
 		{
 			if (i & 1)
 			{
@@ -1252,7 +1252,7 @@ void	DemoApplication::renderscene(int pass)
 				wireColor += btVector3 (.5f,0.f,0.f);
 			}
 		}
-		if(colObj->getActivationState()==2) //ISLAND_SLEEPING
+		if(colObj->getActivationState()== ISLAND_SLEEPING)
 		{
 			if(i&1)
 			{

--- a/src/BulletCollision/CollisionDispatch/btCollisionObject.cpp
+++ b/src/BulletCollision/CollisionDispatch/btCollisionObject.cpp
@@ -49,13 +49,13 @@ btCollisionObject::~btCollisionObject()
 {
 }
 
-void btCollisionObject::setActivationState(int newState) const
+void btCollisionObject::setActivationState(ActivationStates newState) const
 { 
 	if ( (m_activationState1 != DISABLE_DEACTIVATION) && (m_activationState1 != DISABLE_SIMULATION))
 		m_activationState1 = newState;
 }
 
-void btCollisionObject::forceActivationState(int newState) const
+void btCollisionObject::forceActivationState(ActivationStates newState) const
 {
 	m_activationState1 = newState;
 }

--- a/src/BulletCollision/CollisionDispatch/btCollisionObject.h
+++ b/src/BulletCollision/CollisionDispatch/btCollisionObject.h
@@ -19,11 +19,15 @@ subject to the following restrictions:
 #include "LinearMath/btTransform.h"
 
 //island management, m_activationState1
-#define ACTIVE_TAG 1
-#define ISLAND_SLEEPING 2
-#define WANTS_DEACTIVATION 3
-#define DISABLE_DEACTIVATION 4
-#define DISABLE_SIMULATION 5
+
+enum ActivationStates
+{
+	ACTIVE_TAG = 1,
+	ISLAND_SLEEPING = 2,
+	WANTS_DEACTIVATION = 3,
+	DISABLE_DEACTIVATION = 4,
+	DISABLE_SIMULATION = 5
+};
 
 struct	btBroadphaseProxy;
 class	btCollisionShape;
@@ -268,7 +272,7 @@ public:
 
 	SIMD_FORCE_INLINE	int	getActivationState() const { return m_activationState1;}
 	
-	void setActivationState(int newState) const;
+	void setActivationState(ActivationStates newState) const;
 
 	void	setDeactivationTime(btScalar time)
 	{
@@ -279,7 +283,7 @@ public:
 		return m_deactivationTime;
 	}
 
-	void forceActivationState(int newState) const;
+	void forceActivationState(ActivationStates newState) const;
 
 	void	activate(bool forceActivation = false) const;
 

--- a/src/BulletDynamics/Dynamics/btRigidBody.h
+++ b/src/BulletDynamics/Dynamics/btRigidBody.h
@@ -424,7 +424,6 @@ public:
 		} else
 		{
 			m_deactivationTime=btScalar(0.);
-			setActivationState(0);
 		}
 
 	}
@@ -442,7 +441,7 @@ public:
 		if ( (getActivationState() == ISLAND_SLEEPING) || (getActivationState() == WANTS_DEACTIVATION))
 			return true;
 
-		if (m_deactivationTime> gDeactivationTime)
+		if (m_deactivationTime > gDeactivationTime)
 		{
 			return true;
 		}


### PR DESCRIPTION
ACTIVE_TAG = 1,
ISLAND_SLEEPING = 2,
WANTS_DEACTIVATION = 3,
DISABLE_DEACTIVATION = 4,
DISABLE_SIMULATION = 5

With an enum, thus validating at compile time that

setActivationState(), forceActivationState() calls always receive valid arguments.
Also, changed the demo application and btRigidBody to reflect the change.