### PR TITLE
travis.yml: install freeglut3-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ compiler:
   - clang
 install:
   - sudo apt-get update
-  - sudo apt-get install libglew-dev
+  - sudo apt-get install libglew-dev freeglut3-dev
 script:
   - echo "CXX="$CXX
   - echo "CC="$CC


### PR DESCRIPTION
The demos aren't all compiled without freeglut3-dev, so travis didn't catch the broken build from #346. This pull request should fail; the fix is in #348 