### PR TITLE
Threading for Bullet2 using OpenMP, TBB, or PPL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ SET(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -D_DEBUG")
 OPTION(USE_DOUBLE_PRECISION "Use double precision"	OFF)
 OPTION(USE_GRAPHICAL_BENCHMARK "Use Graphical Benchmark" ON)
 OPTION(BUILD_SHARED_LIBS "Use shared libraries" OFF)
+OPTION(BULLET2_USE_THREAD_LOCKS "Build Bullet 2 libraries with mutex locking around certain operations" OFF)
 
 OPTION(USE_MSVC_INCREMENTAL_LINKING "Use MSVC Incremental Linking" OFF)
 OPTION(USE_CUSTOM_VECTOR_MATH "Use custom vectormath library" OFF)
@@ -144,6 +145,10 @@ IF(USE_GRAPHICAL_BENCHMARK)
 ADD_DEFINITIONS( -DUSE_GRAPHICAL_BENCHMARK)
 ENDIF (USE_GRAPHICAL_BENCHMARK)
 
+IF(BULLET2_USE_THREAD_LOCKS)
+ADD_DEFINITIONS( -DBT_THREADSAFE=1 )
+ENDIF (BULLET2_USE_THREAD_LOCKS)
+
 IF (WIN32)
 OPTION(USE_GLUT "Use Glut"	ON)
 ADD_DEFINITIONS( -D_CRT_SECURE_NO_WARNINGS )
@@ -184,8 +189,6 @@ ENDIF (OPENGL_FOUND)
 #FIND_PACKAGE(GLU)
 
 
-
-
 IF (APPLE)
   FIND_LIBRARY(COCOA_LIBRARY Cocoa)
 ENDIF()
@@ -224,6 +227,15 @@ IF(BUILD_BULLET2_DEMOS)
         IF(EXISTS ${BULLET_PHYSICS_SOURCE_DIR}/examples AND IS_DIRECTORY ${BULLET_PHYSICS_SOURCE_DIR}/examples)
                 SUBDIRS(examples)
         ENDIF()
+
+        IF (BULLET2_USE_THREAD_LOCKS)
+            OPTION(BULLET2_MULTITHREADED_OPEN_MP_DEMO "Build Bullet 2 MultithreadedDemo using OpenMP (requires a compiler with OpenMP support)" OFF)
+            OPTION(BULLET2_MULTITHREADED_TBB_DEMO "Build Bullet 2 MultithreadedDemo using Intel Threading Building Blocks (requires the TBB library to be already installed)" OFF)
+            IF (MSVC)
+                OPTION(BULLET2_MULTITHREADED_PPL_DEMO "Build Bullet 2 MultithreadedDemo using Microsoft Parallel Patterns Library (requires MSVC compiler)" OFF)
+            ENDIF (MSVC)
+        ENDIF (BULLET2_USE_THREAD_LOCKS)
+
 ENDIF(BUILD_BULLET2_DEMOS)
 
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,1 +1,2 @@
 SUBDIRS( ExampleBrowser HelloWorld BasicDemo ThirdPartyLibs/Gwen OpenGLWindow)
+

--- a/examples/ExampleBrowser/CMakeLists.txt
+++ b/examples/ExampleBrowser/CMakeLists.txt
@@ -19,6 +19,9 @@ SET(App_ExampleBrowser_SRCS
 	../BasicDemo/BasicExample.h
 	../ForkLift/ForkLiftDemo.cpp
 	../ForkLift/ForkLiftDemo.h
+	../MultiThreadedDemo/MultiThreadedDemo.cpp
+	../MultiThreadedDemo/MultiThreadedDemo.h
+    ../MultiThreadedDemo/ParallelFor.h
 	../GyroscopicDemo/GyroscopicSetup.cpp
 	../GyroscopicDemo/GyroscopicSetup.h
 	../Planar2D/Planar2D.cpp
@@ -135,6 +138,31 @@ SET(App_ExampleBrowser_SRCS
 	${BULLET_PHYSICS_SOURCE_DIR}/build3/bullet.rc
 )
 
+IF (BULLET2_MULTITHREADED_OPEN_MP_DEMO)
+    ADD_DEFINITIONS("-DBT_USE_OPENMP=1")
+    IF (MSVC)
+        ADD_DEFINITIONS("/openmp")
+    ELSE (MSVC)
+        # GCC, Clang
+        ADD_DEFINITIONS("-fopenmp")
+    ENDIF (MSVC)
+ENDIF (BULLET2_MULTITHREADED_OPEN_MP_DEMO)
+
+IF (BULLET2_MULTITHREADED_PPL_DEMO)
+    ADD_DEFINITIONS("-DBT_USE_PPL=1")
+ENDIF (BULLET2_MULTITHREADED_PPL_DEMO)
+
+IF (BULLET2_MULTITHREADED_TBB_DEMO)
+    SET (BULLET2_TBB_INCLUDE_DIR "not found" CACHE PATH "Directory for Intel TBB includes.")
+    SET (BULLET2_TBB_LIB_DIR "not found" CACHE PATH "Directory for Intel TBB libraries.")
+    find_library(TBB_LIBRARY tbb PATHS ${BULLET2_TBB_LIB_DIR})
+    find_library(TBBMALLOC_LIBRARY tbbmalloc PATHS ${BULLET2_TBB_LIB_DIR})
+    ADD_DEFINITIONS("-DBT_USE_TBB=1")
+    INCLUDE_DIRECTORIES( ${BULLET2_TBB_INCLUDE_DIR} )
+    LINK_LIBRARIES( ${TBB_LIBRARY} ${TBBMALLOC_LIBRARY} )
+ENDIF (BULLET2_MULTITHREADED_TBB_DEMO)
+
+
 LINK_LIBRARIES(
         Bullet3Common BulletSoftBody BulletDynamics BulletCollision LinearMath OpenGLWindow gwen ${OPENGL_gl_LIBRARY} ${OPENGL_glu_LIBRARY}
 )
@@ -174,3 +202,19 @@ IF (INTERNAL_ADD_POSTFIX_EXECUTABLE_NAMES)
 			SET_TARGET_PROPERTIES(App_ExampleBrowser PROPERTIES  MINSIZEREL_POSTFIX "_MinsizeRel")
 			SET_TARGET_PROPERTIES(App_ExampleBrowser PROPERTIES  RELWITHDEBINFO_POSTFIX "_RelWithDebugInfo")
 ENDIF(INTERNAL_ADD_POSTFIX_EXECUTABLE_NAMES)
+
+IF (BULLET2_MULTITHREADED_TBB_DEMO AND WIN32)
+    # add a post build command to copy some dlls to the executable directory
+    set(TBB_VC_VER "vc12")
+    set(TBB_VC_ARCH "ia32")
+    # assume 32-bit build in VC12 for now
+    # checks can be added here at a later time
+    ADD_CUSTOM_COMMAND(TARGET App_ExampleBrowser POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        "${BULLET2_TBB_INCLUDE_DIR}/../bin/${TBB_VC_ARCH}/${TBB_VC_VER}/tbb.dll"
+        $<TARGET_FILE_DIR:App_ExampleBrowser>)
+    ADD_CUSTOM_COMMAND(TARGET App_ExampleBrowser POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        "${BULLET2_TBB_INCLUDE_DIR}/../bin/${TBB_VC_ARCH}/${TBB_VC_VER}/tbbmalloc.dll"
+        $<TARGET_FILE_DIR:App_ExampleBrowser>)
+ENDIF (BULLET2_MULTITHREADED_TBB_DEMO AND WIN32)

--- a/examples/ExampleBrowser/ExampleEntries.cpp
+++ b/examples/ExampleBrowser/ExampleEntries.cpp
@@ -8,6 +8,7 @@
 #include "../RenderingExamples/CoordinateSystemDemo.h"
 #include "../RenderingExamples/RaytracerSetup.h"
 #include "../ForkLift/ForkLiftDemo.h"
+#include "../MultiThreadedDemo/MultiThreadedDemo.h"
 #include "../BasicDemo/BasicExample.h"
 #include "../Planar2D/Planar2D.h"
 #include "../Benchmarks/BenchmarkDemo.h"
@@ -181,7 +182,18 @@ static ExampleEntry gDefaultExamples[]=
 	ExampleEntry(1,"Fracture demo", "Create a basic custom implementation to model fracturing objects, based on a btCompoundShape. It explicitly propagates the collision impulses and breaks the rigid body into multiple rigid bodies. Press F to toggle fracture and glue mode.", FractureDemoCreateFunc),
 				 
 	ExampleEntry(1,"Planar 2D","Show the use of 2D collision shapes and rigid body simulation. The collision shape is wrapped into a btConvex2dShape. The rigid bodies are restricted in a plane using the 'setAngularFactor' and 'setLinearFactor' API call.",Planar2DCreateFunc),
-
+#if BT_USE_OPENMP || BT_USE_TBB || BT_USE_PPL
+    // only enable MultiThreaded demo if a task scheduler is available
+    ExampleEntry( 1, "Multithreaded Demo",
+    "Multithreaded demo using OpenMP, Intel Threading Building Blocks (TBB), or Microsoft Parallel Patterns Library (PPL). "
+    "Press o to use OpenMP. "
+    "Press t to use TBB. "
+    "Press p to use PPL. "
+    "Press n for single-threaded. "
+    "Press + or - to change thread count. "
+    ,
+    MultiThreadedDemoCreateFunc ),
+#endif
 
 
 	ExampleEntry(0,"Rendering"),

--- a/examples/MultiThreadedDemo/MultiThreadedDemo.cpp
+++ b/examples/MultiThreadedDemo/MultiThreadedDemo.cpp
@@ -93,7 +93,7 @@ public:
         int pairCount = pairCache->getNumOverlappingPairs();
         Updater updater;
         updater.mCallback = getNearCallback();
-        updater.mPairArray = pairCache->getOverlappingPairArrayPtr();
+        updater.mPairArray = pairCount > 0 ? pairCache->getOverlappingPairArrayPtr() : NULL;
         updater.mDispatcher = this;
         updater.mInfo = &info;
 

--- a/examples/MultiThreadedDemo/MultiThreadedDemo.cpp
+++ b/examples/MultiThreadedDemo/MultiThreadedDemo.cpp
@@ -65,11 +65,18 @@ public:
 
     struct Updater
     {
-        btBroadphasePair* mPairArray = NULL;
-        btNearCallback mCallback = NULL;
-        btCollisionDispatcher* mDispatcher = NULL;
-        const btDispatcherInfo* mInfo = NULL;
+        btBroadphasePair* mPairArray;
+        btNearCallback mCallback;
+        btCollisionDispatcher* mDispatcher;
+        const btDispatcherInfo* mInfo;
 
+        Updater()
+        {
+            mPairArray = NULL;
+            mCallback = NULL;
+            mDispatcher = NULL;
+            mInfo = NULL;
+        }
         void forLoop( int iBegin, int iEnd ) const
         {
             for ( int i = iBegin; i < iEnd; ++i )

--- a/examples/MultiThreadedDemo/MultiThreadedDemo.cpp
+++ b/examples/MultiThreadedDemo/MultiThreadedDemo.cpp
@@ -65,10 +65,10 @@ public:
 
     struct Updater
     {
-        btBroadphasePair* mPairArray = nullptr;
-        btNearCallback mCallback = nullptr;
-        btCollisionDispatcher* mDispatcher = nullptr;
-        const btDispatcherInfo* mInfo = nullptr;
+        btBroadphasePair* mPairArray = NULL;
+        btNearCallback mCallback = NULL;
+        btCollisionDispatcher* mDispatcher = NULL;
+        const btDispatcherInfo* mInfo = NULL;
 
         void forLoop( int iBegin, int iEnd ) const
         {
@@ -298,7 +298,7 @@ protected:
         int bodyCount = m_nonStaticRigidBodies.size();
         UpdaterUnconstrainedMotion update;
         update.timeStep = timeStep;
-        update.rigidBodies = bodyCount ? &m_nonStaticRigidBodies[ 0 ] : nullptr;
+        update.rigidBodies = bodyCount ? &m_nonStaticRigidBodies[ 0 ] : NULL;
         btPushThreadsAreRunning();
         parallelFor( 0, bodyCount, grainSize, update );
         btPopThreadsAreRunning();

--- a/examples/MultiThreadedDemo/MultiThreadedDemo.cpp
+++ b/examples/MultiThreadedDemo/MultiThreadedDemo.cpp
@@ -1,0 +1,838 @@
+/*
+Bullet Continuous Collision Detection and Physics Library
+Copyright (c) 2003-2006 Erwin Coumans  http://continuousphysics.com/Bullet/
+
+This software is provided 'as-is', without any express or implied warranty.
+In no event will the authors be held liable for any damages arising from the use of this software.
+Permission is granted to anyone to use this software for any purpose, 
+including commercial applications, and to alter it and redistribute it freely, 
+subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software. If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
+2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
+3. This notice may not be removed or altered from any source distribution.
+*/
+
+#include "btBulletDynamicsCommon.h"
+#include "LinearMath/btQuickprof.h"
+#include "LinearMath/btIDebugDraw.h"
+
+#include <stdio.h> //printf debugging
+#include <algorithm>
+
+class btCollisionShape;
+
+#include "../CommonInterfaces/CommonExampleInterface.h"
+#include "LinearMath/btAlignedObjectArray.h"
+#include "btBulletCollisionCommon.h"
+#include "BulletCollision/CollisionDispatch/btSimulationIslandManager.h"  // for setSplitIslands()
+#include "../CommonInterfaces/CommonGUIHelperInterface.h"
+#include "../CommonInterfaces/CommonRenderInterface.h"
+#include "../CommonInterfaces/CommonWindowInterface.h"
+#include "../CommonInterfaces/CommonGraphicsAppInterface.h"
+#include "MultiThreadedDemo.h"
+
+#include "ParallelFor.h"
+
+
+#define USE_PARALLEL_NARROWPHASE 1  // detect collisions in parallel
+#define USE_PARALLEL_ISLAND_SOLVER 1   // solve simulation islands in parallel
+#define USE_PARALLEL_CREATE_PREDICTIVE_CONTACTS 1
+#define USE_PARALLEL_INTEGRATE_TRANSFORMS 1
+#define USE_PARALLEL_PREDICT_UNCONSTRAINED_MOTION 1
+
+#if defined (_MSC_VER) && _MSC_VER >= 1600
+// give us a compile error if any signatures of overriden methods is changed
+#define BT_OVERRIDE override
+#else
+#define BT_OVERRIDE
+#endif
+
+
+
+#if USE_PARALLEL_NARROWPHASE
+
+class MyCollisionDispatcher : public btCollisionDispatcher
+{
+public:
+    MyCollisionDispatcher( btCollisionConfiguration* config ) : btCollisionDispatcher( config )
+    {
+    }
+
+    virtual ~MyCollisionDispatcher()
+    {
+    }
+
+    struct Updater
+    {
+        btBroadphasePair* mPairArray = nullptr;
+        btNearCallback mCallback = nullptr;
+        btCollisionDispatcher* mDispatcher = nullptr;
+        const btDispatcherInfo* mInfo = nullptr;
+
+        void forLoop( int iBegin, int iEnd ) const
+        {
+            for ( int i = iBegin; i < iEnd; ++i )
+            {
+                btBroadphasePair* pair = &mPairArray[ i ];
+                mCallback( *pair, *mDispatcher, *mInfo );
+            }
+        }
+    };
+
+    virtual void dispatchAllCollisionPairs( btOverlappingPairCache* pairCache, const btDispatcherInfo& info, btDispatcher* dispatcher ) BT_OVERRIDE
+    {
+        int grainSize = 40;  // iterations per task
+        int pairCount = pairCache->getNumOverlappingPairs();
+        Updater updater;
+        updater.mCallback = getNearCallback();
+        updater.mPairArray = pairCache->getOverlappingPairArrayPtr();
+        updater.mDispatcher = this;
+        updater.mInfo = &info;
+
+        btPushThreadsAreRunning();
+        parallelFor( 0, pairCount, grainSize, updater );
+        btPopThreadsAreRunning();
+    }
+};
+
+#endif
+
+
+#if USE_PARALLEL_ISLAND_SOLVER
+///
+/// MyConstraintSolverPool - masquerades as a constraint solver, but really it is a threadsafe pool of them.
+///
+///  Each solver in the pool is protected by a mutex.  When solveGroup is called from a thread,
+///  the pool looks for a solver that isn't being used by another thread, locks it, and dispatches the
+///  call to the solver.
+///  So long as there are at least as many solvers as there are hardware threads, it should never need to
+///  spin wait.
+///
+class MyConstraintSolverPool : public btConstraintSolver
+{
+    const static size_t kCacheLineSize = 128;
+    struct ThreadSolver
+    {
+        btConstraintSolver* solver;
+        btMutex mutex;
+        char _cachelinePadding[ kCacheLineSize - sizeof( btMutex ) - sizeof( void* ) ];  // keep mutexes from sharing a cache line
+    };
+    btAlignedObjectArray<ThreadSolver> m_solvers;
+    btConstraintSolverType m_solverType;
+
+    ThreadSolver* getAndLockThreadSolver()
+    {
+        while ( true )
+        {
+            for ( int i = 0; i < m_solvers.size(); ++i )
+            {
+                ThreadSolver& solver = m_solvers[ i ];
+                if ( btMutexTryLock( &solver.mutex ) )
+                {
+                    return &solver;
+                }
+            }
+        }
+        return NULL;
+    }
+    void init( btConstraintSolver** solvers, int numSolvers )
+    {
+        m_solverType = BT_SEQUENTIAL_IMPULSE_SOLVER;
+        m_solvers.resize( numSolvers );
+        for ( int i = 0; i < numSolvers; ++i )
+        {
+            m_solvers[ i ].solver = solvers[ i ];
+        }
+        if ( numSolvers > 0 )
+        {
+            m_solverType = solvers[ 0 ]->getSolverType();
+        }
+    }
+public:
+    // create the solvers for me
+    explicit MyConstraintSolverPool( int numSolvers )
+    {
+        btAlignedObjectArray<btConstraintSolver*> solvers;
+        solvers.reserve( numSolvers );
+        for ( int i = 0; i < numSolvers; ++i )
+        {
+            btConstraintSolver* solver = new btSequentialImpulseConstraintSolver();
+            solvers.push_back( solver );
+        }
+        init( &solvers[ 0 ], numSolvers );
+    }
+
+    // pass in fully constructed solvers (destructor will delete them)
+    MyConstraintSolverPool( btConstraintSolver** solvers, int numSolvers )
+    {
+        init( solvers, numSolvers );
+    }
+    virtual ~MyConstraintSolverPool()
+    {
+        // delete all solvers
+        for ( int i = 0; i < m_solvers.size(); ++i )
+        {
+            ThreadSolver& solver = m_solvers[ i ];
+            delete solver.solver;
+            solver.solver = NULL;
+        }
+    }
+
+    //virtual void prepareSolve( int /* numBodies */, int /* numManifolds */ ) { ; } // does nothing
+
+    ///solve a group of constraints
+    virtual btScalar solveGroup( btCollisionObject** bodies,
+                                 int numBodies,
+                                 btPersistentManifold** manifolds,
+                                 int numManifolds,
+                                 btTypedConstraint** constraints,
+                                 int numConstraints,
+                                 const btContactSolverInfo& info,
+                                 btIDebugDraw* debugDrawer,
+                                 btDispatcher* dispatcher
+                                 )
+    {
+        ThreadSolver* solver = getAndLockThreadSolver();
+        solver->solver->solveGroup( bodies, numBodies, manifolds, numManifolds, constraints, numConstraints, info, debugDrawer, dispatcher );
+        btMutexUnlock( &solver->mutex );
+        return 0.0f;
+    }
+
+    //virtual void allSolved( const btContactSolverInfo& /* info */, class btIDebugDraw* /* debugDrawer */ ) { ; } // does nothing
+
+    ///clear internal cached data and reset random seed
+    virtual	void reset()
+    {
+        for ( int i = 0; i < m_solvers.size(); ++i )
+        {
+            ThreadSolver& solver = m_solvers[ i ];
+            btMutexLock( &solver.mutex );
+            solver.solver->reset();
+            btMutexUnlock( &solver.mutex );
+        }
+    }
+
+    virtual btConstraintSolverType getSolverType() const
+    {
+        return m_solverType;
+    }
+};
+
+struct UpdateIslandDispatcher
+{
+    btAlignedObjectArray<btSimulationIslandManager::Island*>* islandsPtr;
+    btSimulationIslandManager::IslandCallback* callback;
+
+    void forLoop( int iBegin, int iEnd ) const
+    {
+        for ( int i = iBegin; i < iEnd; ++i )
+        {
+            btSimulationIslandManager::Island* island = ( *islandsPtr )[ i ];
+            btPersistentManifold** manifolds = island->manifoldArray.size() ? &island->manifoldArray[ 0 ] : NULL;
+            btTypedConstraint** constraintsPtr = island->constraintArray.size() ? &island->constraintArray[ 0 ] : NULL;
+            callback->processIsland( &island->bodyArray[ 0 ],
+                                     island->bodyArray.size(),
+                                     manifolds,
+                                     island->manifoldArray.size(),
+                                     constraintsPtr,
+                                     island->constraintArray.size(),
+                                     island->id
+                                     );
+        }
+    }
+};
+
+void parallelIslandDispatch( btAlignedObjectArray<btSimulationIslandManager::Island*>* islandsPtr, btSimulationIslandManager::IslandCallback* callback )
+{
+    int grainSize = 1;  // iterations per task
+    UpdateIslandDispatcher dispatcher;
+    dispatcher.islandsPtr = islandsPtr;
+    dispatcher.callback = callback;
+    btPushThreadsAreRunning();
+    parallelFor( 0, islandsPtr->size(), grainSize, dispatcher );
+    btPopThreadsAreRunning();
+}
+#endif //#if USE_PARALLEL_ISLAND_SOLVER
+
+
+///
+/// MyDiscreteDynamicsWorld
+///
+///  Should function exactly like btDiscreteDynamicsWorld.
+///  3 methods that iterate over all of the rigidbodies can run in parallel:
+///     - predictUnconstraintMotion
+///     - integrateTransforms
+///     - createPredictiveContacts
+///
+ATTRIBUTE_ALIGNED16( class ) MyDiscreteDynamicsWorld : public btDiscreteDynamicsWorld
+{
+    typedef btDiscreteDynamicsWorld ParentClass;
+
+protected:
+#if USE_PARALLEL_PREDICT_UNCONSTRAINED_MOTION
+    struct UpdaterUnconstrainedMotion
+    {
+        btScalar timeStep;
+        btRigidBody** rigidBodies;
+
+        void forLoop( int iBegin, int iEnd ) const
+        {
+            for ( int i = iBegin; i < iEnd; ++i )
+            {
+                btRigidBody* body = rigidBodies[ i ];
+                if ( !body->isStaticOrKinematicObject() )
+                {
+                    //don't integrate/update velocities here, it happens in the constraint solver
+                    body->applyDamping( timeStep );
+                    body->predictIntegratedTransform( timeStep, body->getInterpolationWorldTransform() );
+                }
+            }
+        }
+    };
+
+    virtual void predictUnconstraintMotion( btScalar timeStep ) BT_OVERRIDE
+    {
+        BT_PROFILE( "predictUnconstraintMotion" );
+        int grainSize = 50;  // num of iterations per task for TBB
+        int bodyCount = m_nonStaticRigidBodies.size();
+        UpdaterUnconstrainedMotion update;
+        update.timeStep = timeStep;
+        update.rigidBodies = bodyCount ? &m_nonStaticRigidBodies[ 0 ] : nullptr;
+        btPushThreadsAreRunning();
+        parallelFor( 0, bodyCount, grainSize, update );
+        btPopThreadsAreRunning();
+    }
+#endif // #if USE_PARALLEL_PREDICT_UNCONSTRAINED_MOTION
+
+#if USE_PARALLEL_CREATE_PREDICTIVE_CONTACTS
+    struct UpdaterCreatePredictiveContacts
+    {
+        btScalar timeStep;
+        btRigidBody** rigidBodies;
+        MyDiscreteDynamicsWorld* world;
+
+        void forLoop( int iBegin, int iEnd ) const
+        {
+            world->createPredictiveContactsInternal( &rigidBodies[ iBegin ], iEnd - iBegin, timeStep );
+        }
+    };
+
+    virtual void createPredictiveContacts( btScalar timeStep )
+    {
+        int grainSize = 50;  // num of iterations per task for TBB or OPENMP
+        if ( int bodyCount = m_nonStaticRigidBodies.size() )
+        {
+            UpdaterCreatePredictiveContacts update;
+            update.world = this;
+            update.timeStep = timeStep;
+            update.rigidBodies = &m_nonStaticRigidBodies[ 0 ];
+            btPushThreadsAreRunning();
+            parallelFor( 0, bodyCount, grainSize, update );
+            btPopThreadsAreRunning();
+        }
+    }
+#endif // #if USE_PARALLEL_CREATE_PREDICTIVE_CONTACTS
+
+#if USE_PARALLEL_INTEGRATE_TRANSFORMS
+    struct UpdaterIntegrateTransforms
+    {
+        btScalar timeStep;
+        btRigidBody** rigidBodies;
+        const MyDiscreteDynamicsWorld* world;
+
+        void forLoop( int iBegin, int iEnd ) const
+        {
+            world->integrateTransformsInternal( &rigidBodies[ iBegin ], iEnd - iBegin, timeStep );
+        }
+    };
+
+    virtual void integrateTransforms( btScalar timeStep ) BT_OVERRIDE
+    {
+        BT_PROFILE( "integrateTransforms" );
+        int grainSize = 50;  // num of iterations per task for TBB or OPENMP
+        if ( int bodyCount = m_nonStaticRigidBodies.size() )
+        {
+            UpdaterIntegrateTransforms update;
+            update.world = this;
+            update.timeStep = timeStep;
+            update.rigidBodies = &m_nonStaticRigidBodies[ 0 ];
+            btPushThreadsAreRunning();
+            parallelFor( 0, bodyCount, grainSize, update );
+            btPopThreadsAreRunning();
+        }
+    }
+#endif // #if USE_PARALLEL_INTEGRATE_TRANSFORMS
+
+public:
+    BT_DECLARE_ALIGNED_ALLOCATOR();
+
+    MyDiscreteDynamicsWorld( btDispatcher* dispatcher,
+                             btBroadphaseInterface* pairCache,
+                             btConstraintSolver* constraintSolver,
+                             btCollisionConfiguration* collisionConfiguration
+                             ) :
+                             btDiscreteDynamicsWorld( dispatcher, pairCache, constraintSolver, collisionConfiguration )
+    {
+    }
+
+};
+
+/// MultiThreadedDemo shows how to setup and use multithreading
+class MultiThreadedDemo  : public CommonExampleInterface
+{
+    static const int kUpAxis = 1;
+
+    btDiscreteDynamicsWorld* m_dynamicsWorld;
+    btBroadphaseInterface*	m_broadphase;
+    btCollisionDispatcher*	m_dispatcher;
+    btConstraintSolver*	m_solver;
+    btDefaultCollisionConfiguration* m_collisionConfiguration;
+    //keep the collision shapes, for deletion/cleanup
+    btAlignedObjectArray<btCollisionShape*>	m_collisionShapes;
+
+    int m_numThreads;
+
+	btDiscreteDynamicsWorld* getDynamicsWorld()
+	{
+		return m_dynamicsWorld;
+	}
+	btRigidBody* localCreateRigidBody(btScalar mass, const btTransform& worldTransform, btCollisionShape* colSape);
+
+	GUIHelperInterface* m_guiHelper;
+
+	btVector3	m_loadStartPos;
+
+    btVector3 m_cameraTargetPos;
+    float m_cameraPitch;
+    float m_cameraYaw;
+    float m_cameraDist;
+
+    void createStack( const btVector3& pos, btCollisionShape* boxShape, const btVector3& halfBoxSize, int size );
+    void createSceneObjects();
+    void destroySceneObjects();
+    void displayProfileString( const btVector3& pos, const char* msg );
+
+public:
+    BT_DECLARE_ALIGNED_ALLOCATOR();
+
+    MultiThreadedDemo( struct GUIHelperInterface* helper );
+
+	virtual ~MultiThreadedDemo();
+
+	virtual void stepSimulation(float deltaTime) BT_OVERRIDE;
+	virtual bool mouseMoveCallback(float x,float y) BT_OVERRIDE
+	{
+		return false;
+	}
+
+    virtual bool mouseButtonCallback( int button, int state, float x, float y ) BT_OVERRIDE
+	{
+		return false;
+	}
+
+    virtual bool keyboardCallback( int key, int state ) BT_OVERRIDE;
+    virtual void renderScene() BT_OVERRIDE;
+    virtual void physicsDebugDraw( int debugFlags ) BT_OVERRIDE;
+
+    virtual void initPhysics() BT_OVERRIDE;
+    virtual void exitPhysics() BT_OVERRIDE;
+
+    virtual void resetCamera() BT_OVERRIDE
+	{
+        m_guiHelper->resetCamera( m_cameraDist,
+                                  m_cameraPitch,
+                                  m_cameraYaw,
+                                  m_cameraTargetPos.x(),
+                                  m_cameraTargetPos.y(),
+                                  m_cameraTargetPos.z()
+                                  );
+	}
+
+};
+
+
+////////////////////////////////////
+
+
+MultiThreadedDemo::MultiThreadedDemo(struct GUIHelperInterface* helper)
+{
+    m_dynamicsWorld = NULL;
+    m_broadphase = NULL;
+    m_dispatcher = NULL;
+    m_solver = NULL;
+    m_collisionConfiguration = NULL;
+    m_guiHelper = helper;
+    m_numThreads = 1;
+    m_cameraTargetPos = btVector3( 0.0f, 0.0f, 0.0f );
+    m_cameraPitch = 90.0f;
+    m_cameraYaw = 30.0f;
+    m_cameraDist = 48.0f;
+    helper->setUpAxis( kUpAxis );
+    initTaskScheduler();
+    m_numThreads = setNumThreads( getMaxNumThreads() );
+}
+
+
+MultiThreadedDemo::~MultiThreadedDemo()
+{
+    cleanupTaskScheduler();
+}
+
+
+void MultiThreadedDemo::exitPhysics()
+{
+    destroySceneObjects();
+
+    //delete dynamics world
+    delete m_dynamicsWorld;
+
+    //delete solver
+    delete m_solver;
+
+    //delete broadphase
+    delete m_broadphase;
+
+    //delete dispatcher
+    delete m_dispatcher;
+
+    delete m_collisionConfiguration;
+}
+
+void MultiThreadedDemo::initPhysics()
+{
+    m_dispatcher = NULL;
+    btDefaultCollisionConstructionInfo cci;
+    // it isn't threadsafe to resize these pools while threads are using them
+    cci.m_defaultMaxPersistentManifoldPoolSize = 32768;
+    cci.m_defaultMaxCollisionAlgorithmPoolSize = 32768;
+    m_collisionConfiguration = new btDefaultCollisionConfiguration( cci );
+
+#if USE_PARALLEL_NARROWPHASE
+    m_dispatcher = new	MyCollisionDispatcher( m_collisionConfiguration );
+#else
+    m_dispatcher = new	btCollisionDispatcher( m_collisionConfiguration );
+#endif //USE_PARALLEL_NARROWPHASE
+
+    if ( false )
+    {
+        const int maxProxies = 32766;
+
+        btVector3 worldAabbMin( -1000, -1000, -1000 );
+        btVector3 worldAabbMax( 1000, 1000, 1000 );
+
+        m_broadphase = new btAxisSweep3( worldAabbMin, worldAabbMax, maxProxies );
+    }
+    else
+    {
+        m_broadphase = new btDbvtBroadphase();
+    }
+
+    // this solver requires the contacts to be in a contiguous pool, so avoid dynamic allocation
+    // (this may no longer be an issue, not sure)
+    m_dispatcher->setDispatcherFlags( btCollisionDispatcher::CD_DISABLE_CONTACTPOOL_DYNAMIC_ALLOCATION );
+
+#if USE_PARALLEL_ISLAND_SOLVER
+    m_solver = new MyConstraintSolverPool( m_numThreads );
+#else
+    m_solver = new btSequentialImpulseConstraintSolver();
+#endif //#if USE_PARALLEL_ISLAND_SOLVER
+    btDiscreteDynamicsWorld* world = new MyDiscreteDynamicsWorld( m_dispatcher, m_broadphase, m_solver, m_collisionConfiguration );
+    m_dynamicsWorld = world;
+
+#if USE_PARALLEL_ISLAND_SOLVER
+    world->getSimulationIslandManager()->setIslandDispatchFunction( parallelIslandDispatch );
+    //world->getSolverInfo().m_numIterations = 4;
+    //default solverMode is SOLVER_RANDMIZE_ORDER. Warmstarting seems not to improve convergence, see 
+    //solver->setSolverMode(0);//btSequentialImpulseConstraintSolver::SOLVER_USE_WARMSTARTING | btSequentialImpulseConstraintSolver::SOLVER_RANDMIZE_ORDER);
+    //world->getSolverInfo().m_solverMode = SOLVER_SIMD + SOLVER_USE_WARMSTARTING;//+SOLVER_RANDMIZE_ORDER;
+#endif //#if USE_PARALLEL_ISLAND_SOLVER
+
+    m_dynamicsWorld->setGravity( btVector3( 0, -10, 0 ) );
+	
+    createSceneObjects();
+
+    m_guiHelper->createPhysicsDebugDrawer( m_dynamicsWorld );
+}
+
+void MultiThreadedDemo::physicsDebugDraw(int debugFlags)
+{
+	if (m_dynamicsWorld && m_dynamicsWorld->getDebugDrawer())
+	{
+		m_dynamicsWorld->getDebugDrawer()->setDebugMode(debugFlags);
+		m_dynamicsWorld->debugDrawWorld();
+	}
+    btVector3 pos( -10.0f, 30.50f, -10.0f );
+    btVector3 posStep( 0.0f, -1.0f, 0.0f );
+    char msg[ 128 ];
+    {
+        int numManifolds = m_dispatcher->getNumManifolds();
+        int numContacts = 0;
+        for ( int i = 0; i < numManifolds; ++i )
+        {
+            const btPersistentManifold* man = m_dispatcher->getManifoldByIndexInternal( i );
+            numContacts += man->getNumContacts();
+        }
+        const char* mtApi = getTaskApiName( gTaskApi );
+        sprintf( msg, "bodies %d manifolds %d contacts %d [%s] threads %d",
+                 m_dynamicsWorld->getNumCollisionObjects(),
+                 numManifolds,
+                 numContacts,
+                 mtApi,
+                 gTaskApi != apiNone ? m_numThreads : 1
+                 );
+        displayProfileString( pos, msg );
+        pos += posStep;
+    }
+}
+
+void MultiThreadedDemo::displayProfileString( const btVector3& pos, const char* msg )
+{
+    // This is kind of a hack.
+    // 2D text would be preferable, but the current 2D text is far too large to be useable
+    btVector3 wp = pos;
+    m_guiHelper->drawText3D( msg, wp.x(), wp.y(), wp.z(), 1.0f );
+}
+
+//to be implemented by the demo
+void MultiThreadedDemo::renderScene()
+{
+	m_guiHelper->syncPhysicsToGraphics(m_dynamicsWorld);
+	m_guiHelper->render(m_dynamicsWorld);
+}
+
+void MultiThreadedDemo::stepSimulation(float deltaTime)
+{
+	float dt = deltaTime;
+	if (m_dynamicsWorld)
+	{
+        m_dynamicsWorld->stepSimulation(1.0f/60.0f, 0);
+	}
+}
+
+
+bool MultiThreadedDemo::keyboardCallback(int key, int state)
+{
+    bool handled = false;
+    if ( state )
+    {
+        if ( key == 'n' )
+        {
+            // 'n' single-threading
+            setTaskApi( apiNone );
+            handled = true;
+        }
+        if ( key == 'o' )
+        {
+            // 'o' use OpenMP
+            setTaskApi( apiOpenMP );
+            handled = true;
+        }
+        if ( key == 'p' )
+        {
+            // 'p' use PPL
+            setTaskApi( apiPpl );
+            handled = true;
+        }
+        if ( key == 't' )
+        {
+            // 't' use TBB
+            setTaskApi( apiTbb );
+            handled = true;
+        }
+        if ( gTaskApi != apiNone )
+        {
+            if ( key == '+' )
+            {
+                m_numThreads = setNumThreads( m_numThreads + 1 );
+                handled = true;
+            }
+            if ( key == '-' )
+            {
+                m_numThreads = setNumThreads( (std::max)( 1, m_numThreads - 1 ) );
+                handled = true;
+            }
+        }
+    }
+
+    return handled;
+}
+
+
+btRigidBody* MultiThreadedDemo::localCreateRigidBody(btScalar mass, const btTransform& startTransform, btCollisionShape* shape)
+{
+	btAssert((!shape || shape->getShapeType() != INVALID_SHAPE_PROXYTYPE));
+
+	//rigidbody is dynamic if and only if mass is non zero, otherwise static
+	bool isDynamic = (mass != 0.f);
+
+	btVector3 localInertia(0,0,0);
+    if ( isDynamic )
+    {
+        shape->calculateLocalInertia( mass, localInertia );
+    }
+
+	//using motionstate is recommended, it provides interpolation capabilities, and only synchronizes 'active' objects
+
+#define USE_MOTIONSTATE 1
+#ifdef USE_MOTIONSTATE
+	btDefaultMotionState* myMotionState = new btDefaultMotionState(startTransform);
+
+	btRigidBody::btRigidBodyConstructionInfo cInfo(mass,myMotionState,shape,localInertia);
+
+	btRigidBody* body = new btRigidBody(cInfo);
+	//body->setContactProcessingThreshold(m_defaultContactProcessingThreshold);
+
+#else
+	btRigidBody* body = new btRigidBody(mass,0,shape,localInertia);
+	body->setWorldTransform(startTransform);
+#endif//
+
+    if ( isDynamic )
+    {
+        body->forceActivationState( DISABLE_DEACTIVATION );
+    }
+	m_dynamicsWorld->addRigidBody(body);
+	return body;
+}
+
+void MultiThreadedDemo::createStack( const btVector3& center, btCollisionShape* boxShape, const btVector3& halfBoxSize, int size )
+{
+    btTransform trans;
+    trans.setIdentity();
+    float halfBoxHeight = halfBoxSize.y();
+    float halfBoxWidth = halfBoxSize.x();
+
+    for ( int i = 0; i<size; i++ )
+    {
+        // This constructs a row, from left to right
+        int rowSize = size - i;
+        for ( int j = 0; j< rowSize; j++ )
+        {
+            btVector3 pos = center + btVector3( halfBoxWidth*( 1 + j * 2 - rowSize ),
+                halfBoxHeight * ( 1 + i * 2),
+                0.0f
+                );
+
+            trans.setOrigin( pos );
+            btScalar mass = 1.f;
+
+            btRigidBody* body = localCreateRigidBody( mass, trans, boxShape );
+        }
+    }
+}
+
+
+void MultiThreadedDemo::createSceneObjects()
+{
+    {
+        // create ground box
+        btTransform tr;
+        tr.setIdentity();
+        tr.setOrigin( btVector3( 0, -3, 0 ) );
+
+        //either use heightfield or triangle mesh
+
+        btVector3 groundExtents( 400, 400, 400 );
+        groundExtents[ kUpAxis ] = 3;
+        btCollisionShape* groundShape = new btBoxShape( groundExtents );
+        m_collisionShapes.push_back( groundShape );
+
+        //create ground object
+        localCreateRigidBody( 0, tr, groundShape );
+    }
+
+    {
+        // create walls of cubes
+        const btVector3 halfExtents = btVector3( 0.5f, 0.25f, 0.5f );
+        int numStackRows = 16;
+        int numStackCols = 6;
+        int stackHeight = 15;
+        float stackZSpacing = 3.0f;
+        float stackXSpacing = 20.0f;
+
+        btBoxShape* boxShape = new btBoxShape( halfExtents );
+        m_collisionShapes.push_back( boxShape );
+
+        for ( int iX = 0; iX < numStackCols; ++iX )
+        {
+            for ( int iZ = 0; iZ < numStackRows; ++iZ )
+            {
+                btVector3 center = btVector3( iX * stackXSpacing, 0.0f, ( iZ - numStackRows / 2 ) * stackZSpacing );
+                createStack( center, boxShape, halfExtents, stackHeight );
+            }
+        }
+    }
+
+    if ( false )
+    {
+        // destroyer ball
+        btTransform sphereTrans;
+        sphereTrans.setIdentity();
+        sphereTrans.setOrigin( btVector3( 0, 2, 40 ) );
+        btSphereShape* ball = new btSphereShape( 2.f );
+        m_collisionShapes.push_back( ball );
+        btRigidBody* ballBody = localCreateRigidBody( 10000.f, sphereTrans, ball );
+        ballBody->setLinearVelocity( btVector3( 0, 0, -10 ) );
+    }
+    if ( false )
+    {
+        btCompoundShape* loadCompound = new btCompoundShape();
+        m_collisionShapes.push_back( loadCompound );
+        btCollisionShape* loadShapeA = new btBoxShape( btVector3( 2.0f, 0.5f, 0.5f ) );
+        m_collisionShapes.push_back( loadShapeA );
+        btTransform loadTrans;
+        loadTrans.setIdentity();
+        loadCompound->addChildShape( loadTrans, loadShapeA );
+        btCollisionShape* loadShapeB = new btBoxShape( btVector3( 0.1f, 1.0f, 1.0f ) );
+        m_collisionShapes.push_back( loadShapeB );
+        loadTrans.setIdentity();
+        loadTrans.setOrigin( btVector3( 2.1f, 0.0f, 0.0f ) );
+        loadCompound->addChildShape( loadTrans, loadShapeB );
+        btCollisionShape* loadShapeC = new btBoxShape( btVector3( 0.1f, 1.0f, 1.0f ) );
+        m_collisionShapes.push_back( loadShapeC );
+        loadTrans.setIdentity();
+        loadTrans.setOrigin( btVector3( -2.1f, 0.0f, 0.0f ) );
+        loadCompound->addChildShape( loadTrans, loadShapeC );
+        loadTrans.setIdentity();
+        m_loadStartPos = btVector3( 0.0f, 3.5f, 7.0f );
+        loadTrans.setOrigin( m_loadStartPos );
+        btScalar loadMass = 350.f;//
+        localCreateRigidBody( loadMass, loadTrans, loadCompound );
+    }
+    m_guiHelper->autogenerateGraphicsObjects( m_dynamicsWorld );
+
+}
+
+void MultiThreadedDemo::destroySceneObjects()
+{
+    //cleanup in the reverse order of creation/initialization
+
+    //remove the rigidbodies from the dynamics world and delete them
+    for ( int i = m_dynamicsWorld->getNumCollisionObjects() - 1; i >= 0; i-- )
+    {
+        btCollisionObject* obj = m_dynamicsWorld->getCollisionObjectArray()[ i ];
+        btRigidBody* body = btRigidBody::upcast( obj );
+        if ( body && body->getMotionState() )
+        {
+            delete body->getMotionState();
+        }
+        m_dynamicsWorld->removeCollisionObject( obj );
+        delete obj;
+    }
+
+    //delete collision shapes
+    for ( int j = 0; j<m_collisionShapes.size(); j++ )
+    {
+        btCollisionShape* shape = m_collisionShapes[ j ];
+        m_collisionShapes[ j ] = 0;
+        delete shape;
+    }
+
+    m_collisionShapes.clear();
+}
+
+CommonExampleInterface*    MultiThreadedDemoCreateFunc( struct CommonExampleOptions& options )
+{
+	return new MultiThreadedDemo(options.m_guiHelper);
+}

--- a/examples/MultiThreadedDemo/MultiThreadedDemo.h
+++ b/examples/MultiThreadedDemo/MultiThreadedDemo.h
@@ -1,0 +1,22 @@
+/*
+Bullet Continuous Collision Detection and Physics Library
+Copyright (c) 2003-2006 Erwin Coumans  http://continuousphysics.com/Bullet/
+
+This software is provided 'as-is', without any express or implied warranty.
+In no event will the authors be held liable for any damages arising from the use of this software.
+Permission is granted to anyone to use this software for any purpose, 
+including commercial applications, and to alter it and redistribute it freely, 
+subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software. If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
+2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
+3. This notice may not be removed or altered from any source distribution.
+*/
+#ifndef MULTITHREADED_DEMO_H
+#define MULTITHREADED_DEMO_H
+
+class CommonExampleInterface*    MultiThreadedDemoCreateFunc(struct CommonExampleOptions& options);
+
+#endif // MULTITHREADED_DEMO_H
+
+

--- a/examples/MultiThreadedDemo/ParallelFor.h
+++ b/examples/MultiThreadedDemo/ParallelFor.h
@@ -1,0 +1,267 @@
+/*
+Bullet Continuous Collision Detection and Physics Library
+Copyright (c) 2003-2006 Erwin Coumans  http://continuousphysics.com/Bullet/
+
+This software is provided 'as-is', without any express or implied warranty.
+In no event will the authors be held liable for any damages arising from the use of this software.
+Permission is granted to anyone to use this software for any purpose, 
+including commercial applications, and to alter it and redistribute it freely, 
+subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software. If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
+2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
+3. This notice may not be removed or altered from any source distribution.
+*/
+
+#include <stdio.h> //printf debugging
+#include <algorithm>
+
+
+// choose threading providers:
+#if BT_USE_TBB
+#define USE_TBB 1     // use Intel Threading Building Blocks for thread management
+#endif
+
+#if BT_USE_PPL
+#define USE_PPL 1     // use Microsoft Parallel Patterns Library (installed with Visual Studio 2010 and later)
+#endif // BT_USE_PPL
+
+#if BT_USE_OPENMP
+#define USE_OPENMP 1  // use OpenMP (also need to change compiler options for OpenMP support)
+#endif
+
+
+#if USE_OPENMP
+
+#include <omp.h>
+
+#endif // #if USE_OPENMP
+
+
+#if USE_PPL
+
+#include <ppl.h>  // if you get a compile error here, check whether your version of Visual Studio includes PPL
+// Visual Studio 2010 and later should come with it
+#include <concrtrm.h>  // for GetProcessorCount()
+#endif // #if USE_PPL
+
+
+#if USE_TBB
+
+#define __TBB_NO_IMPLICIT_LINKAGE 1
+#include <tbb/tbb.h>
+#include <tbb/task_scheduler_init.h>
+#include <tbb/parallel_for.h>
+#include <tbb/blocked_range.h>
+
+tbb::task_scheduler_init* gTaskSchedulerInit;
+
+#endif // #if USE_TBB
+
+enum TaskApi
+{
+    apiNone,
+    apiOpenMP,
+    apiTbb,
+    apiPpl,
+};
+
+
+static TaskApi gTaskApi = apiNone;
+
+static void setTaskApi( TaskApi api )
+{
+#if USE_OPENMP
+    if ( api == apiOpenMP )
+    {
+        gTaskApi = api;
+        return;
+    }
+#endif
+#if USE_TBB
+    if ( api == apiTbb )
+    {
+        gTaskApi = api;
+        return;
+    }
+#endif
+#if USE_PPL
+    if ( api == apiPpl )
+    {
+        gTaskApi = api;
+        return;
+    }
+#endif
+    // no compile time support for selected API, fallback to "none"
+    gTaskApi = apiNone;
+}
+
+static const char* getTaskApiName( TaskApi api )
+{
+    switch ( api )
+    {
+    case apiNone: return "None";
+    case apiOpenMP: return "OpenMP";
+    case apiTbb: return "TBB";
+    case apiPpl: return "PPL";
+    default: return "unknown";
+    }
+}
+
+static int getMaxNumThreads()
+{
+#if USE_OPENMP
+    return omp_get_max_threads();
+#elif USE_PPL
+    return concurrency::GetProcessorCount();
+#elif USE_TBB
+    return tbb::task_scheduler_init::default_num_threads();
+#endif
+    return 1;
+}
+
+static int setNumThreads( int numThreads )
+{
+    numThreads = (std::max)( 1, numThreads );
+
+#if USE_OPENMP
+    omp_set_num_threads( numThreads );
+#endif
+
+#if USE_PPL
+    {
+        using namespace concurrency;
+        if ( CurrentScheduler::Id() != -1 )
+        {
+            CurrentScheduler::Detach();
+        }
+        SchedulerPolicy policy;
+        policy.SetConcurrencyLimits( numThreads, numThreads );
+        CurrentScheduler::Create( policy );
+    }
+#endif
+
+#if USE_TBB
+    if ( gTaskSchedulerInit )
+    {
+        delete gTaskSchedulerInit;
+        gTaskSchedulerInit = NULL;
+    }
+    gTaskSchedulerInit = new tbb::task_scheduler_init( numThreads );
+#endif
+    return numThreads;
+}
+
+static void initTaskScheduler()
+{
+    setTaskApi( apiPpl );
+    setTaskApi( apiTbb );
+    setTaskApi( apiOpenMP );
+}
+
+static void cleanupTaskScheduler()
+{
+#if USE_TBB
+    if ( gTaskSchedulerInit )
+    {
+        delete gTaskSchedulerInit;
+        gTaskSchedulerInit = NULL;
+    }
+#endif
+}
+
+
+#if USE_TBB
+///
+/// TbbBodyAdapter -- Converts a body object that implements the
+///                   "forLoop(int iBegin, int iEnd) const" function
+///  into a TBB compatible object that takes a tbb::blocked_range<int> type.
+///
+template <class TBody>
+struct TbbBodyAdapter
+{
+    const TBody* mBody;
+
+    void operator()( const tbb::blocked_range<int>& range ) const
+    {
+        mBody->forLoop( range.begin(), range.end() );
+    }
+};
+#endif // #if USE_TBB
+
+#if USE_PPL
+///
+/// PplBodyAdapter -- Converts a body object that implements the
+///                   "forLoop(int iBegin, int iEnd) const" function
+///  into a PPL compatible object that implements "void operator()( int ) const"
+///
+template <class TBody>
+struct PplBodyAdapter
+{
+    const TBody* mBody;
+
+    void operator()( int i ) const
+    {
+        mBody->forLoop( i, i+1 );
+    }
+};
+#endif // #if USE_PPL
+
+
+///
+/// parallelFor -- interface for submitting work expressed as a for loop to the worker threads
+///
+template <class TBody>
+void parallelFor( int iBegin, int iEnd, int grainSize, const TBody& body )
+{
+#if USE_OPENMP
+    if ( gTaskApi == apiOpenMP )
+    {
+#pragma omp parallel for schedule(static, 1)
+        for ( int i = iBegin; i < iEnd; i += grainSize )
+        {
+            body.forLoop( i, (std::min)( i + grainSize, iEnd ) );
+        }
+        return;
+    }
+#endif // #if USE_OPENMP
+
+#if USE_PPL
+    if ( gTaskApi == apiPpl )
+    {
+        // PPL dispatch
+        PplBodyAdapter<TBody> pplBody;
+        pplBody.mBody = &body;
+        concurrency::parallel_for( iBegin,
+                                   iEnd,
+                                   pplBody,
+                                   concurrency::simple_partitioner( grainSize )
+                                   );
+        return;
+    }
+#endif //#if USE_PPL
+
+#if USE_TBB
+    if ( gTaskApi == apiTbb )
+    {
+        // TBB dispatch
+        TbbBodyAdapter<TBody> tbbBody;
+        tbbBody.mBody = &body;
+        tbb::parallel_for( tbb::blocked_range<int>( iBegin, iEnd, grainSize ),
+                           tbbBody,
+                           tbb::simple_partitioner()
+                           );
+        return;
+    }
+#endif // #if USE_TBB
+
+    {
+        // run on main thread
+        body.forLoop( iBegin, iEnd );
+    }
+
+}
+
+
+
+

--- a/src/BulletCollision/BroadphaseCollision/btDbvt.h
+++ b/src/BulletCollision/BroadphaseCollision/btDbvt.h
@@ -263,7 +263,6 @@ struct	btDbvt
 
 	
 	btAlignedObjectArray<sStkNN>	m_stkStack;
-	mutable btAlignedObjectArray<const btDbvtNode*>	m_rayTestStack;
 
 
 	// Methods
@@ -343,6 +342,7 @@ struct	btDbvt
 								btScalar lambda_max,
 								const btVector3& aabbMin,
 								const btVector3& aabbMax,
+                                btAlignedObjectArray<const btDbvtNode*>& stack,
 								DBVT_IPOLICY) const;
 
 	DBVT_PREFIX
@@ -959,7 +959,8 @@ inline void		btDbvt::rayTestInternal(	const btDbvtNode* root,
 								btScalar lambda_max,
 								const btVector3& aabbMin,
 								const btVector3& aabbMax,
-								DBVT_IPOLICY) const
+                                btAlignedObjectArray<const btDbvtNode*>& stack,
+                                DBVT_IPOLICY ) const
 {
         (void) rayTo;
 	DBVT_CHECKTYPE
@@ -969,7 +970,6 @@ inline void		btDbvt::rayTestInternal(	const btDbvtNode* root,
 
 		int								depth=1;
 		int								treshold=DOUBLE_STACKSIZE-2;
-		btAlignedObjectArray<const btDbvtNode*>&	stack = m_rayTestStack;
 		stack.resize(DOUBLE_STACKSIZE);
 		stack[0]=root;
 		btVector3 bounds[2];

--- a/src/BulletCollision/BroadphaseCollision/btDbvtBroadphase.cpp
+++ b/src/BulletCollision/BroadphaseCollision/btDbvtBroadphase.cpp
@@ -227,6 +227,11 @@ struct	BroadphaseRayTester : btDbvt::ICollide
 void	btDbvtBroadphase::rayTest(const btVector3& rayFrom,const btVector3& rayTo, btBroadphaseRayCallback& rayCallback,const btVector3& aabbMin,const btVector3& aabbMax)
 {
 	BroadphaseRayTester callback(rayCallback);
+    // for this function to be threadsafe, each thread must have a separate copy
+    // of this stack.  This could be thread-local static to avoid dynamic allocations,
+    // instead of just a local.
+    btAlignedObjectArray<const btDbvtNode*> stack;
+    stack.reserve( 128 );
 
 	m_sets[0].rayTestInternal(	m_sets[0].m_root,
 		rayFrom,
@@ -236,6 +241,7 @@ void	btDbvtBroadphase::rayTest(const btVector3& rayFrom,const btVector3& rayTo, 
 		rayCallback.m_lambda_max,
 		aabbMin,
 		aabbMax,
+        stack,
 		callback);
 
 	m_sets[1].rayTestInternal(	m_sets[1].m_root,
@@ -246,6 +252,7 @@ void	btDbvtBroadphase::rayTest(const btVector3& rayFrom,const btVector3& rayTo, 
 		rayCallback.m_lambda_max,
 		aabbMin,
 		aabbMax,
+        stack,
 		callback);
 
 }

--- a/src/BulletCollision/CollisionDispatch/btCollisionDispatcher.cpp
+++ b/src/BulletCollision/CollisionDispatch/btCollisionDispatcher.cpp
@@ -54,7 +54,7 @@ m_dispatcherFlags(btCollisionDispatcher::CD_USE_RELATIVE_CONTACT_BREAKING_THRESH
 			btAssert(m_doubleDispatch[i][j]);
 		}
 	}
-	
+
 	
 }
 
@@ -85,26 +85,31 @@ btPersistentManifold*	btCollisionDispatcher::getNewManifold(const btCollisionObj
 	btScalar contactProcessingThreshold = btMin(body0->getContactProcessingThreshold(),body1->getContactProcessingThreshold());
 		
  	void* mem = 0;
-	
-	if (m_persistentManifoldPoolAllocator->getFreeCount())
+    btMutexLock( &m_manifoldPoolMutex );
+    if ( m_persistentManifoldPoolAllocator->getFreeCount() )
 	{
-		mem = m_persistentManifoldPoolAllocator->allocate(sizeof(btPersistentManifold));
-	} else
+        mem = m_persistentManifoldPoolAllocator->allocate( sizeof( btPersistentManifold ) );
+        btMutexUnlock( &m_manifoldPoolMutex );
+    }
+    else
 	{
-		//we got a pool memory overflow, by default we fallback to dynamically allocate memory. If we require a contiguous contact pool then assert.
+        btMutexUnlock( &m_manifoldPoolMutex );
+        //we got a pool memory overflow, by default we fallback to dynamically allocate memory. If we require a contiguous contact pool then assert.
 		if ((m_dispatcherFlags&CD_DISABLE_CONTACTPOOL_DYNAMIC_ALLOCATION)==0)
 		{
 			mem = btAlignedAlloc(sizeof(btPersistentManifold),16);
 		} else
 		{
-			btAssert(0);
+            btAssert( 0 );
 			//make sure to increase the m_defaultMaxPersistentManifoldPoolSize in the btDefaultCollisionConstructionInfo/btDefaultCollisionConfiguration
 			return 0;
 		}
 	}
 	btPersistentManifold* manifold = new(mem) btPersistentManifold (body0,body1,0,contactBreakingThreshold,contactProcessingThreshold);
-	manifold->m_index1a = m_manifoldsPtr.size();
+    btMutexLock( &m_manifoldPtrsMutex );
+    manifold->m_index1a = m_manifoldsPtr.size();
 	m_manifoldsPtr.push_back(manifold);
+    btMutexUnlock( &m_manifoldPtrsMutex );
 
 	return manifold;
 }
@@ -123,21 +128,26 @@ void btCollisionDispatcher::releaseManifold(btPersistentManifold* manifold)
 	//printf("releaseManifold: gNumManifold %d\n",gNumManifold);
 	clearManifold(manifold);
 
-	int findIndex = manifold->m_index1a;
+    btMutexLock( &m_manifoldPtrsMutex );
+    int findIndex = manifold->m_index1a;
 	btAssert(findIndex < m_manifoldsPtr.size());
-	m_manifoldsPtr.swap(findIndex,m_manifoldsPtr.size()-1);
+    m_manifoldsPtr.swap( findIndex, m_manifoldsPtr.size() - 1 );
 	m_manifoldsPtr[findIndex]->m_index1a = findIndex;
 	m_manifoldsPtr.pop_back();
+    btMutexUnlock( &m_manifoldPtrsMutex );
 
 	manifold->~btPersistentManifold();
 	if (m_persistentManifoldPoolAllocator->validPtr(manifold))
 	{
-		m_persistentManifoldPoolAllocator->freeMemory(manifold);
-	} else
+        btMutexLock( &m_manifoldPoolMutex );
+        m_persistentManifoldPoolAllocator->freeMemory( manifold );
+        btMutexUnlock( &m_manifoldPoolMutex );
+    }
+    else
 	{
 		btAlignedFree(manifold);
 	}
-	
+
 }
 
 	
@@ -293,11 +303,15 @@ void btCollisionDispatcher::defaultNearCallback(btBroadphasePair& collisionPair,
 
 void* btCollisionDispatcher::allocateCollisionAlgorithm(int size)
 {
-	if (m_collisionAlgorithmPoolAllocator->getFreeCount())
+    btMutexLock( &m_algPoolMutex );
+    if ( m_collisionAlgorithmPoolAllocator->getFreeCount() )
 	{
-		return m_collisionAlgorithmPoolAllocator->allocate(size);
-	}
-	
+        void* mem = m_collisionAlgorithmPoolAllocator->allocate( size );
+        btMutexUnlock( &m_algPoolMutex );
+        return mem;
+    }
+    btMutexUnlock( &m_algPoolMutex );
+
 	//warn user for overflow?
 	return	btAlignedAlloc(static_cast<size_t>(size), 16);
 }
@@ -306,8 +320,11 @@ void btCollisionDispatcher::freeCollisionAlgorithm(void* ptr)
 {
 	if (m_collisionAlgorithmPoolAllocator->validPtr(ptr))
 	{
-		m_collisionAlgorithmPoolAllocator->freeMemory(ptr);
-	} else
+        btMutexLock( &m_algPoolMutex );
+        m_collisionAlgorithmPoolAllocator->freeMemory( ptr );
+        btMutexUnlock( &m_algPoolMutex );
+    }
+    else
 	{
 		btAlignedFree(ptr);
 	}

--- a/src/BulletCollision/CollisionDispatch/btCollisionDispatcher.h
+++ b/src/BulletCollision/CollisionDispatch/btCollisionDispatcher.h
@@ -23,6 +23,7 @@ subject to the following restrictions:
 
 #include "BulletCollision/BroadphaseCollision/btBroadphaseProxy.h"
 #include "LinearMath/btAlignedObjectArray.h"
+#include "LinearMath/btThreads.h"
 
 class btIDebugDraw;
 class btOverlappingPairCache;
@@ -61,6 +62,11 @@ protected:
 
 	btCollisionConfiguration*	m_collisionConfiguration;
 
+    btMutex m_manifoldPtrsMutex;
+    char m_cacheLinePadding1[ 63 ];
+    btMutex m_manifoldPoolMutex;
+    char m_cacheLinePadding2[ 63 ];
+    btMutex m_algPoolMutex;
 
 public:
 

--- a/src/BulletCollision/CollisionDispatch/btConvexConvexAlgorithm.cpp
+++ b/src/BulletCollision/CollisionDispatch/btConvexConvexAlgorithm.cpp
@@ -179,11 +179,10 @@ static SIMD_FORCE_INLINE btScalar capsuleCapsuleDistance(
 
 
 
-btConvexConvexAlgorithm::CreateFunc::CreateFunc(btSimplexSolverInterface*			simplexSolver, btConvexPenetrationDepthSolver* pdSolver)
+btConvexConvexAlgorithm::CreateFunc::CreateFunc(btConvexPenetrationDepthSolver* pdSolver)
 {
 	m_numPerturbationIterations = 0;
 	m_minimumPointsPerturbationThreshold = 3;
-	m_simplexSolver = simplexSolver;
 	m_pdSolver = pdSolver;
 }
 
@@ -191,9 +190,8 @@ btConvexConvexAlgorithm::CreateFunc::~CreateFunc()
 { 
 }
 
-btConvexConvexAlgorithm::btConvexConvexAlgorithm(btPersistentManifold* mf,const btCollisionAlgorithmConstructionInfo& ci,const btCollisionObjectWrapper* body0Wrap,const btCollisionObjectWrapper* body1Wrap,btSimplexSolverInterface* simplexSolver, btConvexPenetrationDepthSolver* pdSolver,int numPerturbationIterations, int minimumPointsPerturbationThreshold)
+btConvexConvexAlgorithm::btConvexConvexAlgorithm(btPersistentManifold* mf,const btCollisionAlgorithmConstructionInfo& ci,const btCollisionObjectWrapper* body0Wrap,const btCollisionObjectWrapper* body1Wrap,btConvexPenetrationDepthSolver* pdSolver,int numPerturbationIterations, int minimumPointsPerturbationThreshold)
 : btActivatingCollisionAlgorithm(ci,body0Wrap,body1Wrap),
-m_simplexSolver(simplexSolver),
 m_pdSolver(pdSolver),
 m_ownManifold (false),
 m_manifoldPtr(mf),
@@ -349,8 +347,8 @@ void btConvexConvexAlgorithm ::processCollision (const btCollisionObjectWrapper*
 
 	
 	btGjkPairDetector::ClosestPointInput input;
-
-	btGjkPairDetector	gjkPairDetector(min0,min1,m_simplexSolver,m_pdSolver);
+    btVoronoiSimplexSolver simplexSolver;
+    btGjkPairDetector	gjkPairDetector( min0, min1, &simplexSolver, m_pdSolver );
 	//TODO: if (dispatchInfo.m_useContinuous)
 	gjkPairDetector.setMinkowskiA(min0);
 	gjkPairDetector.setMinkowskiB(min1);

--- a/src/BulletCollision/CollisionDispatch/btConvexConvexAlgorithm.h
+++ b/src/BulletCollision/CollisionDispatch/btConvexConvexAlgorithm.h
@@ -42,7 +42,6 @@ class btConvexConvexAlgorithm : public btActivatingCollisionAlgorithm
 #ifdef USE_SEPDISTANCE_UTIL2
 	btConvexSeparatingDistanceUtil	m_sepDistance;
 #endif
-	btSimplexSolverInterface*		m_simplexSolver;
 	btConvexPenetrationDepthSolver* m_pdSolver;
 
 	
@@ -59,7 +58,7 @@ class btConvexConvexAlgorithm : public btActivatingCollisionAlgorithm
 
 public:
 
-	btConvexConvexAlgorithm(btPersistentManifold* mf,const btCollisionAlgorithmConstructionInfo& ci,const btCollisionObjectWrapper* body0Wrap,const btCollisionObjectWrapper* body1Wrap, btSimplexSolverInterface* simplexSolver, btConvexPenetrationDepthSolver* pdSolver, int numPerturbationIterations, int minimumPointsPerturbationThreshold);
+	btConvexConvexAlgorithm(btPersistentManifold* mf,const btCollisionAlgorithmConstructionInfo& ci,const btCollisionObjectWrapper* body0Wrap,const btCollisionObjectWrapper* body1Wrap, btConvexPenetrationDepthSolver* pdSolver, int numPerturbationIterations, int minimumPointsPerturbationThreshold);
 
 	virtual ~btConvexConvexAlgorithm();
 
@@ -87,18 +86,17 @@ public:
 	{
 
 		btConvexPenetrationDepthSolver*		m_pdSolver;
-		btSimplexSolverInterface*			m_simplexSolver;
 		int m_numPerturbationIterations;
 		int m_minimumPointsPerturbationThreshold;
 
-		CreateFunc(btSimplexSolverInterface*			simplexSolver, btConvexPenetrationDepthSolver* pdSolver);
+		CreateFunc(btConvexPenetrationDepthSolver* pdSolver);
 		
 		virtual ~CreateFunc();
 
 		virtual	btCollisionAlgorithm* CreateCollisionAlgorithm(btCollisionAlgorithmConstructionInfo& ci, const btCollisionObjectWrapper* body0Wrap,const btCollisionObjectWrapper* body1Wrap)
 		{
 			void* mem = ci.m_dispatcher1->allocateCollisionAlgorithm(sizeof(btConvexConvexAlgorithm));
-			return new(mem) btConvexConvexAlgorithm(ci.m_manifold,ci,body0Wrap,body1Wrap,m_simplexSolver,m_pdSolver,m_numPerturbationIterations,m_minimumPointsPerturbationThreshold);
+			return new(mem) btConvexConvexAlgorithm(ci.m_manifold,ci,body0Wrap,body1Wrap,m_pdSolver,m_numPerturbationIterations,m_minimumPointsPerturbationThreshold);
 		}
 	};
 

--- a/src/BulletCollision/CollisionDispatch/btDefaultCollisionConfiguration.cpp
+++ b/src/BulletCollision/CollisionDispatch/btDefaultCollisionConfiguration.cpp
@@ -44,9 +44,7 @@ btDefaultCollisionConfiguration::btDefaultCollisionConfiguration(const btDefault
 //btDefaultCollisionConfiguration::btDefaultCollisionConfiguration(btStackAlloc*	stackAlloc,btPoolAllocator*	persistentManifoldPool,btPoolAllocator*	collisionAlgorithmPool)
 {
 
-	void* mem = btAlignedAlloc(sizeof(btVoronoiSimplexSolver),16);
-	m_simplexSolver = new (mem)btVoronoiSimplexSolver();
-
+    void* mem = NULL;
 	if (constructionInfo.m_useEpaPenetrationAlgorithm)
 	{
 		mem = btAlignedAlloc(sizeof(btGjkEpaPenetrationDepthSolver),16);
@@ -59,7 +57,7 @@ btDefaultCollisionConfiguration::btDefaultCollisionConfiguration(const btDefault
 	
 	//default CreationFunctions, filling the m_doubleDispatch table
 	mem = btAlignedAlloc(sizeof(btConvexConvexAlgorithm::CreateFunc),16);
-	m_convexConvexCreateFunc = new(mem) btConvexConvexAlgorithm::CreateFunc(m_simplexSolver,m_pdSolver);
+	m_convexConvexCreateFunc = new(mem) btConvexConvexAlgorithm::CreateFunc(m_pdSolver);
 	mem = btAlignedAlloc(sizeof(btConvexConcaveCollisionAlgorithm::CreateFunc),16);
 	m_convexConcaveCreateFunc = new (mem)btConvexConcaveCollisionAlgorithm::CreateFunc;
 	mem = btAlignedAlloc(sizeof(btConvexConcaveCollisionAlgorithm::CreateFunc),16);
@@ -191,9 +189,6 @@ btDefaultCollisionConfiguration::~btDefaultCollisionConfiguration()
 	btAlignedFree( m_convexPlaneCF);
 	m_planeConvexCF->~btCollisionAlgorithmCreateFunc();
 	btAlignedFree( m_planeConvexCF);
-
-	m_simplexSolver->~btVoronoiSimplexSolver();
-	btAlignedFree(m_simplexSolver);
 
 	m_pdSolver->~btConvexPenetrationDepthSolver();
 	

--- a/src/BulletCollision/CollisionDispatch/btDefaultCollisionConfiguration.h
+++ b/src/BulletCollision/CollisionDispatch/btDefaultCollisionConfiguration.h
@@ -60,8 +60,7 @@ protected:
 	btPoolAllocator*	m_collisionAlgorithmPool;
 	bool	m_ownsCollisionAlgorithmPool;
 
-	//default simplex/penetration depth solvers
-	btVoronoiSimplexSolver*	m_simplexSolver;
+	//default penetration depth solver
 	btConvexPenetrationDepthSolver*	m_pdSolver;
 	
 	//default CreationFunctions, filling the m_doubleDispatch table
@@ -99,12 +98,6 @@ public:
 	virtual btPoolAllocator* getCollisionAlgorithmPool()
 	{
 		return m_collisionAlgorithmPool;
-	}
-
-
-	virtual	btVoronoiSimplexSolver*	getSimplexSolver()
-	{
-		return m_simplexSolver;
 	}
 
 

--- a/src/BulletCollision/CollisionDispatch/btSimulationIslandManager.h
+++ b/src/BulletCollision/CollisionDispatch/btSimulationIslandManager.h
@@ -59,19 +59,25 @@ public:
     };
     typedef void( *IslandDispatchFunc ) ( btAlignedObjectArray<Island*>* islands, IslandCallback* callback );
     static void defaultIslandDispatch( btAlignedObjectArray<Island*>* islands, IslandCallback* callback );
-private:
+protected:
     btUnionFind m_unionFind;
     btAlignedObjectArray<Island*> m_allocatedIslands;  // owner of all Islands
     btAlignedObjectArray<Island*> m_activeIslands;  // islands actively in use
     btAlignedObjectArray<Island*> m_freeIslands;  // islands ready to be reused
     btAlignedObjectArray<Island*> m_lookupIslandFromId;  // big lookup table to map islandId to Island pointer
+    Island* m_batchIsland;
     int m_minimumSolverBatchSize;
+    int m_batchIslandMinBodyCount;
     IslandDispatchFunc m_islandDispatch;
 	bool m_splitIslands;
 
     Island* getIsland( int id );
-    Island* allocateIsland( int id, int numBodies );
-    void initIslandPools();
+    virtual Island* allocateIsland( int id, int numBodies );
+    virtual void initIslandPools();
+    virtual void addBodiesToIslands( btCollisionWorld* collisionWorld );
+    virtual void addManifoldsToIslands( btDispatcher* dispatcher );
+    virtual void addConstraintsToIslands( btAlignedObjectArray<btTypedConstraint*>& constraints );
+    virtual void mergeIslands();
 	
 public:
 	btSimulationIslandManager();

--- a/src/BulletCollision/CollisionDispatch/btSimulationIslandManager.h
+++ b/src/BulletCollision/CollisionDispatch/btSimulationIslandManager.h
@@ -25,17 +25,53 @@ class btCollisionObject;
 class btCollisionWorld;
 class btDispatcher;
 class btPersistentManifold;
+class btTypedConstraint;
 
 
 ///SimulationIslandManager creates and handles simulation islands, using btUnionFind
 class btSimulationIslandManager
 {
-	btUnionFind m_unionFind;
+public:
+    struct Island
+    {
+        // a simulation island consisting of bodies, manifolds and constraints,
+        // to be passed into a constraint solver.
+        btAlignedObjectArray<btCollisionObject*> bodyArray;
+        btAlignedObjectArray<btPersistentManifold*> manifoldArray;
+        btAlignedObjectArray<btTypedConstraint*> constraintArray;
+        int id;  // island id
+        bool isSleeping;
 
-	btAlignedObjectArray<btPersistentManifold*>  m_islandmanifold;
-	btAlignedObjectArray<btCollisionObject* >  m_islandBodies;
-	
+        void append( const Island& other );  // add bodies, manifolds, constraints to my own
+    };
+    struct	IslandCallback
+    {
+        virtual ~IslandCallback() {};
+
+        virtual	void processIsland( btCollisionObject** bodies,
+                                    int numBodies,
+                                    btPersistentManifold** manifolds,
+                                    int numManifolds,
+                                    btTypedConstraint** constraints,
+                                    int numConstraints,
+                                    int islandId
+                                    ) = 0;
+    };
+    typedef void( *IslandDispatchFunc ) ( btAlignedObjectArray<Island*>* islands, IslandCallback* callback );
+    static void defaultIslandDispatch( btAlignedObjectArray<Island*>* islands, IslandCallback* callback );
+private:
+    btUnionFind m_unionFind;
+    btAlignedObjectArray<Island*> m_allocatedIslands;  // owner of all Islands
+    btAlignedObjectArray<Island*> m_activeIslands;  // islands actively in use
+    btAlignedObjectArray<Island*> m_freeIslands;  // islands ready to be reused
+    btAlignedObjectArray<Island*> m_lookupIslandFromId;  // big lookup table to map islandId to Island pointer
+    int m_minimumSolverBatchSize;
+    IslandDispatchFunc m_islandDispatch;
 	bool m_splitIslands;
+
+    Island* getIsland( int id );
+    Island* allocateIsland( int id, int numBodies );
+    void initIslandPools();
 	
 public:
 	btSimulationIslandManager();
@@ -53,18 +89,11 @@ public:
 
 	void	findUnions(btDispatcher* dispatcher,btCollisionWorld* colWorld);
 
-	
 
-	struct	IslandCallback
-	{
-		virtual ~IslandCallback() {};
 
-		virtual	void	processIsland(btCollisionObject** bodies,int numBodies,class btPersistentManifold**	manifolds,int numManifolds, int islandId) = 0;
-	};
+    virtual void buildAndProcessIslands( btDispatcher* dispatcher, btCollisionWorld* collisionWorld, btAlignedObjectArray<btTypedConstraint*>& constraints, IslandCallback* callback );
 
-	void	buildAndProcessIslands(btDispatcher* dispatcher,btCollisionWorld* collisionWorld, IslandCallback* callback);
-
-	void buildIslands(btDispatcher* dispatcher,btCollisionWorld* colWorld);
+	virtual void buildIslands(btDispatcher* dispatcher,btCollisionWorld* colWorld);
 
 	bool getSplitIslands()
 	{
@@ -74,7 +103,23 @@ public:
 	{
 		m_splitIslands = doSplitIslands;
 	}
-
+    int getMinimumSolverBatchSize() const
+    {
+        return m_minimumSolverBatchSize;
+    }
+    void setMinimumSolverBatchSize( int sz )
+    {
+        m_minimumSolverBatchSize = sz;
+    }
+    IslandDispatchFunc getIslandDispatchFunction() const
+    {
+        return m_islandDispatch;
+    }
+    // allow users to set their own dispatch function for multithreaded dispatch
+    void setIslandDispatchFunction( IslandDispatchFunc func )
+    {
+        m_islandDispatch = func;
+    }
 };
 
 #endif //BT_SIMULATION_ISLAND_MANAGER_H

--- a/src/BulletCollision/Gimpact/btGImpactShape.h
+++ b/src/BulletCollision/Gimpact/btGImpactShape.h
@@ -722,17 +722,8 @@ public:
 		m_box_set.setPrimitiveManager(&m_primitive_manager);
 	}
 
-
-	btGImpactMeshShapePart(btStridingMeshInterface * meshInterface,	int part)
-	{
-		m_primitive_manager.m_meshInterface = meshInterface;
-		m_primitive_manager.m_part = part;
-		m_box_set.setPrimitiveManager(&m_primitive_manager);
-	}
-
-	virtual ~btGImpactMeshShapePart()
-	{
-	}
+    btGImpactMeshShapePart( btStridingMeshInterface * meshInterface, int part );
+    virtual ~btGImpactMeshShapePart();
 
 	//! if true, then its children must get transforms.
 	virtual bool childrenHasTransform() const
@@ -742,19 +733,8 @@ public:
 
 
 	//! call when reading child shapes
-	virtual void lockChildShapes() const
-	{
-		void * dummy = (void*)(m_box_set.getPrimitiveManager());
-		TrimeshPrimitiveManager * dummymanager = static_cast<TrimeshPrimitiveManager *>(dummy);
-		dummymanager->lock();
-	}
-
-	virtual void unlockChildShapes()  const
-	{
-		void * dummy = (void*)(m_box_set.getPrimitiveManager());
-		TrimeshPrimitiveManager * dummymanager = static_cast<TrimeshPrimitiveManager *>(dummy);
-		dummymanager->unlock();
-	}
+    virtual void lockChildShapes() const;
+    virtual void unlockChildShapes()  const;
 
 	//! Gets the number of children
 	virtual int	getNumChildShapes() const

--- a/src/BulletDynamics/Dynamics/btDiscreteDynamicsWorld.cpp
+++ b/src/BulletDynamics/Dynamics/btDiscreteDynamicsWorld.cpp
@@ -56,44 +56,12 @@ int startHit=2;
 int firstHit=startHit;
 #endif
 
-SIMD_FORCE_INLINE	int	btGetConstraintIslandId(const btTypedConstraint* lhs)
-{
-	int islandId;
-
-	const btCollisionObject& rcolObj0 = lhs->getRigidBodyA();
-	const btCollisionObject& rcolObj1 = lhs->getRigidBodyB();
-	islandId= rcolObj0.getIslandTag()>=0?rcolObj0.getIslandTag():rcolObj1.getIslandTag();
-	return islandId;
-
-}
-
-
-class btSortConstraintOnIslandPredicate
-{
-	public:
-
-		bool operator() ( const btTypedConstraint* lhs, const btTypedConstraint* rhs ) const
-		{
-			int rIslandId0,lIslandId0;
-			rIslandId0 = btGetConstraintIslandId(rhs);
-			lIslandId0 = btGetConstraintIslandId(lhs);
-			return lIslandId0 < rIslandId0;
-		}
-};
-
 struct InplaceSolverIslandCallback : public btSimulationIslandManager::IslandCallback
 {
 	btContactSolverInfo*	m_solverInfo;
 	btConstraintSolver*		m_solver;
-	btTypedConstraint**		m_sortedConstraints;
-	int						m_numConstraints;
 	btIDebugDraw*			m_debugDrawer;
 	btDispatcher*			m_dispatcher;
-
-	btAlignedObjectArray<btCollisionObject*> m_bodies;
-	btAlignedObjectArray<btPersistentManifold*> m_manifolds;
-	btAlignedObjectArray<btTypedConstraint*> m_constraints;
-
 
 	InplaceSolverIslandCallback(
 		btConstraintSolver*	solver,
@@ -101,8 +69,6 @@ struct InplaceSolverIslandCallback : public btSimulationIslandManager::IslandCal
 		btDispatcher* dispatcher)
 		:m_solverInfo(NULL),
 		m_solver(solver),
-		m_sortedConstraints(NULL),
-		m_numConstraints(0),
 		m_debugDrawer(NULL),
 		m_dispatcher(dispatcher)
 	{
@@ -116,85 +82,34 @@ struct InplaceSolverIslandCallback : public btSimulationIslandManager::IslandCal
 		return *this;
 	}
 
-	SIMD_FORCE_INLINE void setup ( btContactSolverInfo* solverInfo, btTypedConstraint** sortedConstraints,	int	numConstraints,	btIDebugDraw* debugDrawer)
+	SIMD_FORCE_INLINE void setup ( btContactSolverInfo* solverInfo, btIDebugDraw* debugDrawer)
 	{
 		btAssert(solverInfo);
 		m_solverInfo = solverInfo;
-		m_sortedConstraints = sortedConstraints;
-		m_numConstraints = numConstraints;
 		m_debugDrawer = debugDrawer;
-		m_bodies.resize (0);
-		m_manifolds.resize (0);
-		m_constraints.resize (0);
 	}
 
 
-	virtual	void	processIsland(btCollisionObject** bodies,int numBodies,btPersistentManifold**	manifolds,int numManifolds, int islandId)
+	virtual	void	processIsland( btCollisionObject** bodies,
+                                   int numBodies,
+                                   btPersistentManifold** manifolds,
+                                   int numManifolds,
+                                   btTypedConstraint** constraints,
+                                   int numConstraints,
+                                   int islandId
+                                   )
 	{
-		if (islandId<0)
-		{
-			///we don't split islands, so all constraints/contact manifolds/bodies are passed into the solver regardless the island id
-			m_solver->solveGroup( bodies,numBodies,manifolds, numManifolds,&m_sortedConstraints[0],m_numConstraints,*m_solverInfo,m_debugDrawer,m_dispatcher);
-		} else
-		{
-				//also add all non-contact constraints/joints for this island
-			btTypedConstraint** startConstraint = 0;
-			int numCurConstraints = 0;
-			int i;
-
-			//find the first constraint for this island
-			for (i=0;i<m_numConstraints;i++)
-			{
-				if (btGetConstraintIslandId(m_sortedConstraints[i]) == islandId)
-				{
-					startConstraint = &m_sortedConstraints[i];
-					break;
-				}
-			}
-			//count the number of constraints in this island
-			for (;i<m_numConstraints;i++)
-			{
-				if (btGetConstraintIslandId(m_sortedConstraints[i]) == islandId)
-				{
-					numCurConstraints++;
-				}
-			}
-
-			if (m_solverInfo->m_minimumSolverBatchSize<=1)
-			{
-				m_solver->solveGroup( bodies,numBodies,manifolds, numManifolds,startConstraint,numCurConstraints,*m_solverInfo,m_debugDrawer,m_dispatcher);
-			} else
-			{
-
-				for (i=0;i<numBodies;i++)
-					m_bodies.push_back(bodies[i]);
-				for (i=0;i<numManifolds;i++)
-					m_manifolds.push_back(manifolds[i]);
-				for (i=0;i<numCurConstraints;i++)
-					m_constraints.push_back(startConstraint[i]);
-				if ((m_constraints.size()+m_manifolds.size())>m_solverInfo->m_minimumSolverBatchSize)
-				{
-					processConstraints();
-				} else
-				{
-					//printf("deferred\n");
-				}
-			}
-		}
-	}
-	void	processConstraints()
-	{
-
-		btCollisionObject** bodies = m_bodies.size()? &m_bodies[0]:0;
-		btPersistentManifold** manifold = m_manifolds.size()?&m_manifolds[0]:0;
-		btTypedConstraint** constraints = m_constraints.size()?&m_constraints[0]:0;
-
-		m_solver->solveGroup( bodies,m_bodies.size(),manifold, m_manifolds.size(),constraints, m_constraints.size() ,*m_solverInfo,m_debugDrawer,m_dispatcher);
-		m_bodies.resize(0);
-		m_manifolds.resize(0);
-		m_constraints.resize(0);
-
-	}
+        m_solver->solveGroup( bodies,
+                              numBodies,
+                              manifolds,
+                              numManifolds,
+                              constraints,
+                              numConstraints,
+                              *m_solverInfo,
+                              m_debugDrawer,
+                              m_dispatcher
+                              );
+    }
 
 };
 
@@ -227,6 +142,7 @@ m_latencyMotionStateInterpolation(true)
 	{
 		void* mem = btAlignedAlloc(sizeof(btSimulationIslandManager),16);
 		m_islandManager = new (mem) btSimulationIslandManager();
+        m_islandManager->setMinimumSolverBatchSize( m_solverInfo.m_minimumSolverBatchSize );
 	}
 
 	m_ownsIslandManager = true;
@@ -712,28 +628,14 @@ void	btDiscreteDynamicsWorld::solveConstraints(btContactSolverInfo& solverInfo)
 {
 	BT_PROFILE("solveConstraints");
 
-	m_sortedConstraints.resize( m_constraints.size());
-	int i;
-	for (i=0;i<getNumConstraints();i++)
-	{
-		m_sortedConstraints[i] = m_constraints[i];
-	}
 
-//	btAssert(0);
-
-
-
-	m_sortedConstraints.quickSort(btSortConstraintOnIslandPredicate());
-
-	btTypedConstraint** constraintsPtr = getNumConstraints() ? &m_sortedConstraints[0] : 0;
-
-	m_solverIslandCallback->setup(&solverInfo,constraintsPtr,m_sortedConstraints.size(),getDebugDrawer());
+	m_solverIslandCallback->setup(&solverInfo, getDebugDrawer());
 	m_constraintSolver->prepareSolve(getCollisionWorld()->getNumCollisionObjects(), getCollisionWorld()->getDispatcher()->getNumManifolds());
 
 	/// solve all the constraints for this island
-	m_islandManager->buildAndProcessIslands(getCollisionWorld()->getDispatcher(),getCollisionWorld(),m_solverIslandCallback);
+    m_islandManager->buildAndProcessIslands( getCollisionWorld()->getDispatcher(), getCollisionWorld(), m_constraints, m_solverIslandCallback );
 
-	m_solverIslandCallback->processConstraints();
+	//m_solverIslandCallback->processConstraints();
 
 	m_constraintSolver->allSolved(solverInfo, m_debugDrawer);
 }

--- a/src/BulletDynamics/Dynamics/btDiscreteDynamicsWorld.cpp
+++ b/src/BulletDynamics/Dynamics/btDiscreteDynamicsWorld.cpp
@@ -980,7 +980,7 @@ void btDiscreteDynamicsWorld::integrateTransformsInternal( btRigidBody** bodies,
 
 #endif
 
-                        return;
+                        continue;
                     }
                 }
             }

--- a/src/BulletDynamics/Dynamics/btDiscreteDynamicsWorld.h
+++ b/src/BulletDynamics/Dynamics/btDiscreteDynamicsWorld.h
@@ -68,9 +68,11 @@ protected:
 	bool	m_latencyMotionStateInterpolation;
 
 	btAlignedObjectArray<btPersistentManifold*>	m_predictiveManifolds;
+    btMutex m_predictiveManifoldsMutex;
 
 	virtual void	predictUnconstraintMotion(btScalar timeStep);
-	
+
+    void integrateTransformsInternal( btRigidBody** bodies, int numBodies, btScalar timeStep ) const;  // can be called in parallel
 	virtual void	integrateTransforms(btScalar timeStep);
 		
 	virtual void	calculateSimulationIslands();
@@ -85,7 +87,9 @@ protected:
 
 	virtual void	internalSingleStepSimulation( btScalar timeStep);
 
-	void	createPredictiveContacts(btScalar timeStep);
+    void releasePredictiveContacts();
+    void createPredictiveContactsInternal( btRigidBody** bodies, int numBodies, btScalar timeStep );  // can be called in parallel
+    virtual void	createPredictiveContacts( btScalar timeStep );
 
 	virtual void	saveKinematicState(btScalar timeStep);
 

--- a/src/BulletDynamics/MLCPSolvers/btMLCPSolver.cpp
+++ b/src/BulletDynamics/MLCPSolvers/btMLCPSolver.cpp
@@ -216,12 +216,12 @@ void btMLCPSolver::createMLCPFast(const btContactSolverInfo& infoGlobal)
 		jointNodeArray.reserve(2*m_allConstraintPtrArray.size());
 	}
 
-	static btMatrixXu J3;
+    btMatrixXu& J3 = m_scratchJ3;
 	{
 		BT_PROFILE("J3.resize");
 		J3.resize(2*m,8);
 	}
-	static btMatrixXu JinvM3;
+    btMatrixXu& JinvM3 = m_scratchJInvM3;
 	{
 		BT_PROFILE("JinvM3.resize/setZero");
 
@@ -231,7 +231,7 @@ void btMLCPSolver::createMLCPFast(const btContactSolverInfo& infoGlobal)
 	}
 	int cur=0;
 	int rowOffset = 0;
-	static btAlignedObjectArray<int> ofs;
+    btAlignedObjectArray<int>& ofs = m_scratchOfs;
 	{
 		BT_PROFILE("ofs resize");
 		ofs.resize(0);
@@ -490,7 +490,7 @@ void btMLCPSolver::createMLCP(const btContactSolverInfo& infoGlobal)
 		}
 	}
  
-	static btMatrixXu Minv;
+    btMatrixXu& Minv = m_scratchMInv;
 	Minv.resize(6*numBodies,6*numBodies);
 	Minv.setZero();
 	for (int i=0;i<numBodies;i++)
@@ -507,7 +507,7 @@ void btMLCPSolver::createMLCP(const btContactSolverInfo& infoGlobal)
 				setElem(Minv,i*6+3+r,i*6+3+c,orgBody? orgBody->getInvInertiaTensorWorld()[r][c] : 0);
 	}
  
-	static btMatrixXu J;
+    btMatrixXu& J = m_scratchJ;
 	J.resize(numConstraintRows,6*numBodies);
 	J.setZero();
  
@@ -542,10 +542,10 @@ void btMLCPSolver::createMLCP(const btContactSolverInfo& infoGlobal)
 		}
 	}
  
