### PR TITLE
Build warning fixes and slight refactoring

### DIFF
--- a/src/Bullet3Collision/BroadPhaseCollision/b3DynamicBvh.h
+++ b/src/Bullet3Collision/BroadPhaseCollision/b3DynamicBvh.h
@@ -961,37 +961,32 @@ inline void		b3DynamicBvh::rayTestInternal(	const b3DbvtNode* root,
 								const b3Vector3& aabbMax,
 								B3_DBVT_IPOLICY) const
 {
-        (void) rayTo;
 	B3_DBVT_CHECKTYPE
 	if(root)
 	{
-		b3Vector3 resultNormal;
-
-		int								depth=1;
-		int								treshold=B3_DOUBLE_STACKSIZE-2;
-		b3AlignedObjectArray<const b3DbvtNode*>&	stack = m_rayTestStack;
+        int depth = 1;
+        int treshold = B3_DOUBLE_STACKSIZE - 2;
+		b3AlignedObjectArray<const b3DbvtNode*>& stack = m_rayTestStack;
 		stack.resize(B3_DOUBLE_STACKSIZE);
-		stack[0]=root;
-		b3Vector3 bounds[2];
+        stack[0] = root;
 		do	
 		{
-			const b3DbvtNode*	node=stack[--depth];
-			bounds[0] = node->volume.Mins()-aabbMax;
-			bounds[1] = node->volume.Maxs()-aabbMin;
-			b3Scalar tmin=1.f,lambda_min=0.f;
-			unsigned int result1=false;
-			result1 = b3RayAabb2(rayFrom,rayDirectionInverse,signs,bounds,tmin,lambda_min,lambda_max);
+            const b3DbvtNode* node = stack[--depth];
+            btVector3 bounds[2] = {node->volume.Mins() - aabbMax,
+                                   node->volume.Maxs() - aabbMin};
+            b3Scalar tmin = 1.f, lambda_min = 0.f;
+            bool result1 = b3RayAabb2(rayFrom,rayDirectionInverse,signs,bounds,tmin,lambda_min,lambda_max);
 			if(result1)
 			{
 				if(node->isinternal())
 				{
 					if(depth>treshold)
 					{
-						stack.resize(stack.size()*2);
+                        stack.resize(stack.size() * 2);
 						treshold=stack.size()-2;
 					}
-					stack[depth++]=node->childs[0];
-					stack[depth++]=node->childs[1];
+                    stack[depth++] = node->childs[0];
+                    stack[depth++] = node->childs[1];
 				}
 				else
 				{
@@ -1028,8 +1023,8 @@ inline void		b3DynamicBvh::rayTest(	const b3DbvtNode* root,
 
 			b3AlignedObjectArray<const b3DbvtNode*>	stack;
 
-			int								depth=1;
-			int								treshold=B3_DOUBLE_STACKSIZE-2;
+			int depth=1;
+			int treshold=B3_DOUBLE_STACKSIZE-2;
 
 			stack.resize(B3_DOUBLE_STACKSIZE);
 			stack[0]=root;

--- a/src/Bullet3Collision/BroadPhaseCollision/b3DynamicBvh.h
+++ b/src/Bullet3Collision/BroadPhaseCollision/b3DynamicBvh.h
@@ -972,7 +972,7 @@ inline void		b3DynamicBvh::rayTestInternal(	const b3DbvtNode* root,
 		do	
 		{
             const b3DbvtNode* node = stack[--depth];
-            btVector3 bounds[2] = {node->volume.Mins() - aabbMax,
+            b3Vector3 bounds[2] = { node->volume.Mins() - aabbMax,
                                    node->volume.Maxs() - aabbMin};
             b3Scalar tmin = 1.f, lambda_min = 0.f;
             bool result1 = b3RayAabb2(rayFrom,rayDirectionInverse,signs,bounds,tmin,lambda_min,lambda_max);

--- a/src/BulletCollision/BroadphaseCollision/btCollisionAlgorithm.cpp
+++ b/src/BulletCollision/BroadphaseCollision/btCollisionAlgorithm.cpp
@@ -20,4 +20,3 @@ btCollisionAlgorithm::btCollisionAlgorithm(const btCollisionAlgorithmConstructio
 {
 	m_dispatcher = ci.m_dispatcher1;
 }
-

--- a/src/BulletCollision/BroadphaseCollision/btCollisionAlgorithm.h
+++ b/src/BulletCollision/BroadphaseCollision/btCollisionAlgorithm.h
@@ -36,10 +36,9 @@ struct btCollisionAlgorithmConstructionInfo
 		m_manifold(0)
 	{
 	}
-	btCollisionAlgorithmConstructionInfo(btDispatcher* dispatcher,int temp)
+	btCollisionAlgorithmConstructionInfo(btDispatcher* dispatcher)
 		:m_dispatcher1(dispatcher)
 	{
-		(void)temp;
 	}
 
 	btDispatcher*	m_dispatcher1;
@@ -64,11 +63,11 @@ protected:
 	
 public:
 
-	btCollisionAlgorithm() {};
+	btCollisionAlgorithm() = default;
 
 	btCollisionAlgorithm(const btCollisionAlgorithmConstructionInfo& ci);
 
-	virtual ~btCollisionAlgorithm() {};
+	virtual ~btCollisionAlgorithm() = default;
 
 	virtual void processCollision (const btCollisionObjectWrapper* body0Wrap,const btCollisionObjectWrapper* body1Wrap,const btDispatcherInfo& dispatchInfo,btManifoldResult* resultOut) = 0;
 

--- a/src/BulletCollision/CollisionDispatch/btCollisionDispatcher.h
+++ b/src/BulletCollision/CollisionDispatch/btCollisionDispatcher.h
@@ -106,7 +106,7 @@ public:
 
 	btCollisionDispatcher (btCollisionConfiguration* collisionConfiguration);
 
-	virtual ~btCollisionDispatcher();
+	virtual ~btCollisionDispatcher() = default;
 
 	virtual btPersistentManifold*	getNewManifold(const btCollisionObject* b0,const btCollisionObject* b1);
 	

--- a/src/BulletCollision/CollisionDispatch/btCollisionWorld.cpp
+++ b/src/BulletCollision/CollisionDispatch/btCollisionWorld.cpp
@@ -77,10 +77,8 @@ m_forceUpdateAllAabbs(true)
 
 btCollisionWorld::~btCollisionWorld()
 {
-
 	//clean up remaining objects
-	int i;
-	for (i=0;i<m_collisionObjects.size();i++)
+	for (int i=0;i<m_collisionObjects.size();i++)
 	{
 		btCollisionObject* collisionObject= m_collisionObjects[i];
 
@@ -95,22 +93,10 @@ btCollisionWorld::~btCollisionWorld()
 			collisionObject->setBroadphaseHandle(0);
 		}
 	}
-
-
 }
 
-
-
-
-
-
-
-
-
-
-void	btCollisionWorld::addCollisionObject(btCollisionObject* collisionObject,short int collisionFilterGroup,short int collisionFilterMask)
+void btCollisionWorld::addCollisionObject(btCollisionObject* collisionObject,short int collisionFilterGroup,short int collisionFilterMask)
 {
-
 	btAssert(collisionObject);
 
 	//check that the object isn't already added
@@ -133,13 +119,8 @@ void	btCollisionWorld::addCollisionObject(btCollisionObject* collisionObject,sho
 		collisionObject,
 		collisionFilterGroup,
 		collisionFilterMask,
-		m_dispatcher1,0
-		))	;
-
-
-
-
-
+		m_dispatcher1,
+        0));
 }
 
 
@@ -190,8 +171,6 @@ void	btCollisionWorld::updateSingleAabb(btCollisionObject* colObj)
 void	btCollisionWorld::updateAabbs()
 {
 	BT_PROFILE("updateAabbs");
-
-	btTransform predictedTrans;
 	for ( int i=0;i<m_collisionObjects.size();i++)
 	{
 		btCollisionObject* colObj = m_collisionObjects[i];
@@ -230,16 +209,10 @@ void	btCollisionWorld::performDiscreteCollisionDetection()
 
 }
 
-
-
 void	btCollisionWorld::removeCollisionObject(btCollisionObject* collisionObject)
 {
-
-
 	//bool removeFromBroadphase = false;
-
 	{
-
 		btBroadphaseProxy* bp = collisionObject->getBroadphaseHandle();
 		if (bp)
 		{
@@ -251,13 +224,10 @@ void	btCollisionWorld::removeCollisionObject(btCollisionObject* collisionObject)
 			collisionObject->setBroadphaseHandle(0);
 		}
 	}
-
-
+    
 	//swapremove
 	m_collisionObjects.remove(collisionObject);
-
 }
-
 
 void	btCollisionWorld::rayTestSingle(const btTransform& rayFromTrans,const btTransform& rayToTrans,
 										btCollisionObject* collisionObject,
@@ -293,7 +263,7 @@ void	btCollisionWorld::rayTestSingleInternal(const btTransform& rayFromTrans,con
 		
 		//btContinuousConvexCollision convexCaster(castShape,convexShape,&simplexSolver,0);
 
-		btConvexCast* convexCasterPtr = 0;
+		btConvexCast* convexCasterPtr = nullptr;
 		//use kF_UseSubSimplexConvexCastRaytest by default
 		if (resultCallback.m_flags & btTriangleRaycastCallback::kF_UseGjkConvexCastRaytest)
 			convexCasterPtr = &gjkConvexCaster;
@@ -325,7 +295,6 @@ void	btCollisionWorld::rayTestSingleInternal(const btTransform& rayFromTrans,con
 
 					bool normalInWorldSpace = true;
 					resultCallback.addSingleResult(localRayResult, normalInWorldSpace);
-
 				}
 			}
 		}
@@ -344,15 +313,14 @@ void	btCollisionWorld::rayTestSingleInternal(const btTransform& rayFromTrans,con
 
 					BridgeTriangleRaycastCallback( const btVector3& from,const btVector3& to,
 					btCollisionWorld::RayResultCallback* resultCallback, const btCollisionObject* collisionObject,const btConcaveShape*	triangleMesh,const btTransform& colObjWorldTransform):
-						//@BP Mod
-						btTriangleRaycastCallback(from,to, resultCallback->m_flags),
-							m_resultCallback(resultCallback),
-							m_collisionObject(collisionObject),
-							m_triangleMesh(triangleMesh),
-							m_colObjWorldTransform(colObjWorldTransform)
-						{
-						}
-
+					//@BP Mod
+					btTriangleRaycastCallback(from,to, resultCallback->m_flags),
+						m_resultCallback(resultCallback),
+						m_collisionObject(collisionObject),
+						m_triangleMesh(triangleMesh),
+						m_colObjWorldTransform(colObjWorldTransform)
+					{
+					}
 
 					virtual btScalar reportHit(const btVector3& hitNormalLocal, btScalar hitFraction, int partId, int triangleIndex )
 					{
@@ -371,7 +339,6 @@ void	btCollisionWorld::rayTestSingleInternal(const btTransform& rayFromTrans,con
 						bool	normalInWorldSpace = true;
 						return m_resultCallback->addSingleResult(rayResult,normalInWorldSpace);
 					}
-
 				};
 
 			btTransform worldTocollisionObject = colObjWorldTransform.inverse();
@@ -403,13 +370,17 @@ void	btCollisionWorld::rayTestSingleInternal(const btTransform& rayFromTrans,con
 				struct BridgeTriangleRaycastCallback : public btTriangleRaycastCallback
 				{
 					btCollisionWorld::RayResultCallback* m_resultCallback;
-					const btCollisionObject*	m_collisionObject;
+					const btCollisionObject* m_collisionObject;
 					btConcaveShape*	m_triangleMesh;
 
 					btTransform m_colObjWorldTransform;
 
-					BridgeTriangleRaycastCallback( const btVector3& from,const btVector3& to,
-						btCollisionWorld::RayResultCallback* resultCallback, const btCollisionObject* collisionObject,btConcaveShape*	triangleMesh, const btTransform& colObjWorldTransform):
+					BridgeTriangleRaycastCallback(const btVector3& from,
+                                                  const btVector3& to,
+                                                  btCollisionWorld::RayResultCallback* resultCallback,
+                                                  const btCollisionObject* collisionObject,
+                                                  btConcaveShape* triangleMesh,
+                                                  const btTransform& colObjWorldTransform):
 					//@BP Mod
 					btTriangleRaycastCallback(from,to, resultCallback->m_flags),
 						m_resultCallback(resultCallback),
@@ -419,6 +390,7 @@ void	btCollisionWorld::rayTestSingleInternal(const btTransform& rayFromTrans,con
 					{
 					}
 
+                    virtual ~BridgeTriangleRaycastCallback() = default;
 
 					virtual btScalar reportHit(const btVector3& hitNormalLocal, btScalar hitFraction, int partId, int triangleIndex )
 					{
@@ -437,9 +409,7 @@ void	btCollisionWorld::rayTestSingleInternal(const btTransform& rayFromTrans,con
 						bool	normalInWorldSpace = true;
 						return m_resultCallback->addSingleResult(rayResult,normalInWorldSpace);
 					}
-
 				};
-
 
 				BridgeTriangleRaycastCallback	rcb(rayFromLocal,rayToLocal,&resultCallback,collisionObjectWrap->getCollisionObject(),concaveShape, colObjWorldTransform);
 				rcb.m_hitFraction = resultCallback.m_closestHitFraction;
@@ -519,16 +489,13 @@ void	btCollisionWorld::rayTestSingleInternal(const btTransform& rayFromTrans,con
 						btCollisionObjectWrapper tmpOb(0,childCollisionShape,m_collisionObject,childWorldTrans,-1,i);
 						// replace collision shape so that callback can determine the triangle
 
-						
-
 						LocalInfoAdder2 my_cb(i, &m_resultCallback);
 
 						rayTestSingleInternal(
 							m_rayFromTrans,
 							m_rayToTrans,
 							&tmpOb,
-							my_cb);
-						
+							my_cb);						
 					}
 				
 					void Process(const btDbvtNode* leaf)
@@ -601,8 +568,6 @@ void	btCollisionWorld::objectQuerySingleInternal(const btConvexShape* castShape,
 		//btSubsimplexConvexCast convexCaster3(castShape,convexShape,&simplexSolver);
 
 		btConvexCast* castPtr = &convexCaster1;
-
-
 
 		if (castPtr->calcTimeOfImpact(convexFromTrans,convexToTrans,colObjWorldTransform,colObjWorldTransform,castResult))
 		{
@@ -880,8 +845,6 @@ struct btSingleRayCallback : public btBroadphaseRayCallback
 
 	}
 
-
-
 	virtual bool	process(const btBroadphaseProxy* proxy)
 	{
 		///terminate further ray tests, once the closestHitFraction reached zero
@@ -937,7 +900,6 @@ void	btCollisionWorld::rayTest(const btVector3& rayFromWorld, const btVector3& r
 #endif //USE_BRUTEFORCE_RAYBROADPHASE
 
 }
-
 
 struct btSingleSweepCallback : public btBroadphaseRayCallback
 {
@@ -1222,10 +1184,9 @@ public:
 		  (void)partId;
 		  (void)triangleIndex;
 
-		  btVector3 wv0,wv1,wv2;
-		  wv0 = m_worldTrans*triangle[0];
-		  wv1 = m_worldTrans*triangle[1];
-		  wv2 = m_worldTrans*triangle[2];
+          btVector3 wv0 = m_worldTrans*triangle[0];
+		  btVector3 wv1 = m_worldTrans*triangle[1];
+          btVector3 wv2 = m_worldTrans*triangle[2];
 		  btVector3 center = (wv0+wv1+wv2)*btScalar(1./3.);
           
           if (m_debugDrawer->getDebugMode() & btIDebugDraw::DBG_DrawNormals )
@@ -1345,12 +1306,11 @@ void btCollisionWorld::debugDrawObject(const btTransform& worldTransform, const 
                 if (shape->isPolyhedral())
                 {
                     btPolyhedralConvexShape* polyshape = (btPolyhedralConvexShape*) shape;
-                    
-                    int i;
+
                     if (polyshape->getConvexPolyhedron())
                     {
                         const btConvexPolyhedron* poly = polyshape->getConvexPolyhedron();
-                        for (i=0;i<poly->m_faces.size();i++)
+                        for (int i=0;i<poly->m_faces.size();i++)
                         {
                             btVector3 centroid(0,0,0);
                             int numVerts = poly->m_faces[i].m_indices.size();
@@ -1378,7 +1338,7 @@ void btCollisionWorld::debugDrawObject(const btTransform& worldTransform, const 
                         
                     } else
                     {
-                        for (i=0;i<polyshape->getNumEdges();i++)
+                        for (int i=0;i<polyshape->getNumEdges();i++)
                         {
                             btVector3 a,b;
                             polyshape->getEdge(i,a,b);
@@ -1414,11 +1374,7 @@ void btCollisionWorld::debugDrawObject(const btTransform& worldTransform, const 
                     DebugDrawcallback drawCallback(getDebugDrawer(),worldTransform,color);
                     convexMesh->getMeshInterface()->InternalProcessAllTriangles(&drawCallback,aabbMin,aabbMax);
                 }
-
-
-                
             }
-       
 		}
 	}
 }
@@ -1450,9 +1406,7 @@ void	btCollisionWorld::debugDrawWorld()
 
 	if (getDebugDrawer() && (getDebugDrawer()->getDebugMode() & (btIDebugDraw::DBG_DrawWireframe | btIDebugDraw::DBG_DrawAabb)))
 	{
-		int i;
-
-		for (  i=0;i<m_collisionObjects.size();i++)
+        for (int i = 0; i < m_collisionObjects.size(); i++)
 		{
 			btCollisionObject* colObj = m_collisionObjects[i];
 			if ((colObj->getCollisionFlags() & btCollisionObject::CF_DISABLE_VISUALIZE_OBJECT)==0)
@@ -1511,12 +1465,10 @@ void	btCollisionWorld::debugDrawWorld()
 
 void	btCollisionWorld::serializeCollisionObjects(btSerializer* serializer)
 {
-	int i;
-
 	///keep track of shapes already serialized
 	btHashMap<btHashPtr,btCollisionShape*>	serializedShapes;
 
-	for (i=0;i<m_collisionObjects.size();i++)
+    for (int i = 0; i < m_collisionObjects.size(); i++)
 	{
 		btCollisionObject* colObj = m_collisionObjects[i];
 		btCollisionShape* shape = colObj->getCollisionShape();
@@ -1529,7 +1481,7 @@ void	btCollisionWorld::serializeCollisionObjects(btSerializer* serializer)
 	}
 
 	//serialize all collision objects
-	for (i=0;i<m_collisionObjects.size();i++)
+	for (int i=0;i<m_collisionObjects.size();i++)
 	{
 		btCollisionObject* colObj = m_collisionObjects[i];
 		if (colObj->getInternalType() == btCollisionObject::CO_COLLISION_OBJECT)
@@ -1549,4 +1501,3 @@ void	btCollisionWorld::serialize(btSerializer* serializer)
 	
 	serializer->finishSerialization();
 }
-

--- a/src/BulletCollision/CollisionDispatch/btCollisionWorldImporter.h
+++ b/src/BulletCollision/CollisionDispatch/btCollisionWorldImporter.h
@@ -24,7 +24,7 @@ subject to the following restrictions:
 
 class btCollisionShape;
 class btCollisionObject;
-class btBulletSerializedArrays;
+struct btBulletSerializedArrays;
 
 
 struct ConstraintInput;

--- a/src/BulletCollision/CollisionShapes/btBox2dShape.cpp
+++ b/src/BulletCollision/CollisionShapes/btBox2dShape.cpp
@@ -15,28 +15,21 @@ subject to the following restrictions:
 
 #include "btBox2dShape.h"
 
-
-//{ 
-
-
 void btBox2dShape::getAabb(const btTransform& t,btVector3& aabbMin,btVector3& aabbMax) const
 {
 	btTransformAabb(getHalfExtentsWithoutMargin(),getMargin(),t,aabbMin,aabbMax);
 }
 
-
-void	btBox2dShape::calculateLocalInertia(btScalar mass,btVector3& inertia) const
+void btBox2dShape::calculateLocalInertia(btScalar mass,btVector3& inertia) const
 {
 	//btScalar margin = btScalar(0.);
 	btVector3 halfExtents = getHalfExtentsWithMargin();
 
-	btScalar lx=btScalar(2.)*(halfExtents.x());
-	btScalar ly=btScalar(2.)*(halfExtents.y());
-	btScalar lz=btScalar(2.)*(halfExtents.z());
+    const btScalar lx = btScalar(2.)*(halfExtents.x());
+    const btScalar ly = btScalar(2.)*(halfExtents.y());
+    const btScalar lz = btScalar(2.)*(halfExtents.z());
 
-	inertia.setValue(mass/(btScalar(12.0)) * (ly*ly + lz*lz),
-					mass/(btScalar(12.0)) * (lx*lx + lz*lz),
-					mass/(btScalar(12.0)) * (lx*lx + ly*ly));
-
+    inertia.setValue(mass / (btScalar(12.0)) * (ly*ly + lz*lz),
+                     mass / (btScalar(12.0)) * (lx*lx + lz*lz),
+                     mass / (btScalar(12.0)) * (lx*lx + ly*ly));
 }
-

--- a/src/BulletCollision/CollisionShapes/btBox2dShape.h
+++ b/src/BulletCollision/CollisionShapes/btBox2dShape.h
@@ -135,40 +135,16 @@ public:
 
 	virtual void getAabb(const btTransform& t,btVector3& aabbMin,btVector3& aabbMax) const;
 
-	
-
 	virtual void	calculateLocalInertia(btScalar mass,btVector3& inertia) const;
 
+    int	getVertexCount() const { return 4; }
 
+	virtual int getNumVertices()const { return 4; }
 
+	const btVector3* getVertices() const { return &m_vertices[0]; }
 
-
-	int	getVertexCount() const
-	{
-		return 4;
-	}
-
-	virtual int getNumVertices()const
-	{
-		return 4;
-	}
-
-	const btVector3* getVertices() const
-	{
-		return &m_vertices[0];
-	}
-
-	const btVector3* getNormals() const
-	{
-		return &m_normals[0];
-	}
-
-
-
-
-
-
-
+	const btVector3* getNormals() const { return &m_normals[0]; }
+    
 	virtual void getPlane(btVector3& planeNormal,btVector3& planeSupport,int i ) const
 	{
 		//this plane might not be aligned...
@@ -178,24 +154,11 @@ public:
 		planeSupport = localGetSupportingVertex(-planeNormal);
 	}
 
-
-	const btVector3& getCentroid() const
-	{
-		return m_centroid;
-	}
+	const btVector3& getCentroid() const { return m_centroid; }
 	
-	virtual int getNumPlanes() const
-	{
-		return 6;
-	}	
-	
-	
+	virtual int getNumPlanes() const { return 6; }
 
-	virtual int getNumEdges() const
-	{
-		return 12;
-	}
-
+	virtual int getNumEdges() const { return 12; }
 
 	virtual void getVertex(int i,btVector3& vtx) const
 	{
@@ -205,8 +168,7 @@ public:
 				halfExtents.x() * (1-(i&1)) - halfExtents.x() * (i&1),
 				halfExtents.y() * (1-((i&2)>>1)) - halfExtents.y() * ((i&2)>>1),
 				halfExtents.z() * (1-((i&4)>>2)) - halfExtents.z() * ((i&4)>>2));
-	}
-	
+	}	
 
 	virtual void	getPlaneEquation(btVector4& plane,int i) const
 	{
@@ -304,38 +266,25 @@ public:
 		getVertex(edgeVert0,pa );
 		getVertex(edgeVert1,pb );
 	}
-
-
-
-
 	
 	virtual	bool isInside(const btVector3& pt,btScalar tolerance) const
 	{
-		btVector3 halfExtents = getHalfExtentsWithoutMargin();
+		const btVector3 halfExtents = getHalfExtentsWithoutMargin();
 
 		//btScalar minDist = 2*tolerance;
-		
-		bool result =	(pt.x() <= (halfExtents.x()+tolerance)) &&
-						(pt.x() >= (-halfExtents.x()-tolerance)) &&
-						(pt.y() <= (halfExtents.y()+tolerance)) &&
-						(pt.y() >= (-halfExtents.y()-tolerance)) &&
-						(pt.z() <= (halfExtents.z()+tolerance)) &&
-						(pt.z() >= (-halfExtents.z()-tolerance));
-		
-		return result;
+        return (pt.x() <= (halfExtents.x() + tolerance)) &&
+               (pt.x() >= (-halfExtents.x() - tolerance)) &&
+               (pt.y() <= (halfExtents.y() + tolerance)) &&
+               (pt.y() >= (-halfExtents.y() - tolerance)) &&
+               (pt.z() <= (halfExtents.z() + tolerance)) &&
+               (pt.z() >= (-halfExtents.z() - tolerance));
 	}
 
 
 	//debugging
-	virtual const char*	getName()const
-	{
-		return "Box2d";
-	}
+	virtual const char*	getName() const { return "Box2d"; }
 
-	virtual int		getNumPreferredPenetrationDirections() const
-	{
-		return 6;
-	}
+	virtual int getNumPreferredPenetrationDirections() const { return 6; }
 	
 	virtual void	getPreferredPenetrationDirection(int index, btVector3& penetrationVector) const
 	{
@@ -367,5 +316,3 @@ public:
 };
 
 #endif //BT_OBB_BOX_2D_SHAPE_H
-
-

--- a/src/BulletCollision/CollisionShapes/btCollisionShape.cpp
+++ b/src/BulletCollision/CollisionShapes/btCollisionShape.cpp
@@ -27,8 +27,6 @@ void btBulletCollisionProbe ();
 void btBulletCollisionProbe () {}
 }
 
-
-
 void	btCollisionShape::getBoundingSphere(btVector3& center,btScalar& radius) const
 {
 	btTransform tr;

--- a/src/BulletCollision/CollisionShapes/btConvexPolyhedron.cpp
+++ b/src/BulletCollision/CollisionShapes/btConvexPolyhedron.cpp
@@ -21,22 +21,6 @@ subject to the following restrictions:
 #include "btConvexPolyhedron.h"
 #include "LinearMath/btHashMap.h"
 
-btConvexPolyhedron::btConvexPolyhedron()
-{
-
-}
-btConvexPolyhedron::~btConvexPolyhedron()
-{
-
-}
-
-
-inline bool IsAlmostZero(const btVector3& v)
-{
-	if(fabsf(v.x())>1e-6 || fabsf(v.y())>1e-6 || fabsf(v.z())>1e-6)	return false;
-	return true;
-}
-
 struct btInternalVertexPair
 {
 	btInternalVertexPair(short int v0,short int v1)

--- a/src/BulletCollision/CollisionShapes/btConvexPolyhedron.h
+++ b/src/BulletCollision/CollisionShapes/btConvexPolyhedron.h
@@ -36,12 +36,12 @@ struct btFace
 
 ATTRIBUTE_ALIGNED16(class) btConvexPolyhedron
 {
-	public:
+public:
 		
 	BT_DECLARE_ALIGNED_ALLOCATOR();
 		
-	btConvexPolyhedron();
-	virtual	~btConvexPolyhedron();
+	btConvexPolyhedron() = default;
+	virtual	~btConvexPolyhedron() = default;
 
 	btAlignedObjectArray<btVector3>	m_vertices;
 	btAlignedObjectArray<btFace>	m_faces;

--- a/src/BulletCollision/CollisionShapes/btConvexShape.cpp
+++ b/src/BulletCollision/CollisionShapes/btConvexShape.cpp
@@ -38,16 +38,6 @@ static inline vec_float4 vec_dot3( vec_float4 vec0, vec_float4 vec1 )
 }
 #endif //__SPU__
 
-btConvexShape::btConvexShape ()
-{
-}
-
-btConvexShape::~btConvexShape()
-{
-
-}
-
-
 void btConvexShape::project(const btTransform& trans, const btVector3& dir, btScalar& min, btScalar& max) const
 {
 	btVector3 localAxis = dir*trans.getBasis();

--- a/src/BulletCollision/CollisionShapes/btConvexShape.h
+++ b/src/BulletCollision/CollisionShapes/btConvexShape.h
@@ -30,15 +30,12 @@ subject to the following restrictions:
 /// It describes general convex shapes using the localGetSupportingVertex interface, used by collision detectors such as btGjkPairDetector.
 ATTRIBUTE_ALIGNED16(class) btConvexShape : public btCollisionShape
 {
-
-
 public:
 
 	BT_DECLARE_ALIGNED_ALLOCATOR();
 
-	btConvexShape ();
-
-	virtual ~btConvexShape();
+	btConvexShape () = default;
+	virtual ~btConvexShape() = default;
 
 	virtual btVector3	localGetSupportingVertex(const btVector3& vec)const = 0;
 
@@ -73,12 +70,5 @@ public:
 	virtual int		getNumPreferredPenetrationDirections() const=0;
 	
 	virtual void	getPreferredPenetrationDirection(int index, btVector3& penetrationVector) const=0;
-
-
-	
-	
 };
-
-
-
 #endif //BT_CONVEX_SHAPE_INTERFACE1

--- a/src/BulletCollision/CollisionShapes/btCylinderShape.h
+++ b/src/BulletCollision/CollisionShapes/btCylinderShape.h
@@ -22,9 +22,7 @@ subject to the following restrictions:
 
 /// The btCylinderShape class implements a cylinder shape primitive, centered around the origin. Its central axis aligned with the Y axis. btCylinderShapeX is aligned with the X axis and btCylinderShapeZ around the Z axis.
 ATTRIBUTE_ALIGNED16(class) btCylinderShape : public btConvexInternalShape
-
 {
-
 protected:
 
 	int	m_upAxis;
@@ -52,9 +50,9 @@ BT_DECLARE_ALIGNED_ALLOCATOR();
 
 	virtual void	calculateLocalInertia(btScalar mass,btVector3& inertia) const;
 
-	virtual btVector3	localGetSupportingVertexWithoutMargin(const btVector3& vec)const;
+	virtual btVector3	localGetSupportingVertexWithoutMargin(const btVector3& vec) const;
 
-	virtual void	batchedUnitVectorGetSupportingVertexWithoutMargin(const btVector3* vectors,btVector3* supportVerticesOut,int numVectors) const;
+	virtual void batchedUnitVectorGetSupportingVertexWithoutMargin(const btVector3* vectors,btVector3* supportVerticesOut,int numVectors) const;
 
 	virtual void setMargin(btScalar collisionMargin)
 	{

--- a/src/BulletCollision/CollisionShapes/btHeightfieldTerrainShape.cpp
+++ b/src/BulletCollision/CollisionShapes/btHeightfieldTerrainShape.cpp
@@ -19,12 +19,15 @@ subject to the following restrictions:
 
 
 
-btHeightfieldTerrainShape::btHeightfieldTerrainShape
-(
-int heightStickWidth, int heightStickLength, const void* heightfieldData,
-btScalar heightScale, btScalar minHeight, btScalar maxHeight,int upAxis,
-PHY_ScalarType hdt, bool flipQuadEdges
-)
+btHeightfieldTerrainShape::btHeightfieldTerrainShape( int heightStickWidth,
+                                                      int heightStickLength,
+                                                      const void* heightfieldData,
+                                                      btScalar heightScale,
+                                                      btScalar minHeight,
+                                                      btScalar maxHeight,
+                                                      int upAxis,
+                                                      PHY_ScalarType hdt,
+                                                      bool flipQuadEdges)
 {
 	initialize(heightStickWidth, heightStickLength, heightfieldData,
 	           heightScale, minHeight, maxHeight, upAxis, hdt,
@@ -51,12 +54,15 @@ btHeightfieldTerrainShape::btHeightfieldTerrainShape(int heightStickWidth, int h
 
 
 
-void btHeightfieldTerrainShape::initialize
-(
-int heightStickWidth, int heightStickLength, const void* heightfieldData,
-btScalar heightScale, btScalar minHeight, btScalar maxHeight, int upAxis,
-PHY_ScalarType hdt, bool flipQuadEdges
-)
+void btHeightfieldTerrainShape::initialize (int heightStickWidth,
+                                            int heightStickLength,
+                                            const void* heightfieldData,
+                                            btScalar heightScale,
+                                            btScalar minHeight,
+                                            btScalar maxHeight,
+                                            int upAxis,
+                                            PHY_ScalarType hdt,
+                                            bool flipQuadEdges)
 {
 	// validation
 	btAssert(heightStickWidth > 1 && "bad width");
@@ -117,14 +123,6 @@ PHY_ScalarType hdt, bool flipQuadEdges
 	// remember origin (defined as exact middle of aabb)
 	m_localOrigin = btScalar(0.5) * (m_localAabbMin + m_localAabbMax);
 }
-
-
-
-btHeightfieldTerrainShape::~btHeightfieldTerrainShape()
-{
-}
-
-
 
 void btHeightfieldTerrainShape::getAabb(const btTransform& t,btVector3& aabbMin,btVector3& aabbMax) const
 {
@@ -193,7 +191,7 @@ void	btHeightfieldTerrainShape::getVertex(int x,int y,btVector3& vertex) const
 	btAssert(x<m_heightStickWidth);
 	btAssert(y<m_heightStickLength);
 
-	btScalar	height = getRawHeightFieldValue(x,y);
+	btScalar height = getRawHeightFieldValue(x,y);
 
 	switch (m_upAxis)
 	{
@@ -236,19 +234,10 @@ void	btHeightfieldTerrainShape::getVertex(int x,int y,btVector3& vertex) const
 
 
 
-static inline int
-getQuantized
-(
-btScalar x
-)
+static inline int getQuantized (btScalar x)
 {
-	if (x < 0.0) {
-		return (int) (x - 0.5);
-	}
-	return (int) (x + 0.5);
+    return x < 0.0 ? int(x - 0.5) : int(x + 0.5);
 }
-
-
 
 /// given input vector, return quantized version
 /**
@@ -268,10 +257,7 @@ void btHeightfieldTerrainShape::quantizeWithClamp(int* out, const btVector3& poi
 	out[0] = getQuantized(clampedPoint.getX());
 	out[1] = getQuantized(clampedPoint.getY());
 	out[2] = getQuantized(clampedPoint.getZ());
-		
 }
-
-
 
 /// process all triangles within the provided axis-aligned bounding box
 /**
@@ -353,9 +339,6 @@ void	btHeightfieldTerrainShape::processAllTriangles(btTriangleCallback* callback
 		}
 	}
 
-	
-  
-
 	for(int j=startJ; j<endJ; j++)
 	{
 		for(int x=startX; x<endX; x++)
@@ -363,48 +346,45 @@ void	btHeightfieldTerrainShape::processAllTriangles(btTriangleCallback* callback
 			btVector3 vertices[3];
 			if (m_flipQuadEdges || (m_useDiamondSubdivision && !((j+x) & 1))|| (m_useZigzagSubdivision  && !(j & 1)))
 			{
-        //first triangle
-        getVertex(x,j,vertices[0]);
-		getVertex(x, j + 1, vertices[1]);
-		getVertex(x + 1, j + 1, vertices[2]);
-        callback->processTriangle(vertices,x,j);
-        //second triangle
-      //  getVertex(x,j,vertices[0]);//already got this vertex before, thanks to Danny Chapman
-        getVertex(x+1,j+1,vertices[1]);
-		getVertex(x + 1, j, vertices[2]);
-		callback->processTriangle(vertices, x, j);
-
-			} else
+                //first triangle
+                getVertex(x,j,vertices[0]);
+		        getVertex(x, j + 1, vertices[1]);
+		        getVertex(x + 1, j + 1, vertices[2]);
+                callback->processTriangle(vertices,x,j);
+                //second triangle
+              //  getVertex(x,j,vertices[0]);//already got this vertex before, thanks to Danny Chapman
+                getVertex(x+1,j+1,vertices[1]);
+		        getVertex(x + 1, j, vertices[2]);
+		        callback->processTriangle(vertices, x, j);
+			} 
+            else
 			{
-        //first triangle
-        getVertex(x,j,vertices[0]);
-        getVertex(x,j+1,vertices[1]);
-        getVertex(x+1,j,vertices[2]);
-        callback->processTriangle(vertices,x,j);
-        //second triangle
-        getVertex(x+1,j,vertices[0]);
-        //getVertex(x,j+1,vertices[1]);
-        getVertex(x+1,j+1,vertices[2]);
-        callback->processTriangle(vertices,x,j);
+                //first triangle
+                getVertex(x,j,vertices[0]);
+                getVertex(x,j+1,vertices[1]);
+                getVertex(x+1,j,vertices[2]);
+                callback->processTriangle(vertices,x,j);
+                //second triangle
+                getVertex(x+1,j,vertices[0]);
+                //getVertex(x,j+1,vertices[1]);
+                getVertex(x+1,j+1,vertices[2]);
+                callback->processTriangle(vertices,x,j);
 			}
 		}
 	}
-
-	
-
 }
 
 void	btHeightfieldTerrainShape::calculateLocalInertia(btScalar ,btVector3& inertia) const
 {
-	//moving concave objects not supported
-	
-	inertia.setValue(btScalar(0.),btScalar(0.),btScalar(0.));
+	//moving concave objects not supported	
+    inertia = btVector3{};
 }
 
 void	btHeightfieldTerrainShape::setLocalScaling(const btVector3& scaling)
 {
 	m_localScaling = scaling;
 }
+
 const btVector3& btHeightfieldTerrainShape::getLocalScaling() const
 {
 	return m_localScaling;

--- a/src/BulletCollision/CollisionShapes/btHeightfieldTerrainShape.h
+++ b/src/BulletCollision/CollisionShapes/btHeightfieldTerrainShape.h
@@ -141,7 +141,7 @@ public:
  	 */
 	btHeightfieldTerrainShape(int heightStickWidth,int heightStickLength,const void* heightfieldData, btScalar maxHeight,int upAxis,bool useFloatData,bool flipQuadEdges);
 
-	virtual ~btHeightfieldTerrainShape();
+	virtual ~btHeightfieldTerrainShape() = default;
 
 
 	void setUseDiamondSubdivision(bool useDiamondSubdivision=true) { m_useDiamondSubdivision = useDiamondSubdivision;}

--- a/src/BulletCollision/CollisionShapes/btShapeHull.cpp
+++ b/src/BulletCollision/CollisionShapes/btShapeHull.cpp
@@ -40,7 +40,7 @@ btShapeHull::buildHull (btScalar /*margin*/)
 {
 	int numSampleDirections = NUM_UNITSPHERE_POINTS;
 	{
-		int numPDA = m_shape->getNumPreferredPenetrationDirections();
+		const int numPDA = m_shape->getNumPreferredPenetrationDirections();
 		if (numPDA)
 		{
 			for (int i=0;i<numPDA;i++)
@@ -54,8 +54,7 @@ btShapeHull::buildHull (btScalar /*margin*/)
 	}
 
 	btVector3 supportPoints[NUM_UNITSPHERE_POINTS+MAX_PREFERRED_PENETRATION_DIRECTIONS*2];
-	int i;
-	for (i = 0; i < numSampleDirections; i++)
+	for (int i = 0; i < numSampleDirections; i++)
 	{
 		supportPoints[i] = m_shape->localGetSupportingVertex(getUnitSpherePoints()[i]);
 	}
@@ -82,13 +81,13 @@ btShapeHull::buildHull (btScalar /*margin*/)
 	m_vertices.resize (static_cast<int>(hr.mNumOutputVertices));
 
 
-	for (i = 0; i < static_cast<int>(hr.mNumOutputVertices); i++)
+	for (int i = 0; i < static_cast<int>(hr.mNumOutputVertices); i++)
 	{
 		m_vertices[i] = hr.m_OutputVertices[i];
 	}
 	m_numIndices = hr.mNumIndices;
 	m_indices.resize(static_cast<int>(m_numIndices));
-	for (i = 0; i < static_cast<int>(m_numIndices); i++)
+	for (int i = 0; i < static_cast<int>(m_numIndices); i++)
 	{
 		m_indices[i] = hr.m_Indices[i];
 	}
@@ -167,4 +166,3 @@ btVector3* btShapeHull::getUnitSpherePoints()
 	};
 	return sUnitSpherePoints;
 }
-

--- a/src/BulletCollision/CollisionShapes/btTriangleMeshShape.cpp
+++ b/src/BulletCollision/CollisionShapes/btTriangleMeshShape.cpp
@@ -35,15 +35,6 @@ btTriangleMeshShape::btTriangleMeshShape(btStridingMeshInterface* meshInterface)
 	}
 }
 
-
-btTriangleMeshShape::~btTriangleMeshShape()
-{
-		
-}
-
-
-
-
 void btTriangleMeshShape::getAabb(const btTransform& trans,btVector3& aabbMin,btVector3& aabbMax) const
 {
 
@@ -74,8 +65,6 @@ void	btTriangleMeshShape::recalcLocalAabb()
 	}
 }
 
-
-
 class SupportVertexCallback : public btTriangleCallback
 {
 
@@ -88,7 +77,6 @@ public:
 
 	SupportVertexCallback(const btVector3& supportVecWorld,const btTransform& trans)
 		: m_supportVertexLocal(btScalar(0.),btScalar(0.),btScalar(0.)), m_worldTrans(trans) ,m_maxDot(btScalar(-BT_LARGE_FLOAT))
-		
 	{
 		m_supportVecLocal = supportVecWorld * m_worldTrans.getBasis();
 	}
@@ -132,15 +120,7 @@ const btVector3& btTriangleMeshShape::getLocalScaling() const
 	return m_meshInterface->getScaling();
 }
 
-
-
-
-
-
 //#define DEBUG_TRIANGLE_MESH
-
-
-
 void	btTriangleMeshShape::processAllTriangles(btTriangleCallback* callback,const btVector3& aabbMin,const btVector3& aabbMax) const
 {
 		struct FilteredCallback : public btInternalTriangleIndexCallback
@@ -163,9 +143,7 @@ void	btTriangleMeshShape::processAllTriangles(btTriangleCallback* callback,const
 				//check aabb in triangle-space, before doing this
 				m_callback->processTriangle(triangle,partId,triangleIndex);
 			}
-			
 		}
-
 	};
 
 	FilteredCallback filterCallback(callback,aabbMin,aabbMax);
@@ -173,23 +151,16 @@ void	btTriangleMeshShape::processAllTriangles(btTriangleCallback* callback,const
 	m_meshInterface->InternalProcessAllTriangles(&filterCallback,aabbMin,aabbMax);
 }
 
-
-
-
-
 void	btTriangleMeshShape::calculateLocalInertia(btScalar mass,btVector3& inertia) const
 {
 	(void)mass;
 	//moving concave objects not supported
 	btAssert(0);
-	inertia.setValue(btScalar(0.),btScalar(0.),btScalar(0.));
+    inertia = btVector3{};
 }
-
 
 btVector3 btTriangleMeshShape::localGetSupportingVertex(const btVector3& vec) const
 {
-	btVector3 supportVertex;
-
 	btTransform ident;
 	ident.setIdentity();
 
@@ -199,9 +170,5 @@ btVector3 btTriangleMeshShape::localGetSupportingVertex(const btVector3& vec) co
 	
 	processAllTriangles(&supportCallback,-aabbMax,aabbMax);
 		
-	supportVertex = supportCallback.GetSupportVertexLocal();
-
-	return supportVertex;
+    return supportCallback.GetSupportVertexLocal();
 }
-
-

--- a/src/BulletCollision/CollisionShapes/btTriangleMeshShape.h
+++ b/src/BulletCollision/CollisionShapes/btTriangleMeshShape.h
@@ -35,7 +35,7 @@ protected:
 public:
 	BT_DECLARE_ALIGNED_ALLOCATOR();
 
-	virtual ~btTriangleMeshShape();
+	virtual ~btTriangleMeshShape() = default;
 
 	virtual btVector3 localGetSupportingVertex(const btVector3& vec) const;
 

--- a/src/BulletCollision/NarrowPhaseCollision/btConvexPenetrationDepthSolver.h
+++ b/src/BulletCollision/NarrowPhaseCollision/btConvexPenetrationDepthSolver.h
@@ -26,15 +26,15 @@ class btTransform;
 class btConvexPenetrationDepthSolver
 {
 public:	
-	
-	virtual ~btConvexPenetrationDepthSolver() {};
+	virtual ~btConvexPenetrationDepthSolver() = default;
 	virtual bool calcPenDepth( btSimplexSolverInterface& simplexSolver,
-		const btConvexShape* convexA,const btConvexShape* convexB,
-					const btTransform& transA,const btTransform& transB,
-				btVector3& v, btVector3& pa, btVector3& pb,
-				class btIDebugDraw* debugDraw) = 0;
-
-
+                               const btConvexShape* convexA,
+                               const btConvexShape* convexB,
+                               const btTransform& transA,
+                               const btTransform& transB,
+                               btVector3& v,
+                               btVector3& pa,
+                               btVector3& pb,
+                               class btIDebugDraw* debugDraw) = 0;
 };
 #endif //BT_CONVEX_PENETRATION_DEPTH_H
-

--- a/src/BulletCollision/NarrowPhaseCollision/btPolyhedralContactClipping.cpp
+++ b/src/BulletCollision/NarrowPhaseCollision/btPolyhedralContactClipping.cpp
@@ -59,7 +59,7 @@ void btPolyhedralContactClipping::clipFace(const btVertexArray& pVtxIn, btVertex
 			else
 			{
 				// Start < 0, end >= 0, so output intersection
-				ppVtxOut.push_back( 	firstVertex.lerp(endVertex,btScalar(ds * 1.f/(ds - de))));
+				ppVtxOut.push_back(firstVertex.lerp(endVertex,btScalar(ds * 1.f/(ds - de))));
 			}
 		}
 		else
@@ -91,9 +91,9 @@ static bool TestSepAxis(const btConvexPolyhedron& hullA, const btConvexPolyhedro
 		return false;
 
 	btScalar d0 = Max0 - Min1;
-	btAssert(d0>=0.0f);
+    btAssert(d0 >= 0.0);
 	btScalar d1 = Max1 - Min0;
-	btAssert(d1>=0.0f);
+    btAssert(d1 >= 0.0);
 	if (d0<d1)
 	{
 		depth = d0;
@@ -113,12 +113,6 @@ static bool TestSepAxis(const btConvexPolyhedron& hullA, const btConvexPolyhedro
 
 
 static int gActualSATPairTests=0;
-
-inline bool IsAlmostZero(const btVector3& v)
-{
-	if(fabsf(v.x())>1e-6 || fabsf(v.y())>1e-6 || fabsf(v.z())>1e-6)	return false;
-	return true;
-}
 
 #ifdef TEST_INTERNAL_OBJECTS
 
@@ -171,10 +165,9 @@ void InverseTransformPoint3x3(btVector3& out, const btVector3& in, const btTrans
 	const btScalar d0 = MinMaxRadius + dp;
 	const btScalar d1 = MinMaxRadius - dp;
 
-	const btScalar depth = d0<d1 ? d0:d1;
-	if(depth>dmin)
-		return false;
-	return true;
+    const btScalar depth = d0 < d1 ? d0 : d1;
+	
+    return depth <= dmin;
 }
 #endif //TEST_INTERNAL_OBJECTS
 
@@ -237,7 +230,7 @@ void InverseTransformPoint3x3(btVector3& out, const btVector3& in, const btTrans
 
 
 
-bool btPolyhedralContactClipping::findSeparatingAxis(	const btConvexPolyhedron& hullA, const btConvexPolyhedron& hullB, const btTransform& transA,const btTransform& transB, btVector3& sep, btDiscreteCollisionDetectorInterface::Result& resultOut)
+bool btPolyhedralContactClipping::findSeparatingAxis(const btConvexPolyhedron& hullA, const btConvexPolyhedron& hullB, const btTransform& transA,const btTransform& transB, btVector3& sep, btDiscreteCollisionDetectorInterface::Result& resultOut)
 {
 	gActualSATPairTests++;
 
@@ -250,9 +243,8 @@ bool btPolyhedralContactClipping::findSeparatingAxis(	const btConvexPolyhedron& 
 	btScalar dmin = FLT_MAX;
 	int curPlaneTests=0;
 
-	int numFacesA = hullA.m_faces.size();
 	// Test normals from hullA
-	for(int i=0;i<numFacesA;i++)
+    for (int i = 0; i < hullA.m_faces.size(); i++)
 	{
 		const btVector3 Normal(hullA.m_faces[i].m_plane[0], hullA.m_faces[i].m_plane[1], hullA.m_faces[i].m_plane[2]);
 		btVector3 faceANormalWS = transA.getBasis() * Normal;
@@ -279,9 +271,8 @@ bool btPolyhedralContactClipping::findSeparatingAxis(	const btConvexPolyhedron& 
 		}
 	}
 
-	int numFacesB = hullB.m_faces.size();
 	// Test normals from hullB
-	for(int i=0;i<numFacesB;i++)
+    for (int i = 0; i<hullB.m_faces.size(); i++)
 	{
 		const btVector3 Normal(hullB.m_faces[i].m_plane[0], hullB.m_faces[i].m_plane[1], hullB.m_faces[i].m_plane[2]);
 		btVector3 WorldNormal = transB.getBasis() * Normal;
@@ -411,7 +402,7 @@ bool btPolyhedralContactClipping::findSeparatingAxis(	const btConvexPolyhedron& 
 	return true;
 }
 
-void	btPolyhedralContactClipping::clipFaceAgainstHull(const btVector3& separatingNormal, const btConvexPolyhedron& hullA,  const btTransform& transA, btVertexArray& worldVertsB1, const btScalar minDist, btScalar maxDist,btDiscreteCollisionDetectorInterface::Result& resultOut)
+void btPolyhedralContactClipping::clipFaceAgainstHull(const btVector3& separatingNormal, const btConvexPolyhedron& hullA,  const btTransform& transA, btVertexArray& worldVertsB1, const btScalar minDist, btScalar maxDist,btDiscreteCollisionDetectorInterface::Result& resultOut)
 {
 	btVertexArray worldVertsB2;
 	btVertexArray* pVtxIn = &worldVertsB1;
@@ -439,15 +430,15 @@ void	btPolyhedralContactClipping::clipFaceAgainstHull(const btVector3& separatin
 
 	const btFace& polyA = hullA.m_faces[closestFaceA];
 
-		// clip polygon to back of planes of all faces of hull A that are adjacent to witness face
-	int numVerticesA = polyA.m_indices.size();
-	for(int e0=0;e0<numVerticesA;e0++)
+	// clip polygon to back of planes of all faces of hull A that are adjacent to witness face
+	const int numVerticesA = polyA.m_indices.size();
+    for (int e0 = 0; e0 < numVerticesA; e0++)
 	{
 		const btVector3& a = hullA.m_vertices[polyA.m_indices[e0]];
-		const btVector3& b = hullA.m_vertices[polyA.m_indices[(e0+1)%numVerticesA]];
+        const btVector3& b = hullA.m_vertices[polyA.m_indices[(e0 + 1) % numVerticesA]];
 		const btVector3 edge0 = a - b;
 		const btVector3 WorldEdge0 = transA.getBasis() * edge0;
-		btVector3 worldPlaneAnormal1 = transA.getBasis()* btVector3(polyA.m_plane[0],polyA.m_plane[1],polyA.m_plane[2]);
+        btVector3 worldPlaneAnormal1 = transA.getBasis()* btVector3(polyA.m_plane[0], polyA.m_plane[1], polyA.m_plane[2]);
 
 		btVector3 planeNormalWS1 = -WorldEdge0.cross(worldPlaneAnormal1);//.cross(WorldEdge0);
 		btVector3 worldA1 = transA*a;
@@ -478,8 +469,6 @@ void	btPolyhedralContactClipping::clipFaceAgainstHull(const btVector3& separatin
 //#define ONLY_REPORT_DEEPEST_POINT
 
 	btVector3 point;
-	
-
 	// only keep points that are behind the witness face
 	{
 		btVector3 localPlaneNormal (polyA.m_plane[0],polyA.m_plane[1],polyA.m_plane[2]);
@@ -523,10 +512,6 @@ void	btPolyhedralContactClipping::clipFaceAgainstHull(const btVector3& separatin
 
 }
 
-
-
-
-
 void	btPolyhedralContactClipping::clipHullAgainstHull(const btVector3& separatingNormal1, const btConvexPolyhedron& hullA, const btConvexPolyhedron& hullB, const btTransform& transA,const btTransform& transB, const btScalar minDist, btScalar maxDist,btDiscreteCollisionDetectorInterface::Result& resultOut)
 {
 
@@ -552,19 +537,18 @@ void	btPolyhedralContactClipping::clipHullAgainstHull(const btVector3& separatin
 			}
 		}
 	}
-				btVertexArray worldVertsB1;
-				{
-					const btFace& polyB = hullB.m_faces[closestFaceB];
-					const int numVertices = polyB.m_indices.size();
-					for(int e0=0;e0<numVertices;e0++)
-					{
-						const btVector3& b = hullB.m_vertices[polyB.m_indices[e0]];
-						worldVertsB1.push_back(transB*b);
-					}
-				}
 
+    btVertexArray worldVertsB1;
+    {
+        const btFace& polyB = hullB.m_faces[closestFaceB];
+        const int numVertices = polyB.m_indices.size();
+        for (int e0 = 0; e0 < numVertices; e0++)
+        {
+            const btVector3& b = hullB.m_vertices[polyB.m_indices[e0]];
+            worldVertsB1.push_back(transB*b);
+        }
+    }
 	
 	if (closestFaceB>=0)
 		clipFaceAgainstHull(separatingNormal, hullA, transA,worldVertsB1, minDist, maxDist,resultOut);
-
 }

--- a/src/BulletCollision/NarrowPhaseCollision/btRaycastCallback.h
+++ b/src/BulletCollision/NarrowPhaseCollision/btRaycastCallback.h
@@ -45,6 +45,7 @@ public:
 	btScalar	m_hitFraction;
 
 	btTriangleRaycastCallback(const btVector3& from,const btVector3& to, unsigned int flags=0);
+    virtual ~btTriangleRaycastCallback() = default;
 	
 	virtual void processTriangle(btVector3* triangle, int partId, int triangleIndex);
 
@@ -64,6 +65,7 @@ public:
 	btScalar m_allowedPenetration;
 
 	btTriangleConvexcastCallback (const btConvexShape* convexShape, const btTransform& convexShapeFrom, const btTransform& convexShapeTo, const btTransform& triangleToWorld, const btScalar triangleCollisionMargin);
+    virtual ~btTriangleConvexcastCallback() = default;
 
 	virtual void processTriangle (btVector3* triangle, int partId, int triangleIndex);
 

--- a/src/BulletDynamics/ConstraintSolver/btConeTwistConstraint.cpp
+++ b/src/BulletDynamics/ConstraintSolver/btConeTwistConstraint.cpp
@@ -642,7 +642,7 @@ void btConeTwistConstraint::calcAngleInfo2(const btTransform& transA, const btTr
 		btTransform trDeltaAB = trB * trPose * trA.inverse();
 		btQuaternion qDeltaAB = trDeltaAB.getRotation();
 		btVector3 swingAxis = 	btVector3(qDeltaAB.x(), qDeltaAB.y(), qDeltaAB.z());
-		float swingAxisLen2 = swingAxis.length2();
+		btScalar swingAxisLen2 = swingAxis.length2();
 		if(btFuzzyZero(swingAxisLen2))
 		{
 		   return;
@@ -901,14 +901,14 @@ btVector3 btConeTwistConstraint::GetPointForAngle(btScalar fAngleInRadians, btSc
 	//  a^2   b^2
 	// Do the math and it should be clear.
 
-	float swingLimit = m_swingSpan1; // if xEllipse == 0, just use axis b (1)
+	btScalar swingLimit = m_swingSpan1; // if xEllipse == 0, just use axis b (1)
 	if (fabs(xEllipse) > SIMD_EPSILON)
 	{
 		btScalar surfaceSlope2 = (yEllipse*yEllipse)/(xEllipse*xEllipse);
 		btScalar norm = 1 / (m_swingSpan2 * m_swingSpan2);
 		norm += surfaceSlope2 / (m_swingSpan1 * m_swingSpan1);
 		btScalar swingLimit2 = (1 + surfaceSlope2) / norm;
-		swingLimit = sqrt(swingLimit2);
+		swingLimit = static_cast<btScalar>(sqrt(swingLimit2));
 	}
 
 	// convert into point in constraint space:

--- a/src/BulletDynamics/Featherstone/btMultiBody.cpp
+++ b/src/BulletDynamics/Featherstone/btMultiBody.cpp
@@ -1799,7 +1799,7 @@ void btMultiBody::stepVelocities(btScalar dt,
         }
 		btVector3 rhs_top (zero_acc_top_angular[0][0], zero_acc_top_angular[0][1], zero_acc_top_angular[0][2]);
 		btVector3 rhs_bot (zero_acc_bottom_linear[0][0], zero_acc_bottom_linear[0][1], zero_acc_bottom_linear[0][2]);
-        float result[6];
+        btScalar result[6];
 
 		solveImatrix(rhs_top, rhs_bot, result);
 //		printf("result=%f,%f,%f,%f,%f,%f\n",result[0],result[0],result[0],result[0],result[0],result[0]);
@@ -1856,7 +1856,7 @@ void btMultiBody::stepVelocities(btScalar dt,
 	
 }
 
-void btMultiBody::solveImatrix(const btVector3& rhs_top, const btVector3& rhs_bot, float result[6]) const
+void btMultiBody::solveImatrix(const btVector3& rhs_top, const btVector3& rhs_bot, btScalar result[6]) const
 {
 	int num_links = getNumLinks();
 	///solve I * x = rhs, so the result = invI * rhs
@@ -2393,7 +2393,7 @@ void btMultiBody::calcAccelerationDeltas(const btScalar *force, btScalar *output
 		btVector3 rhs_top (zero_acc_top_angular[0][0], zero_acc_top_angular[0][1], zero_acc_top_angular[0][2]);
 		btVector3 rhs_bot (zero_acc_bottom_linear[0][0], zero_acc_bottom_linear[0][1], zero_acc_bottom_linear[0][2]);
 		
-		float result[6];
+		btScalar result[6];
         solveImatrix(rhs_top,rhs_bot, result);
 	//	printf("result=%f,%f,%f,%f,%f,%f\n",result[0],result[0],result[0],result[0],result[0],result[0]);
 
@@ -2482,7 +2482,7 @@ void btMultiBody::stepPositions(btScalar dt)
     // Finally we can update m_jointPos for each of the m_links
     for (int i = 0; i < num_links; ++i) 
 	{
-		float jointVel = getJointVel(i);
+		btScalar jointVel = getJointVel(i);
         m_links[i].m_jointPos[0] += dt * jointVel;
         m_links[i].updateCache();
     }

--- a/src/BulletDynamics/Featherstone/btMultiBody.h
+++ b/src/BulletDynamics/Featherstone/btMultiBody.h
@@ -535,7 +535,7 @@ private:
 
     void compTreeLinkVelocities(btVector3 *omega, btVector3 *vel) const;
 
-	void solveImatrix(const btVector3& rhs_top, const btVector3& rhs_bot, float result[6]) const;
+	void solveImatrix(const btVector3& rhs_top, const btVector3& rhs_bot, btScalar result[6]) const;
 #ifdef TEST_SPATIAL_ALGEBRA_LAYER
 	void solveImatrix(const btSpatialForceVector &rhs, btSpatialMotionVector &result) const;
 #endif

--- a/src/BulletDynamics/MLCPSolvers/btSolveProjectedGaussSeidel.h
+++ b/src/BulletDynamics/MLCPSolvers/btSolveProjectedGaussSeidel.h
@@ -24,7 +24,7 @@ subject to the following restrictions:
 class btSolveProjectedGaussSeidel : public btMLCPSolverInterface
 {
 public:
-	virtual bool solveMLCP(const btMatrixXu & A, const btVectorXu & b, btVectorXu& x, const btVectorXu & lo,const btVectorXu & hi,const btAlignedObjectArray<int>& limitDependency, int numIterations, bool useSparsity = true)
+	virtual bool solveMLCP(const btMatrixXu& A, const btVectorXu& b, btVectorXu& x, const btVectorXu& lo, const btVectorXu& hi, const btAlignedObjectArray<int>& limitDependency, int numIterations, bool useSparsity = true)
 	{
 		if (!A.rows())
 			return true;
@@ -34,18 +34,16 @@ public:
 		//A is a m-n matrix, m rows, n columns
 		btAssert(A.rows() == b.rows());
 
-		int i, j, numRows = A.rows();
+		int numRows = A.rows();
 	
-		float delta;
-
 		for (int k = 0; k <numIterations; k++)
 		{
-			for (i = 0; i <numRows; i++)
+			for (int i = 0; i <numRows; i++)
 			{
-				delta = 0.0f;
+				double delta = 0.0;
 				if (useSparsity)
 				{
-					for (int h=0;h<A.m_rowNonZeroElements1[i].size();h++)
+                    for (int h = 0; h < A.m_rowNonZeroElements1[i].size(); h++)
 					{
 						int j = A.m_rowNonZeroElements1[i][h];
 						if (j != i)//skip main diagonal
@@ -55,15 +53,15 @@ public:
 					}
 				} else
 				{
-					for (j = 0; j <i; j++) 
+                    for (int j = 0; j < i; j++)
 						delta += A(i,j) * x[j];
-					for (j = i+1; j<numRows; j++) 
+                    for (int j = i + 1; j < numRows; j++)
 						delta += A(i,j) * x[j];
 				}
 
-				float aDiag = A(i,i);
-				x [i] = (b [i] - delta) / aDiag;
-				float s = 1.f;
+				double aDiag = A(i,i);
+                x[i] = (b[i] - delta) / aDiag;
+				double s = 1.0;
 
 				if (limitDependency[i]>=0)
 				{
@@ -72,15 +70,14 @@ public:
 						s=1;
 				}
 			
-				if (x[i]<lo[i]*s)
-					x[i]=lo[i]*s;
-				if (x[i]>hi[i]*s)
-					x[i]=hi[i]*s;
+                if (x[i]<lo[i] * s)
+                    x[i] = lo[i] * s;
+                if (x[i] > hi[i] * s)
+                    x[i] = hi[i] * s;
 			}
 		}
 		return true;
 	}
-
 };
 
 #endif //BT_SOLVE_PROJECTED_GAUSS_SEIDEL_H

--- a/src/LinearMath/btAlignedObjectArray.h
+++ b/src/LinearMath/btAlignedObjectArray.h
@@ -39,6 +39,7 @@ subject to the following restrictions:
 #include <new> //for placement new
 #endif //BT_USE_PLACEMENT_NEW
 
+#include <utility>
 
 ///The btAlignedObjectArray template class uses a subset of the stl::vector interface for its methods
 ///It is developed to replace stl::vector to avoid portability issues, including STL alignment issues to add SIMD/SSE data
@@ -69,12 +70,11 @@ private:
 protected:
 		SIMD_FORCE_INLINE	int	allocSize(int size)
 		{
-			return (size ? size*2 : 1);
+            return (size ? size * 2 : 1);
 		}
 		SIMD_FORCE_INLINE	void	copy(int start,int end, T* dest) const
 		{
-			int i;
-			for (i=start;i<end;++i)
+            for (int i = start; i < end; ++i)
 #ifdef BT_USE_PLACEMENT_NEW
 				new (&dest[i]) T(m_data[i]);
 #else
@@ -92,8 +92,7 @@ protected:
 		}
 		SIMD_FORCE_INLINE	void	destroy(int first,int last)
 		{
-			int i;
-			for (i=first; i<last;i++)
+            for (int i = first; i < last; i++)
 			{
 				m_data[i].~T();
 			}
@@ -117,10 +116,7 @@ protected:
 				m_data = 0;
 			}
 		}
-
-	
-
-
+        
 	public:
 		
 		btAlignedObjectArray()
@@ -142,8 +138,7 @@ protected:
 			resize (otherSize);
 			otherArray.copy(0, otherSize, m_data);
 		}
-
-		
+        
 		
 		/// return the number of elements in the array
 		SIMD_FORCE_INLINE	int size() const
@@ -275,10 +270,9 @@ protected:
 
 		SIMD_FORCE_INLINE	void push_back(const T& _Val)
 		{	
-			int sz = size();
-			if( sz == capacity() )
+            if (size() == capacity())
 			{
-				reserve( allocSize(size()) );
+                reserve(allocSize(size()));
 			}
 			
 #ifdef BT_USE_PLACEMENT_NEW
@@ -304,32 +298,15 @@ protected:
 				T*	s = (T*)allocate(_Count);
 
 				copy(0, size(), s);
-
 				destroy(0,size());
-
 				deallocate();
 				
 				//PCK: added this line
 				m_ownsMemory = true;
-
 				m_data = s;
-				
 				m_capacity = _Count;
-
 			}
 		}
-
-
-		class less
-		{
-			public:
-
-				bool operator() ( const T& a, const T& b )
-				{
-					return ( a < b );
-				}
-		};
-	
 
 		template <typename L>
 		void quickSortInternal(const L& CompareFunc,int lo, int hi)
@@ -412,9 +389,7 @@ protected:
 			memcpy(&m_data[index0],&m_data[index1],sizeof(T));
 			memcpy(&m_data[index1],temp,sizeof(T));
 #else
-			T temp = m_data[index0];
-			m_data[index0] = m_data[index1];
-			m_data[index1] = temp;
+            std::swap(m_data[index0], m_data[index1]);
 #endif //BT_USE_PLACEMENT_NEW
 
 		}
@@ -423,19 +398,15 @@ protected:
 	void heapSort(const L& CompareFunc)
 	{
 		/* sort a[0..N-1],  N.B. 0 to N-1 */
-		int k;
-		int n = m_size;
-		for (k = n/2; k > 0; k--) 
+		for (int k = n/2; k > 0; k--) 
 		{
-			downHeap(m_data, k, n, CompareFunc);
+            downHeap(m_data, k, m_size CompareFunc);
 		}
 
 		/* a[1..N] is now a heap */
-		while ( n>=1 ) 
+        while (n >= 1)
 		{
 			swap(0,n-1); /* largest of a[0..n-1] */
-
-
 			n = n - 1;
 			/* restore a[1..i-1] heap */
 			downHeap(m_data, 1, n, CompareFunc);
@@ -464,10 +435,8 @@ protected:
 
 	int	findLinearSearch(const T& key) const
 	{
-		int index=size();
-		int i;
-
-		for (i=0;i<size();i++)
+        int index = size();
+        for (int i = 0; i < size(); i++)
 		{
 			if (m_data[i] == key)
 			{
@@ -478,9 +447,8 @@ protected:
 		return index;
 	}
 
-	void	remove(const T& key)
+	void remove(const T& key)
 	{
-
 		int findIndex = findLinearSearch(key);
 		if (findIndex<size())
 		{
@@ -501,11 +469,10 @@ protected:
 
 	void copyFromArray(const btAlignedObjectArray& otherArray)
 	{
-		int otherSize = otherArray.size();
+		const int otherSize = otherArray.size();
 		resize (otherSize);
 		otherArray.copy(0, otherSize, m_data);
 	}
-
 };
 
 #endif //BT_OBJECT_ARRAY__

--- a/src/LinearMath/btAlignedObjectArray.h
+++ b/src/LinearMath/btAlignedObjectArray.h
@@ -391,16 +391,16 @@ protected:
 #else
             std::swap(m_data[index0], m_data[index1]);
 #endif //BT_USE_PLACEMENT_NEW
-
 		}
 
 	template <typename L>
 	void heapSort(const L& CompareFunc)
 	{
+        int n = m_size;
 		/* sort a[0..N-1],  N.B. 0 to N-1 */
 		for (int k = n/2; k > 0; k--) 
 		{
-            downHeap(m_data, k, m_size CompareFunc);
+            downHeap(m_data, k, m_size, CompareFunc);
 		}
 
 		/* a[1..N] is now a heap */

--- a/src/LinearMath/btScalar.h
+++ b/src/LinearMath/btScalar.h
@@ -26,6 +26,7 @@ subject to the following restrictions:
 #include <math.h>
 #include <stdlib.h>//size_t for MSVC 6.0
 #include <float.h>
+#include <utility>
 
 /* SVN $Revision$ on $Date$ from http://bullet.googlecode.com*/
 #define BT_BULLET_VERSION 283
@@ -507,19 +508,13 @@ SIMD_FORCE_INLINE btScalar btAtan2Fast(btScalar y, btScalar x)
 	return (y < 0.0f) ? -angle : angle;
 }
 
-SIMD_FORCE_INLINE bool      btFuzzyZero(btScalar x) { return btFabs(x) < SIMD_EPSILON; }
+SIMD_FORCE_INLINE bool btFuzzyZero(btScalar x) { return btFabs(x) < SIMD_EPSILON; }
 
-SIMD_FORCE_INLINE bool	btEqual(btScalar a, btScalar eps) {
-	return (((a) <= eps) && !((a) < -eps));
-}
-SIMD_FORCE_INLINE bool	btGreaterEqual (btScalar a, btScalar eps) {
-	return (!((a) <= eps));
-}
+SIMD_FORCE_INLINE bool	btEqual(btScalar a, btScalar eps) { return (((a) <= eps) && !((a) < -eps)); }
 
+SIMD_FORCE_INLINE bool	btGreaterEqual (btScalar a, btScalar eps) {	return (!((a) <= eps)); }
 
-SIMD_FORCE_INLINE int       btIsNegative(btScalar x) {
-    return x < btScalar(0.0) ? 1 : 0;
-}
+SIMD_FORCE_INLINE int btIsNegative(btScalar x) { return x < btScalar(0.0) ? 1 : 0; }
 
 SIMD_FORCE_INLINE btScalar btRadians(btScalar x) { return x * SIMD_RADS_PER_DEG; }
 SIMD_FORCE_INLINE btScalar btDegrees(btScalar x) { return x * SIMD_DEGS_PER_RAD; }
@@ -527,10 +522,7 @@ SIMD_FORCE_INLINE btScalar btDegrees(btScalar x) { return x * SIMD_DEGS_PER_RAD;
 #define BT_DECLARE_HANDLE(name) typedef struct name##__ { int unused; } *name
 
 #ifndef btFsel
-SIMD_FORCE_INLINE btScalar btFsel(btScalar a, btScalar b, btScalar c)
-{
-	return a >= 0 ? b : c;
-}
+SIMD_FORCE_INLINE btScalar btFsel(btScalar a, btScalar b, btScalar c) { return a >= 0 ? b : c; }
 #endif
 #define btFsels(a,b,c) (btScalar)btFsel(a,b,c)
 
@@ -539,13 +531,8 @@ SIMD_FORCE_INLINE bool btMachineIsLittleEndian()
 {
    long int i = 1;
    const char *p = (const char *) &i;
-   if (p[0] == 1)  // Lowest address contains the least significant byte
-	   return true;
-   else
-	   return false;
+   return p[0] == 1;  // Lowest address contains the least significant byte
 }
-
-
 
 ///btSelect avoids branches, which makes performance much better for consoles like Playstation 3 and XBox 360
 ///Thanks Phil Knight. See also http://www.cellperformance.com/articles/2006/04/more_techniques_for_eliminatin_1.html
@@ -574,13 +561,7 @@ SIMD_FORCE_INLINE float btSelect(unsigned condition, float valueIfConditionNonZe
 #endif
 }
 
-template<typename T> SIMD_FORCE_INLINE void btSwap(T& a, T& b)
-{
-	T tmp = a;
-	a = b;
-	b = tmp;
-}
-
+template<typename T> SIMD_FORCE_INLINE void btSwap(T& a, T& b) { std::swap(a, b); }
 
 //PCK: endian swapping functions
 SIMD_FORCE_INLINE unsigned btSwapEndian(unsigned val)

--- a/src/LinearMath/btVector3.h
+++ b/src/LinearMath/btVector3.h
@@ -685,7 +685,6 @@ public:
 		return m_floats[0] == btScalar(0) && m_floats[1] == btScalar(0) && m_floats[2] == btScalar(0);
 	}
 
-
 	SIMD_FORCE_INLINE bool fuzzyZero() const 
 	{
 		return length2() < SIMD_EPSILON*SIMD_EPSILON;
@@ -937,8 +936,6 @@ lerp(const btVector3& v1, const btVector3& v2, const btScalar& t)
 	return v1.lerp(v2, t);
 }
 
-
-
 SIMD_FORCE_INLINE btScalar btVector3::distance2(const btVector3& v) const
 {
 	return (v - *this).length2();
@@ -1073,6 +1070,10 @@ SIMD_FORCE_INLINE   long    btVector3::minDot( const btVector3 *array, long arra
 #endif//BT_USE_SIMD_VECTOR3
 }
 
+SIMD_FORCE_INLINE bool IsAlmostZero(const btVector3& v)
+{
+    return btFabs(v.x()) <= 1e-6 && btFabs(v.y()) <= 1e-6 && btFabs(v.z()) <= 1e-6;
+}
 
 class btVector4 : public btVector3
 {


### PR DESCRIPTION
Fixed instances of build warnings regarding signed unsigned mismatches. Also fixed build warnings regarding potential loss of precision (btScalar vs float vs double). Minor refactoring such as removing excess newlines, const-ing variables, const-ing trivial member functions, etc.