### PR TITLE
Use absolute paths in pkg-config file

### DIFF
--- a/bullet.pc.cmake
+++ b/bullet.pc.cmake
@@ -2,5 +2,5 @@ Name: bullet
 Description: Bullet Continuous Collision Detection and Physics Library
 Requires:
 Version: @BULLET_VERSION@
-Libs: -L@LIB_DESTINATION@ -lBulletSoftBody -lBulletDynamics -lBulletCollision -lLinearMath
-Cflags: @BULLET_DOUBLE_DEF@ -I@INCLUDE_INSTALL_DIR@
+Libs: -L@CMAKE_INSTALL_PREFIX@/@LIB_DESTINATION@ -lBulletSoftBody -lBulletDynamics -lBulletCollision -lLinearMath
+Cflags: @BULLET_DOUBLE_DEF@ -I@CMAKE_INSTALL_PREFIX@/@INCLUDE_INSTALL_DIR@


### PR DESCRIPTION
Otherwise compilation can fail depending on where the build folder is located.