### PR TITLE
Don't compile SimpleOpenGL3App.* if NOT OPENGL3

### DIFF
--- a/examples/OpenGLWindow/CMakeLists.txt
+++ b/examples/OpenGLWindow/CMakeLists.txt
@@ -18,6 +18,13 @@ LIST(REMOVE_ITEM OpenGLWindowCommon_CPP ${OpenGLWindowLinux_CPP} )
 LIST(REMOVE_ITEM OpenGLWindowCommon_CPP X11OpenGLWindow.cpp )
 #MESSAGE (${OpenGLWindowCommon_CPP})
 
+IF (NOT BUILD_OPENGL3_DEMOS)
+  FILE(GLOB OPENGL3_CPP  "SimpleOpenGL3App.cpp")
+  FILE(GLOB OPENGL3_HDRS "SimpleOpenGL3App.h")
+  LIST(REMOVE_ITEM OpenGLWindowCommon_CPP ${OPENGL3_CPP} )
+  LIST(REMOVE_ITEM OpenGLWindow_HDRS      ${OPENGL3_HDRS} )
+ENDIF()
+
 IF (WIN32)
 	SET(OpenGLWindow_SRCS ${BULLET_PHYSICS_SOURCE_DIR}/examples/ThirdPartyLibs/Glew/glew.c ${OpenGLWindowWin32_CPP} ${OpenGLWindowCommon_CPP})	
 	INCLUDE_DIRECTORIES(


### PR DESCRIPTION
This should fix the Mountain Lion shared library issues