### PR TITLE
Fix for use of uninitialized variables.

### DIFF
--- a/src/BulletCollision/CollisionShapes/btBox2dShape.h
+++ b/src/BulletCollision/CollisionShapes/btBox2dShape.h
@@ -103,11 +103,12 @@ public:
 		btScalar minDimension = boxHalfExtents.getX();
 		if (minDimension>boxHalfExtents.getY())
 			minDimension = boxHalfExtents.getY();
-		setSafeMargin(minDimension);
 
 		m_shapeType = BOX_2D_SHAPE_PROXYTYPE;
 		btVector3 margin(getMargin(),getMargin(),getMargin());
 		m_implicitShapeDimensions = (boxHalfExtents * m_localScaling) - margin;
+
+		setSafeMargin(minDimension);
 	};
 
 	virtual void setMargin(btScalar collisionMargin)

--- a/src/BulletCollision/CollisionShapes/btBoxShape.cpp
+++ b/src/BulletCollision/CollisionShapes/btBoxShape.cpp
@@ -19,10 +19,10 @@ btBoxShape::btBoxShape( const btVector3& boxHalfExtents)
 {
 	m_shapeType = BOX_SHAPE_PROXYTYPE;
 
-	setSafeMargin(boxHalfExtents);
-
 	btVector3 margin(getMargin(),getMargin(),getMargin());
 	m_implicitShapeDimensions = (boxHalfExtents * m_localScaling) - margin;
+
+	setSafeMargin(boxHalfExtents);
 };
 
 

--- a/src/BulletCollision/CollisionShapes/btCylinderShape.cpp
+++ b/src/BulletCollision/CollisionShapes/btCylinderShape.cpp
@@ -19,10 +19,11 @@ btCylinderShape::btCylinderShape (const btVector3& halfExtents)
 :btConvexInternalShape(),
 m_upAxis(1)
 {
-	setSafeMargin(halfExtents);
-
 	btVector3 margin(getMargin(),getMargin(),getMargin());
 	m_implicitShapeDimensions = (halfExtents * m_localScaling) - margin;
+
+	setSafeMargin(halfExtents);
+
 	m_shapeType = CYLINDER_SHAPE_PROXYTYPE;
 }
 


### PR DESCRIPTION
m_implicitShapeDimensions was used in setMargin, called from setSafeMargin
from constructors of btBoxShape, btCylinerShape and btBox2dShape,
effectively using uninitialized variable and leading to floating point
exceptions.
It was working correctly only because in the same constructor
m_implicitShapeDimensions was reinitialized after setSafeMargin.
Properly initialize variable before use by first setting it up and only
then using it in setSafeMargin.
