### PR TITLE
Moved initial allocations of some arrays and stacks onto the actual runt...

### DIFF
--- a/src/BulletCollision/BroadphaseCollision/btCollisionAlgorithm.h
+++ b/src/BulletCollision/BroadphaseCollision/btCollisionAlgorithm.h
@@ -29,6 +29,9 @@ class	btPersistentManifold;
 
 typedef btAlignedObjectArray<btPersistentManifold*>	btManifoldArray;
 
+// [jt] How big in items should the default manifolds that we create on the stack be?
+#define BT_DEFAULT_MANIFOLD_STACK_SIZE (1024*16)
+
 struct btCollisionAlgorithmConstructionInfo
 {
 	btCollisionAlgorithmConstructionInfo()

--- a/src/BulletCollision/BroadphaseCollision/btDbvt.h
+++ b/src/BulletCollision/BroadphaseCollision/btDbvt.h
@@ -928,8 +928,8 @@ inline void		btDbvt::collideTV(	const btDbvtNode* root,
 		{
 			ATTRIBUTE_ALIGNED16(btDbvtVolume)		volume(vol);
 			btAlignedObjectArray<const btDbvtNode*>	stack;
-			stack.resize(0);
-			stack.reserve(SIMPLE_STACKSIZE);
+			char tempmemory[SIMPLE_STACKSIZE*sizeof(const btDbvtNode*)];
+			stack.initializeFromBuffer(tempmemory, 0, SIMPLE_STACKSIZE);
 			stack.push_back(root);
 			do	{
 				const btDbvtNode*	n=stack[stack.size()-1];
@@ -1031,7 +1031,8 @@ inline void		btDbvt::rayTest(	const btDbvtNode* root,
 			int								depth=1;
 			int								treshold=DOUBLE_STACKSIZE-2;
 
-			stack.resize(DOUBLE_STACKSIZE);
+			char tempmemory[DOUBLE_STACKSIZE * sizeof(const btDbvtNode*)];
+			stack.initializeFromBuffer(tempmemory, DOUBLE_STACKSIZE, DOUBLE_STACKSIZE);
 			stack[0]=root;
 			btVector3 bounds[2];
 			do	{

--- a/src/BulletCollision/CollisionDispatch/btCompoundCollisionAlgorithm.cpp
+++ b/src/BulletCollision/CollisionDispatch/btCompoundCollisionAlgorithm.cpp
@@ -245,6 +245,8 @@ void btCompoundCollisionAlgorithm::processCollision (const btCollisionObjectWrap
 	{
 		int i;
 		btManifoldArray manifoldArray;
+		char tempArrayMemory__[BT_DEFAULT_MANIFOLD_STACK_SIZE * sizeof(btPersistentManifold*)];
+		manifoldArray.initializeFromBuffer(tempArrayMemory__,0, BT_DEFAULT_MANIFOLD_STACK_SIZE);
 		for (i=0;i<m_childCollisionAlgorithms.size();i++)
 		{
 			if (m_childCollisionAlgorithms[i])
@@ -292,11 +294,13 @@ void btCompoundCollisionAlgorithm::processCollision (const btCollisionObjectWrap
 		int numChildren = m_childCollisionAlgorithms.size();
 		int i;
 		btManifoldArray	manifoldArray;
-        const btCollisionShape* childShape = 0;
-        btTransform	orgTrans;
+		char tempArrayMemory__[BT_DEFAULT_MANIFOLD_STACK_SIZE * sizeof(btPersistentManifold*)];
+		manifoldArray.initializeFromBuffer(tempArrayMemory__,0, BT_DEFAULT_MANIFOLD_STACK_SIZE);
+		const btCollisionShape* childShape = 0;
+		btTransform	orgTrans;
         
-        btTransform	newChildWorldTrans;
-        btVector3 aabbMin0,aabbMax0,aabbMin1,aabbMax1;        
+		btTransform	newChildWorldTrans;
+		btVector3 aabbMin0,aabbMax0,aabbMin1,aabbMax1;        
         
 		for (i=0;i<numChildren;i++)
 		{

--- a/src/BulletCollision/CollisionDispatch/btCompoundCompoundCollisionAlgorithm.cpp
+++ b/src/BulletCollision/CollisionDispatch/btCompoundCompoundCollisionAlgorithm.cpp
@@ -313,6 +313,8 @@ void btCompoundCompoundCollisionAlgorithm::processCollision (const btCollisionOb
 	{
 		int i;
 		btManifoldArray manifoldArray;
+		char tempArrayMemory__[BT_DEFAULT_MANIFOLD_STACK_SIZE * sizeof(btPersistentManifold*)];
+		manifoldArray.initializeFromBuffer(tempArrayMemory__,0, BT_DEFAULT_MANIFOLD_STACK_SIZE);
 		btSimplePairArray& pairs = m_childCollisionAlgorithmCache->getOverlappingPairArray();
 		for (i=0;i<pairs.size();i++)
 		{
@@ -355,13 +357,11 @@ void btCompoundCompoundCollisionAlgorithm::processCollision (const btCollisionOb
 		
 		int i;
 		btManifoldArray	manifoldArray;
-        
-		
+		char tempArrayMemory__[BT_DEFAULT_MANIFOLD_STACK_SIZE * sizeof(btPersistentManifold*)];
+		manifoldArray.initializeFromBuffer(tempArrayMemory__,0, BT_DEFAULT_MANIFOLD_STACK_SIZE);
 
-        
-        
-        btVector3 aabbMin0,aabbMax0,aabbMin1,aabbMax1;        
-        
+		btVector3 aabbMin0,aabbMax0,aabbMin1,aabbMax1;        
+
 		for (i=0;i<pairs.size();i++)
 		{
 			if (pairs[i].m_userPointer)


### PR DESCRIPTION
...ime stack so that we hit the global allocator less, in the cases when the global allocator is slow.

(reduced the per frame allocations in a typical frame significantly)
