### PR TITLE
quickfix: SSE was accidentally disabled on windows desktop 

### DIFF
--- a/src/LinearMath/btScalar.h
+++ b/src/LinearMath/btScalar.h
@@ -96,7 +96,6 @@ inline int	btGetVersion()
 			#endif //BT_USE_SSE
 			#include <emmintrin.h>
 #endif
-#endif
 
 		#endif//_XBOX
 


### PR DESCRIPTION
by a change intended to disable it only for Windows Phone.  The old code was relying on a WINAPI_FAMILY macro that is not defined.  In fact, the API check is unnecessary because SSE isn't compatible with ARM hardware period.  ARM should be using NEON if anything.
