### PR TITLE
fix for bug in btRigidBody::appplyImpulse()

### DIFF
--- a/src/BulletDynamics/Dynamics/btRigidBody.h
+++ b/src/BulletDynamics/Dynamics/btRigidBody.h
@@ -177,11 +177,11 @@ public:
 
 
 	virtual ~btRigidBody()
-        { 
-                //No constraints should point to this rigidbody
+	{ 
+		//No constraints should point to this rigidbody
 		//Remove constraints from the dynamics world before you delete the related rigidbodies. 
-                btAssert(m_constraintRefs.size()==0); 
-        }
+		btAssert(m_constraintRefs.size()==0); 
+	}
 
 protected:
 
@@ -287,7 +287,7 @@ public:
 	{
 		return m_totalTorque;
 	};
-    
+
 	const btVector3& getInvInertiaDiagLocal() const
 	{
 		return m_invInertiaLocal;
@@ -320,7 +320,7 @@ public:
 		m_linearVelocity += impulse *m_linearFactor * m_inverseMass;
 	}
 	
-  	void applyTorqueImpulse(const btVector3& torque)
+	void applyTorqueImpulse(const btVector3& torque)
 	{
 			m_angularVelocity += m_invInertiaTensorWorld * torque * m_angularFactor;
 	}
@@ -329,20 +329,20 @@ public:
 	{
 		if (m_inverseMass != btScalar(0.))
 		{
-            float d = rel_pos.length();
-            if (d < SIMD_EPSILON)
-            {
+			float d = rel_pos.length();
+			if (d < SIMD_EPSILON)
+			{
 			    applyCentralImpulse(impulse);
-            }
-            else
-            {
-                btVector3 normal = rel_pos / d;
+			}
+			else
+			{
+				btVector3 normal = rel_pos / d;
 			    applyCentralImpulse(impulse.dot(normal) * normal);
 			    if (m_angularFactor)
 			    {
 				    applyTorqueImpulse(rel_pos.cross(impulse*m_linearFactor));
 			    }
-            }
+			}
 		}
 	}
 


### PR DESCRIPTION
There is an inaccuracy in btRigidBody::applyImpulse() that causes an instability in some experimental custom constraints I've been working on.  This is a proposed fix.

When an impulse is applied at some relative offset from the RigidBody's center of mass it should be split into its linear and angular components. The bugged implementation of applyImpulse() does not compute the true linear component and instead applies the full impulse at the body's center of mass.  The fixed implementation applies only the component of impulse that is parallel to the offset vector.
