### PR TITLE
Fix #69 - Fix collisions between concave shapes and transformed planes.

### DIFF
--- a/src/BulletCollision/Gimpact/btGImpactCollisionAlgorithm.cpp
+++ b/src/BulletCollision/Gimpact/btGImpactCollisionAlgorithm.cpp
@@ -53,10 +53,11 @@ public:
 
 	void get_plane_equation_transformed(const btTransform & trans,btVector4 &equation) const 
 	{
-		equation[0] = trans.getBasis().getRow(0).dot(m_planeNormal);
-		equation[1] = trans.getBasis().getRow(1).dot(m_planeNormal);
-		equation[2] = trans.getBasis().getRow(2).dot(m_planeNormal);
-		equation[3] = trans.getOrigin().dot(m_planeNormal) + m_planeConstant;
+                const btVector3 normal = trans.getBasis() * m_planeNormal;
+                equation[0] = normal[0];
+                equation[1] = normal[1];
+                equation[2] = normal[2];
+                equation[3] = normal.dot(trans * (m_planeConstant * m_planeNormal));
 	}
 };
 


### PR DESCRIPTION
This corrects the computation of the plane constant for transformed plane shapes.
