### PR TITLE
Fix a potential division by zero for cone twist constraints.

### DIFF
--- a/src/BulletDynamics/ConstraintSolver/btConeTwistConstraint.cpp
+++ b/src/BulletDynamics/ConstraintSolver/btConeTwistConstraint.cpp
@@ -778,8 +778,10 @@ void btConeTwistConstraint::calcAngleInfo2(const btTransform& transA, const btTr
 				target[2] = x * ivA[2] + y * jvA[2] + z * kvA[2];
 				target.normalize();
 				m_swingAxis = -ivB.cross(target);
-				m_swingCorrection = m_swingAxis.length();
-				m_swingAxis.normalize();
+                                m_swingCorrection = m_swingAxis.length();
+
+                                if (!btFuzzyZero(m_swingCorrection))
+                                    m_swingAxis.normalize();
 			}
 		}
 


### PR DESCRIPTION
This could occur if the two objects are exactly aligned and the angle limits are configured like a hinge. This can reproduced by changing line 211 of `RagdollDemo.cpp` to `coneC->setLimit(0, M_PI_4, 0);`