### PR TITLE
Prevent SSE Alignment crash in VS2010 and up

### DIFF
--- a/src/LinearMath/btQuadWord.h
+++ b/src/LinearMath/btQuadWord.h
@@ -73,7 +73,7 @@ public:
 
 	public:
   
-#if defined(BT_USE_SSE) || defined(BT_USE_NEON)
+#if (defined(BT_USE_SSE_IN_API) && defined(BT_USE_SSE)) || defined(BT_USE_NEON)
 
 	// Set Vector 
 	SIMD_FORCE_INLINE btQuadWord(const btSimdFloat4 vec)


### PR DESCRIPTION
Note, I'm not the original author of this fix (author's name is Viatrak in the forums).

See http://bulletphysics.org/Bullet/phpBB3/viewtopic.php?t=8915