### PR TITLE
Build fixes 2.83

### DIFF
--- a/Demos3/SimpleOpenGL3/CMakeLists.txt
+++ b/Demos3/SimpleOpenGL3/CMakeLists.txt
@@ -12,7 +12,7 @@ SET(AppSimpleOpenGL3_SRCS
 )
 
 LINK_LIBRARIES(
-        gwen OpenGLWindow Bullet3Common ${OPENGL_gl_LIBRARY} ${OPENGL_glu_LIBRARY}
+        gwen OpenGLWindow Bullet3Common
 )
 
 IF (WIN32)
@@ -39,6 +39,11 @@ ELSE(WIN32)
 	ENDIF(APPLE)
 ENDIF(WIN32)
 
+# Move OGENGL linking after Linux pthread linking,
+# since it was not linking on Ubuntu Trusty 14.04
+LINK_LIBRARIES(
+        ${OPENGL_gl_LIBRARY} ${OPENGL_glu_LIBRARY}
+)
 
 ADD_EXECUTABLE(AppSimpleOpenGL3
 		${AppSimpleOpenGL3_SRCS}

--- a/Demos3/SimpleOpenGL3/CMakeLists.txt
+++ b/Demos3/SimpleOpenGL3/CMakeLists.txt
@@ -39,7 +39,7 @@ ELSE(WIN32)
 	ENDIF(APPLE)
 ENDIF(WIN32)
 
-# Move OGENGL linking after Linux pthread linking,
+# Move OPENGL linking after Linux pthread linking,
 # since it was not linking on Ubuntu Trusty 14.04
 LINK_LIBRARIES(
         ${OPENGL_gl_LIBRARY} ${OPENGL_glu_LIBRARY}

--- a/bullet.pc.cmake
+++ b/bullet.pc.cmake
@@ -2,5 +2,5 @@ Name: bullet
 Description: Bullet Continuous Collision Detection and Physics Library
 Requires:
 Version: @BULLET_VERSION@
-Libs: -L@LIB_DESTINATION@ -lBulletSoftBody -lBulletDynamics -lBulletCollision -lLinearMath
-Cflags: @BULLET_DOUBLE_DEF@ -I@INCLUDE_INSTALL_DIR@
+Libs: -L@CMAKE_INSTALL_PREFIX@/@LIB_DESTINATION@ -lBulletSoftBody -lBulletDynamics -lBulletCollision -lLinearMath
+Cflags: @BULLET_DOUBLE_DEF@ -I@CMAKE_INSTALL_PREFIX@/@INCLUDE_INSTALL_DIR@


### PR DESCRIPTION
There are two fixes here to the build system:

1. Use absolute paths in the installed pkg-config `bullet.pc` file. Compilation can fail depending on where the build folder is located.

2. Fix a weird pthread linking error on Ubuntu 14.04 (trusty). Here is the console output that I saw:
~~~
[ 44%] ../../btgui/OpenGLWindow/libOpenGLWindow.so: undefined reference to `pthread_getconcurrency'
collect2: error: ld returned 1 exit status
make[2]: *** [Demos3/SimpleOpenGL3/AppSimpleOpenGL3] Error 1
make[1]: *** [Demos3/SimpleOpenGL3/CMakeFiles/AppSimpleOpenGL3.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
~~~
The libraries were listed for the compiler in the following order:
~~~
../../btgui/Gwen/libgwen.so ../../btgui/OpenGLWindow/libOpenGLWindow.so
../../src/Bullet3Common/libBullet3Common.so.2.83
-lGL -lGLU -lX11 -lpthread -ldl -lXext
~~~
Note that pthread is near the end of the list. I manage to fix the issue by moving the `-lpthread` before the `-lGL -lGLU`. I don't know why it happened, but this fixes the issue on Ubuntu 14.04.