### PR TITLE
Fix build of Gyroscopic Demo

### DIFF
--- a/src/BulletDynamics/Dynamics/btRigidBody.h
+++ b/src/BulletDynamics/Dynamics/btRigidBody.h
@@ -41,13 +41,15 @@ extern bool gDisableDeactivation;
 enum	btRigidBodyFlags
 {
 	BT_DISABLE_WORLD_GRAVITY = 1,
-	///BT_ENABLE_GYROPSCOPIC_FORCE flags is enabled by default in Bullet 2.83 and onwards.
+	///BT_ENABLE_GYROSCOPIC_FORCE_EWERT flag is enabled by default in Bullet 2.83 and onwards.
 	///See Demos/GyroscopicDemo and computeGyroscopicImpulseImplicit
 	BT_ENABLE_GYROSCOPIC_FORCE_EXPLICIT = 2,
 	BT_ENABLE_GYROSCOPIC_FORCE_IMPLICIT_COOPER=4,
 	BT_ENABLE_GYROSCOPIC_FORCE_IMPLICIT_EWERT=8,
 	BT_ENABLE_GYROSCOPIC_FORCE_IMPLICIT_CATTO=16,
 };
+///Backwards compatibility
+static const size_t BT_ENABLE_GYROPSCOPIC_FORCE = BT_ENABLE_GYROSCOPIC_FORCE_IMPLICIT_EWERT;
 
 
 ///The btRigidBody is the main class for rigid body objects. It is derived from btCollisionObject, so it keeps a pointer to a btCollisionShape.


### PR DESCRIPTION
The build is failing for me on OSX and trusty:
~~~
Demos/GyroscopicDemo/GyroscopicDemo.cpp: In member function ‘virtual void GyroscopicDemo::initPhysics()’:
Demos/GyroscopicDemo/GyroscopicDemo.cpp:110:19: error: ‘BT_ENABLE_GYROPSCOPIC_FORCE’ was not declared in this scope
    body->setFlags(BT_ENABLE_GYROPSCOPIC_FORCE);
                   ^
make[2]: *** [Demos/GyroscopicDemo/CMakeFiles/AppGyroscopicDemo.dir/GyroscopicDemo.o] Error 1
make[1]: *** [Demos/GyroscopicDemo/CMakeFiles/AppGyroscopicDemo.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
~~~

This restores the `BT_ENABLE_GYROPSCOPIC_FORCE` flag for backwards compatibility and fixes the build. I don't know why travis succeeded for #346