### PR TITLE
demos3: gl: fixing false error from glewInit()

### DIFF
--- a/Demos3/GpuDemos/main_opengl3core.cpp
+++ b/Demos3/GpuDemos/main_opengl3core.cpp
@@ -724,7 +724,13 @@ int main(int argc, char* argv[])
 
 
 #ifndef __APPLE__
-	glewInit();
+  glewExperimental=true;
+	GLenum glew_err=glewInit();
+  if(glew_err!=GLEW_OK) {
+    fprintf(stderr, "glewInit() failed! Error: %d\n", glew_err);
+  }
+  // Clear false GLEW errors
+  int gl_error = glGetError();
 #endif
 
 	gui = new GwenUserInterface();

--- a/btgui/OpenGLWindow/LoadShader.cpp
+++ b/btgui/OpenGLWindow/LoadShader.cpp
@@ -18,7 +18,11 @@ void gltLoadShaderSrc(const char *szShaderSrc, GLuint shader)
 GLuint gltLoadShaderPair(const char *szVertexProg, const char *szFragmentProg)
 {
 
-  assert(glGetError()==GL_NO_ERROR);
+  int gl_error = glGetError();
+  if(gl_error!=GL_NO_ERROR) {
+    fprintf(stderr, "OpenGL Error: %d\n", gl_error);
+    assert(gl_error==GL_NO_ERROR);
+  }
 
 	// Temporary Shader objects
 	GLuint hVertexShader;


### PR DESCRIPTION
Calling `glewInit()` can yeild an OpenGL error `1280` on some systems. This checks the proper place for an error and then clears the OpenGL error in case this happens.

https://www.opengl.org/wiki/OpenGL_Loading_Library#GLEW_.28OpenGL_Extension_Wrangler.29