### PR TITLE
Fix for 64bit builds btSqrt and USE_APPROXIMATION

### DIFF
--- a/src/LinearMath/btScalar.h
+++ b/src/LinearMath/btScalar.h
@@ -418,7 +418,17 @@ SIMD_FORCE_INLINE btScalar btFmod(btScalar x,btScalar y) { return fmod(x,y); }
 SIMD_FORCE_INLINE btScalar btSqrt(btScalar y) 
 { 
 #ifdef USE_APPROXIMATION
-#ifdef __arm__
+#ifdef __LP64__
+    float xhalf = 0.5f*y;
+    int i = *(int*)&y;
+    i = 0x5f375a86 - (i>>1);
+    y = *(float*)&i;
+    y = y*(1.5f - xhalf*y*y);
+    y = y*(1.5f - xhalf*y*y);
+    y = y*(1.5f - xhalf*y*y);
+    y=1/y;
+    return y;
+#else
     double x, z, tempf;
     unsigned long *tfptr = ((unsigned long *)&tempf) + 1;
     tempf = y;
@@ -431,19 +441,9 @@ SIMD_FORCE_INLINE btScalar btSqrt(btScalar y)
     x = (btScalar(1.5)*x)-(x*x)*(x*z);
     x = (btScalar(1.5)*x)-(x*x)*(x*z);
     return x*y;
-#elif __arm64__
-    float xhalf = 0.5f*y;
-    int i = *(int*)&y;
-    i = 0x5f375a86 - (i>>1);
-    y = *(float*)&i;
-    y = y*(1.5f - xhalf*y*y);
-    y = y*(1.5f - xhalf*y*y);
-    y = y*(1.5f - xhalf*y*y);
-    y=1/y;
-    return y;
 #endif
 #else
-    return sqrtf(y);
+	return sqrtf(y); 
 #endif
 }
 SIMD_FORCE_INLINE btScalar btFabs(btScalar x) { return fabsf(x); }

--- a/src/LinearMath/btScalar.h
+++ b/src/LinearMath/btScalar.h
@@ -418,21 +418,32 @@ SIMD_FORCE_INLINE btScalar btFmod(btScalar x,btScalar y) { return fmod(x,y); }
 SIMD_FORCE_INLINE btScalar btSqrt(btScalar y) 
 { 
 #ifdef USE_APPROXIMATION
+#ifdef __arm__
     double x, z, tempf;
     unsigned long *tfptr = ((unsigned long *)&tempf) + 1;
-
-	tempf = y;
-	*tfptr = (0xbfcdd90a - *tfptr)>>1; /* estimate of 1/sqrt(y) */
-	x =  tempf;
-	z =  y*btScalar(0.5);
-	x = (btScalar(1.5)*x)-(x*x)*(x*z);         /* iteration formula     */
-	x = (btScalar(1.5)*x)-(x*x)*(x*z);
-	x = (btScalar(1.5)*x)-(x*x)*(x*z);
-	x = (btScalar(1.5)*x)-(x*x)*(x*z);
-	x = (btScalar(1.5)*x)-(x*x)*(x*z);
-	return x*y;
+    tempf = y;
+    *tfptr = (0xbfcdd90a - *tfptr)>>1; /* estimate of 1/sqrt(y) */
+    x =  tempf;
+    z =  y*btScalar(0.5);
+    x = (btScalar(1.5)*x)-(x*x)*(x*z);         /* iteration formula     */
+    x = (btScalar(1.5)*x)-(x*x)*(x*z);
+    x = (btScalar(1.5)*x)-(x*x)*(x*z);
+    x = (btScalar(1.5)*x)-(x*x)*(x*z);
+    x = (btScalar(1.5)*x)-(x*x)*(x*z);
+    return x*y;
+#elif __arm64__
+    float xhalf = 0.5f*y;
+    int i = *(int*)&y;
+    i = 0x5f375a86 - (i>>1);
+    y = *(float*)&i;
+    y = y*(1.5f - xhalf*y*y);
+    y = y*(1.5f - xhalf*y*y);
+    y = y*(1.5f - xhalf*y*y);
+    y=1/y;
+    return y;
+#endif
 #else
-	return sqrtf(y); 
+    return sqrtf(y);
 #endif
 }
 SIMD_FORCE_INLINE btScalar btFabs(btScalar x) { return fabsf(x); }


### PR DESCRIPTION
Fix issue with btSqrt with macro USE_APPROXIMATION turned on.

In 64bit systems, type 'long' is 8 bytes and not 4 which the btSqrt USE_APPROXIMATION code relies on to get to upper 4 bytes. Changed algorithm for arm64 to something more stable. 

Source of implementation: http://www.hackersdelight.org/hdcodetxt/rsqrt.c.txt
Note, author is unknown.