-	static btMatrixXu J_transpose;
+    btMatrixXu& J_transpose = m_scratchJTranspose;
 	J_transpose= J.transpose();
 
-	static btMatrixXu tmp;
+    btMatrixXu& tmp = m_scratchTmp;
 
 	{
 		{

--- a/src/BulletDynamics/MLCPSolvers/btMLCPSolver.h
+++ b/src/BulletDynamics/MLCPSolvers/btMLCPSolver.h
@@ -44,6 +44,17 @@ protected:
 	int m_fallback;
 	btScalar m_cfm;
 
+    /// The following scratch variables are not stateful -- contents are cleared prior to each use.
+    /// They are only cached here to avoid extra memory allocations and deallocations and to ensure
+    /// that multiple instances of the solver can be run in parallel.
+    btMatrixXu m_scratchJ3;
+    btMatrixXu m_scratchJInvM3;
+    btAlignedObjectArray<int> m_scratchOfs;
+    btMatrixXu m_scratchMInv;
+    btMatrixXu m_scratchJ;
+    btMatrixXu m_scratchJTranspose;
+    btMatrixXu m_scratchTmp;
+
 	virtual btScalar solveGroupCacheFriendlySetup(btCollisionObject** bodies, int numBodies, btPersistentManifold** manifoldPtr, int numManifolds,btTypedConstraint** constraints,int numConstraints,const btContactSolverInfo& infoGlobal,btIDebugDraw* debugDrawer);
 	virtual btScalar solveGroupCacheFriendlyIterations(btCollisionObject** bodies ,int numBodies,btPersistentManifold** manifoldPtr, int numManifolds,btTypedConstraint** constraints,int numConstraints,const btContactSolverInfo& infoGlobal,btIDebugDraw* debugDrawer);
 

--- a/src/LinearMath/CMakeLists.txt
+++ b/src/LinearMath/CMakeLists.txt
@@ -11,6 +11,7 @@ SET(LinearMath_SRCS
 	btPolarDecomposition.cpp
 	btQuickprof.cpp
 	btSerializer.cpp
+	btThreads.cpp
 	btVector3.cpp
 )
 
@@ -38,6 +39,7 @@ SET(LinearMath_HDRS
 	btScalar.h
 	btSerializer.h
 	btStackAlloc.h
+	btThreads.h
 	btTransform.h
 	btTransformUtil.h
 	btVector3.h

--- a/src/LinearMath/btAlignedObjectArray.h
+++ b/src/LinearMath/btAlignedObjectArray.h
@@ -324,7 +324,7 @@ protected:
 		{
 			public:
 
-				bool operator() ( const T& a, const T& b )
+				bool operator() ( const T& a, const T& b ) const
 				{
 					return ( a < b );
 				}

--- a/src/LinearMath/btConvexHull.cpp
+++ b/src/LinearMath/btConvexHull.cpp
@@ -87,7 +87,7 @@ btVector3  NormalOf(const btVector3 *vert, const int n);
 btVector3 PlaneLineIntersection(const btPlane &plane, const btVector3 &p0, const btVector3 &p1)
 {
 	// returns the point where the line p0-p1 intersects the plane n&d
-				static btVector3 dif;
+    btVector3 dif;
 		dif = p1-p0;
 				btScalar dn= btDot(plane.normal,dif);
 				btScalar t = -(plane.dist+btDot(plane.normal,p0) )/dn;
@@ -112,7 +112,7 @@ btVector3 TriNormal(const btVector3 &v0, const btVector3 &v1, const btVector3 &v
 
 btScalar DistanceBetweenLines(const btVector3 &ustart, const btVector3 &udir, const btVector3 &vstart, const btVector3 &vdir, btVector3 *upoint, btVector3 *vpoint)
 {
-	static btVector3 cp;
+	btVector3 cp;
 	cp = btCross(udir,vdir).normalized();
 
 	btScalar distu = -btDot(cp,ustart);

--- a/src/LinearMath/btQuickprof.cpp
+++ b/src/LinearMath/btQuickprof.cpp
@@ -17,6 +17,9 @@
 
 #ifndef BT_NO_PROFILE
 
+#if BT_THREADSAFE
+#include "btThreads.h"
+#endif //#if BT_THREADSAFE
 
 static btClock gProfileClock;
 
@@ -455,6 +458,14 @@ unsigned long int			CProfileManager::ResetTime = 0;
  *=============================================================================================*/
 void	CProfileManager::Start_Profile( const char * name )
 {
+#if BT_THREADSAFE
+    // profile system is not designed for profiling multiple threads
+    // disable collection on all but the main thread
+    if ( !btIsMainThread() )
+    {
+        return;
+    }
+#endif //#if BT_THREADSAFE
 	if (name != CurrentNode->Get_Name()) {
 		CurrentNode = CurrentNode->Get_Sub_Node( name );
 	}
@@ -468,7 +479,15 @@ void	CProfileManager::Start_Profile( const char * name )
  *=============================================================================================*/
 void	CProfileManager::Stop_Profile( void )
 {
-	// Return will indicate whether we should back up to our parent (we may
+#if BT_THREADSAFE
+    // profile system is not designed for profiling multiple threads
+    // disable collection on all but the main thread
+    if ( !btIsMainThread() )
+    {
+        return;
+    }
+#endif //#if BT_THREADSAFE
+    // Return will indicate whether we should back up to our parent (we may
 	// be profiling a recursive function)
 	if (CurrentNode->Return()) {
 		CurrentNode = CurrentNode->Get_Parent();

--- a/src/LinearMath/btThreads.cpp
+++ b/src/LinearMath/btThreads.cpp
@@ -1,0 +1,201 @@
+/*
+Copyright (c) 2003-2014 Erwin Coumans  http://bullet.googlecode.com
+
+This software is provided 'as-is', without any express or implied warranty.
+In no event will the authors be held liable for any damages arising from the use of this software.
+Permission is granted to anyone to use this software for any purpose, 
+including commercial applications, and to alter it and redistribute it freely, 
+subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software. If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
+2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
+3. This notice may not be removed or altered from any source distribution.
+*/
+
+
+#include "btThreads.h"
+#include "btVector3.h"
+
+int gThreadsRunningCounter = 0;
+btMutex gThreadsRunningCounterMutex;
+
+void btPushThreadsAreRunning()
+{
+    gThreadsRunningCounterMutex.lock();
+    gThreadsRunningCounter++;
+    gThreadsRunningCounterMutex.unlock();
+}
+
+void btPopThreadsAreRunning()
+{
+    gThreadsRunningCounterMutex.lock();
+    gThreadsRunningCounter--;
+    gThreadsRunningCounterMutex.unlock();
+}
+
+bool btThreadsAreRunning()
+{
+    return gThreadsRunningCounter != 0;
+}
+
+#if BT_THREADSAFE
+
+#if __cplusplus >= 201103L
+
+// for anything claiming full C++11 compliance, use C++11 atomics
+#define USE_CPP11_ATOMICS 1
+
+#elif defined( _MSC_VER ) && _MSC_VER >= 1800
+
+// MSVC 2013 does support C++11 atomics (even if it isn't fully C++11 compliant)
+//#define USE_CPP11_ATOMICS 1
+#define USE_MSVC_INTRINSICS 1 // however the native intrinsics seem to have better performance
+
+#elif defined( _MSC_VER ) && _MSC_VER >= 1600
+
+// some older MSVC versions can use MSVC intrinsics instead
+#define USE_MSVC_INTRINSICS 1
+
+#endif
+
+
+#if USE_CPP11_ATOMICS
+
+#include <atomic>
+#include <thread>
+
+void btMutex::lock()
+{
+    // Lightweight mutex based on atomics and the C++11 memory model.
+    // note: this lock does not sleep the thread.
+    // Using ordinary system-provided mutexes like Windows critical sections was noticeably slower
+    // presumably because when it fails to lock at first it would sleep the thread and trigger costly
+    // context switches.
+    // 
+	std::atomic<unsigned char>* aDest = reinterpret_cast<std::atomic<unsigned char>*>(&mLock);
+    for ( ;; )
+    {
+        unsigned char expected = 0;
+        if ( std::atomic_compare_exchange_weak_explicit( aDest, &expected, (unsigned char)1, std::memory_order_acq_rel, std::memory_order_acquire ) )
+        {
+            break;
+        }
+    }
+}
+
+void btMutex::unlock()
+{
+	std::atomic<unsigned char>* aDest = reinterpret_cast<std::atomic<unsigned char>*>(&mLock);
+    std::atomic_store_explicit( aDest, (unsigned char)0, std::memory_order_release );
+}
+
+bool btMutex::tryLock()
+{
+	std::atomic<unsigned char>* aDest = reinterpret_cast<std::atomic<unsigned char>*>(&mLock);
+    unsigned char expected = 0;
+    return std::atomic_compare_exchange_weak_explicit( aDest, &expected, (unsigned char)1, std::memory_order_acq_rel, std::memory_order_acquire );
+}
+
+std::thread::id gMainThreadId = std::this_thread::get_id();
+
+bool btIsMainThread()
+{
+    return std::this_thread::get_id() == gMainThreadId;
+}
+
+
+#elif USE_MSVC_INTRINSICS
+
+#define WIN32_LEAN_AND_MEAN
+
+#include <windows.h>
+#include <intrin.h>
+
+
+void btMutex::lock()
+{
+    // note: this lock does not sleep the thread
+    volatile char* aDest = reinterpret_cast<char*>( &mLock );
+    for ( ;; )
+    {
+        unsigned char expected = 0;
+        if ( 0 == _InterlockedCompareExchange8( aDest, 1, 0) )
+        {
+            break;
+        }
+    }
+}
+
+void btMutex::unlock()
+{
+    volatile char* aDest = reinterpret_cast<char*>( &mLock );
+    _InterlockedExchange8( aDest, 0 );
+}
+
+bool btMutex::tryLock()
+{
+    volatile char* aDest = reinterpret_cast<char*>( &mLock );
+    return ( 0 == _InterlockedCompareExchange8( aDest, 1, 0) );
+}
+
+DWORD gMainThreadId = GetCurrentThreadId();
+
+bool btIsMainThread()
+{
+    return GetCurrentThreadId() == gMainThreadId;
+}
+
+
+#else //#elif USE_MSVC_INTRINSICS
+
+#error "no threading primitives defined -- unknown platform"
+
+#endif  //#else //#elif USE_MSVC_INTRINSICS
+
+
+void btMutexLockInternal( btMutex* mutex )
+{
+    mutex->lock();
+}
+
+btMutexLockFunc gBtLockFunc = btMutexLockInternal;
+
+void btMutexLock( btMutex* mutex )
+{
+    // call through a user-hookable pointer
+    gBtLockFunc( mutex );
+}
+
+void btMutexUnlock( btMutex* mutex )
+{
+    mutex->unlock();
+}
+
+bool btMutexTryLock( btMutex* mutex )
+{
+    return mutex->tryLock();
+}
+
+void btSetMutexLockFunc( btMutexLockFunc lockFunc )
+{
+    gBtLockFunc = lockFunc;
+}
+
+#else
+
+void btMutex::lock()
+{
+}
+
+void btMutex::unlock()
+{
+}
+
+bool btMutex::tryLock()
+{
+    return true;
+}
+
+#endif //#if BT_THREADSAFE
+
+

--- a/src/LinearMath/btThreads.h
+++ b/src/LinearMath/btThreads.h
@@ -1,0 +1,77 @@
+/*
+Copyright (c) 2003-2014 Erwin Coumans  http://bullet.googlecode.com
+
+This software is provided 'as-is', without any express or implied warranty.
+In no event will the authors be held liable for any damages arising from the use of this software.
+Permission is granted to anyone to use this software for any purpose, 
+including commercial applications, and to alter it and redistribute it freely, 
+subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software. If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
+2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
+3. This notice may not be removed or altered from any source distribution.
+*/
+
+
+
+#ifndef BT_THREADS_H
+#define BT_THREADS_H
+
+//#undef BT_THREADSAFE
+
+#include "btScalar.h" // has definitions like SIMD_FORCE_INLINE
+
+class btMutex
+{
+    unsigned char mLock;  // assumption: bytes are atomic to read and write on all architectures
+
+public:
+    btMutex()
+    {
+        mLock = 0;
+    }
+    void lock();
+    void unlock();
+    bool tryLock();
+};
+
+#if BT_THREADSAFE
+
+// for internal Bullet use only
+void btMutexLock( btMutex* );
+void btMutexUnlock( btMutex* );
+bool btMutexTryLock( btMutex* );
+
+bool btIsMainThread();
+
+#else
+
+// for internal Bullet use only
+// if BT_THREADSAFE is 0, should optimize away to nothing
+SIMD_FORCE_INLINE void btMutexLock( btMutex* ) {}
+SIMD_FORCE_INLINE void btMutexUnlock( btMutex* ) {}
+SIMD_FORCE_INLINE bool btMutexTryLock( btMutex* ) {return true;}
+
+#endif
+
+//
+// btPushThreadsAreRunning()/btPopThreadsAreRunning()
+//
+// [Optional] User may push this just before tasks are started and pop it after tasks have finished
+// to help identify threading bugs in debug builds.  It needs to be push/pop rather than set/clear
+// because of the potential for nested task launching (launching tasks from within a task).
+//
+void btPushThreadsAreRunning();
+void btPopThreadsAreRunning();
+
+bool btThreadsAreRunning();  // useful for debugging and asserts
+
+typedef void( *btMutexLockFunc ) ( btMutex* );
+
+// override the mutex lock function (useful for profiling)
+void btSetMutexLockFunc( btMutexLockFunc lockFunc );
+
+// don't call directly except within an external wrapper function that has hooked the lock function
+void btMutexLockInternal( btMutex* );
+
+#endif //BT_THREADS_H


### PR DESCRIPTION
Adds a multithreading demo to the example browser which uses either OpenMP, Intel TBB or Microsoft PPL to provide task scheduling. (issue #126) Demo allows task scheduler API to be changed on the fly. On my quad-core machine the bullet part of the demo (ignoring rendering, etc) runs about 3 times faster with threading enabled than in single-threaded mode.

Also makes Dvbt rayTest threadsafe (issue #254, #258)
Discussion (here)[http://www.bulletphysics.org/Bullet/phpBB3/viewtopic.php?f=9&t=10232]

Areas that run in parallel:

narrowphase (dispatchAllPairs)
discreteDynamicsWorld solve islands (each island is a separate task)
discreteDynamicsWorld predictUnconstraintMotion
discreteDynamicsWorld createPredictiveContacts
discreteDynamicsWorld integrateTransforms

There were some significant changes to how the btSimulationIslandManager works, so that islands could be dispatched in parallel to different solvers.
Based on an earlier (pull request)[https://github.com/bulletphysics/bullet3/pull/303].
This version has been collapsed into fewer commits and many dead ends were stripped out. All of the previous patch's changes in the sequential impulse constraint solver were dropped, it is simpler and more effective to run islands of constraints in parallel.
