### PR TITLE
Fix maxLinMotorForce for btSliderConstraint

### DIFF
--- a/Demos/ForkLiftDemo/ForkLiftDemo.cpp
+++ b/Demos/ForkLiftDemo/ForkLiftDemo.cpp
@@ -27,7 +27,7 @@ subject to the following restrictions:
 #include "BulletDynamics/MLCPSolvers/btMLCPSolver.h"
 
 
-btScalar maxMotorImpulse = 1400.f;
+btScalar maxMotorImpulse = 4000.f;
 
 //the sequential impulse solver has difficulties dealing with large mass ratios (differences), between loadMass and the fork parts
 btScalar loadMass = 350.f;//

--- a/src/BulletDynamics/ConstraintSolver/btSliderConstraint.cpp
+++ b/src/BulletDynamics/ConstraintSolver/btSliderConstraint.cpp
@@ -641,8 +641,8 @@ void btSliderConstraint::getInfo2NonVirtual(btConstraintInfo2* info, const btTra
 			}
 			btScalar mot_fact = getMotorFactor(m_angPos, m_lowerAngLimit, m_upperAngLimit, getTargetAngMotorVelocity(), info->fps * currERP);
 			info->m_constraintError[srow] = mot_fact * getTargetAngMotorVelocity();
-			info->m_lowerLimit[srow] = -getMaxAngMotorForce() * info->fps;
-			info->m_upperLimit[srow] = getMaxAngMotorForce() * info->fps;
+			info->m_lowerLimit[srow] = -getMaxAngMotorForce() / info->fps;
+			info->m_upperLimit[srow] = getMaxAngMotorForce() / info->fps;
 		}
 		if(limit)
 		{

--- a/src/BulletDynamics/ConstraintSolver/btSliderConstraint.cpp
+++ b/src/BulletDynamics/ConstraintSolver/btSliderConstraint.cpp
@@ -539,8 +539,8 @@ void btSliderConstraint::getInfo2NonVirtual(btConstraintInfo2* info, const btTra
 			btScalar tag_vel = getTargetLinMotorVelocity();
 			btScalar mot_fact = getMotorFactor(m_linPos, m_lowerLinLimit, m_upperLinLimit, tag_vel, info->fps * currERP);
 			info->m_constraintError[srow] -= signFact * mot_fact * getTargetLinMotorVelocity();
-			info->m_lowerLimit[srow] += -getMaxLinMotorForce() * info->fps;
-			info->m_upperLimit[srow] += getMaxLinMotorForce() * info->fps;
+			info->m_lowerLimit[srow] += -getMaxLinMotorForce() / info->fps;
+			info->m_upperLimit[srow] += getMaxLinMotorForce() / info->fps;
 		}
 		if(limit)
 		{


### PR DESCRIPTION
In btSliderConstraint::getInfo2NonVirtual,
the maxLinMotorForce should be multiplied by
the simulation time step to compute an impulse
that is used to set up the constraints for the
linear motor. Instead of multiplying by timestep,
it was multiplying by fps, so it was effectively
dividing by the timestep. This fixes the error
by dividing by fps.

I also increased the max motor force (incorrectly named `maxMotorImpulse`) in the ForkLiftDemo so that it will have enough force to lift the load.

I've been using the joint motors to [implement Coulomb joint friction in Gazebo](https://bitbucket.org/osrf/gazebo/issue/381), and I successfully [implemented it in ODE](https://bitbucket.org/osrf/gazebo/pull-request/1221/implement-coulomb-joint-friction-for-ode) and for [btHingeConstraint](https://bitbucket.org/osrf/gazebo/pull-request/1317/enable-joint-friction-for-bullethingejoint), but my [test was failing for btSliderConstraint](https://bitbucket.org/osrf/gazebo/issue/1348/implement-coulomb-joint-friction-in). That led me to this bug. I'll make a workaround for 2.82, but it would be nice to fix this for 2.83.