### PR TITLE
Microsoft compiler wrongly assumed on Windows platform

### DIFF
--- a/src/Bullet3Common/b3Logging.cpp
+++ b/src/Bullet3Common/b3Logging.cpp
@@ -82,7 +82,7 @@ void b3OutputPrintfVarArgsInternal(const char *str, ...)
     char strDebug[B3_MAX_DEBUG_STRING_LENGTH]={0};
     va_list argList;
     va_start(argList, str);
-#ifdef _WIN32
+#ifdef _MSC_VER
     vsprintf_s(strDebug,B3_MAX_DEBUG_STRING_LENGTH,str,argList);
 #else
     vsnprintf(strDebug,B3_MAX_DEBUG_STRING_LENGTH,str,argList);
@@ -95,7 +95,7 @@ void b3OutputWarningMessageVarArgsInternal(const char *str, ...)
     char strDebug[B3_MAX_DEBUG_STRING_LENGTH]={0};
     va_list argList;
     va_start(argList, str);
-#ifdef _WIN32
+#ifdef _MSC_VER
     vsprintf_s(strDebug,B3_MAX_DEBUG_STRING_LENGTH,str,argList);
 #else
     vsnprintf(strDebug,B3_MAX_DEBUG_STRING_LENGTH,str,argList);
@@ -109,7 +109,7 @@ void b3OutputErrorMessageVarArgsInternal(const char *str, ...)
     char strDebug[B3_MAX_DEBUG_STRING_LENGTH]={0};
     va_list argList;
     va_start(argList, str);
-#ifdef _WIN32
+#ifdef _MSC_VER
     vsprintf_s(strDebug,B3_MAX_DEBUG_STRING_LENGTH,str,argList);
 #else
     vsnprintf(strDebug,B3_MAX_DEBUG_STRING_LENGTH,str,argList);
@@ -149,7 +149,7 @@ void b3SetCustomLeaveProfileZoneFunc(b3LeaveProfileZoneFunc* leaveFunc)
 
 
 
-#ifndef _WIN32
+#ifndef _MSC_VER
 #undef vsprintf_s
 #endif
 

--- a/src/Bullet3OpenCL/Initialize/b3OpenCLUtils.cpp
+++ b/src/Bullet3OpenCL/Initialize/b3OpenCLUtils.cpp
@@ -618,7 +618,7 @@ cl_program b3OpenCLUtils_compileCLProgramFromString(cl_context clContext, cl_dev
 		strippedName = strip2(clFileNameForCaching,"\\");
 		strippedName = strip2(strippedName,"/");
 	
-#ifdef _WIN32
+#ifdef _MSVC_VER
 		sprintf_s(binaryFileName,B3_MAX_STRING_LENGTH,"%s/%s.%s.%s.bin",sCachedBinaryPath,strippedName, deviceName,driverVersion );
 #else
 		sprintf(binaryFileName,"%s/%s.%s.%s.bin",sCachedBinaryPath,strippedName, deviceName,driverVersion );
@@ -765,7 +765,7 @@ cl_program b3OpenCLUtils_compileCLProgramFromString(cl_context clContext, cl_dev
 	
 	if( fileUpToDate)
 	{
-#ifdef _WIN32
+#ifdef _MSC_VER
 		FILE* file;
 		if (fopen_s(&file,binaryFileName, "rb")!=0)
 			file=0;
@@ -892,7 +892,7 @@ cl_program b3OpenCLUtils_compileCLProgramFromString(cl_context clContext, cl_dev
 
         		flagsize = sizeof(char)*(strlen(additionalMacros) + strlen(flags) + 5);
 		compileFlags = (char*) malloc(flagsize);
-#ifdef _WIN32
+#ifdef _MSC_VER
 		sprintf_s(compileFlags,flagsize, "%s %s", flags, additionalMacros);
 #else
 		sprintf(compileFlags, "%s %s", flags, additionalMacros);
@@ -941,7 +941,7 @@ cl_program b3OpenCLUtils_compileCLProgramFromString(cl_context clContext, cl_dev
 
 				{
 					FILE* file=0;
-#ifdef _WIN32
+#ifdef _MSC_VER
 					if (fopen_s(&file,binaryFileName, "wb")!=0)
 						file=0;
 #else


### PR DESCRIPTION
Right now, Bullet 3 is unbuildable using gcc through MinGW on Windows because of Microsoft-specific functions like `sprintf_s` and `fopen_s`. Since MinGW defines the `_WIN32` macro, a better candidate would be checking for `_MSC_VER` to ensure that the Microsoft-specific craziness is only included when MSVC is actually used.

An example from b3OpenCLUtils.cpp

``` c++
#ifdef _WIN32
        sprintf_s(binaryFileName,B3_MAX_STRING_LENGTH,"%s/%s.%s.%s.bin",sCachedBinaryPath,strippedName, deviceName,driverVersion );
#else
        sprintf(binaryFileName,"%s/%s.%s.%s.bin",sCachedBinaryPath,strippedName, deviceName,driverVersion );
#endif
```
