### PR TITLE
Add libpthread dependency to libOpenGLWindow.so

### DIFF
--- a/btgui/OpenGLWindow/CMakeLists.txt
+++ b/btgui/OpenGLWindow/CMakeLists.txt
@@ -56,3 +56,9 @@ if (BUILD_SHARED_LIBS)
 endif()
 
 target_link_libraries(OpenGLWindow ${OPENGL_gl_LIBRARY})
+
+if (UNIX AND NOT APPLE)
+  set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
+  FIND_PACKAGE( Threads )
+  target_link_libraries(OpenGLWindow ${CMAKE_THREAD_LIBS_INIT})
+endif()


### PR DESCRIPTION
Hi, thanks for a great library.
I'm getting a small linking error. Here's the fix I think is correct:

When configuring with shared libs on linux with:
cmake .. -DINSTALL_LIBS=on -DBUILD_SHARED_LIBS=on
and then compiling, AppSimpleOpenGL3 gives a pthread linking error:
../../btgui/OpenGLWindow/libOpenGLWindow.so: undefined reference to `pthread_getconcurrency'

libpthread.so is not listed as one of libOpenGLWindow.so's dependencies
(when running: ldd ./btgui/OpenGLWindow/libOpenGLWindow.so )
so libOpenGLWindow.so was likely not linked with pthreads.

This CMakeLists.txt change uses cmake utils to link libOpenGLWindow.so with pthreads.
Now ldd ./btgui/OpenGLWindow/libOpenGLWindow.so does list libpthread as a dependency:
...
libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0
...

Now AppSimpleOpenGL3 compiles without error for me.
