### PR TITLE
 Improve Compound Shape Construction.

### DIFF
--- a/src/BulletCollision/CollisionShapes/btCompoundShape.cpp
+++ b/src/BulletCollision/CollisionShapes/btCompoundShape.cpp
@@ -18,7 +18,7 @@ subject to the following restrictions:
 #include "BulletCollision/BroadphaseCollision/btDbvt.h"
 #include "LinearMath/btSerializer.h"
 
-btCompoundShape::btCompoundShape(bool enableDynamicAabbTree)
+btCompoundShape::btCompoundShape(bool enableDynamicAabbTree, const int initialChildCapacity)
 : m_localAabbMin(btScalar(BT_LARGE_FLOAT),btScalar(BT_LARGE_FLOAT),btScalar(BT_LARGE_FLOAT)),
 m_localAabbMax(btScalar(-BT_LARGE_FLOAT),btScalar(-BT_LARGE_FLOAT),btScalar(-BT_LARGE_FLOAT)),
 m_dynamicAabbTree(0),
@@ -34,6 +34,8 @@ m_localScaling(btScalar(1.),btScalar(1.),btScalar(1.))
 		m_dynamicAabbTree = new(mem) btDbvt();
 		btAssert(mem==m_dynamicAabbTree);
 	}
+
+	m_children.reserve(initialChildCapacity);
 }
 
 

--- a/src/BulletCollision/CollisionShapes/btCompoundShape.h
+++ b/src/BulletCollision/CollisionShapes/btCompoundShape.h
@@ -70,7 +70,7 @@ protected:
 public:
 	BT_DECLARE_ALIGNED_ALLOCATOR();
 
-	btCompoundShape(bool enableDynamicAabbTree = true);
+	explicit btCompoundShape(bool enableDynamicAabbTree = true, const int initialChildCapacity = 0);
 
 	virtual ~btCompoundShape();
 

--- a/src/LinearMath/btAlignedObjectArray.h
+++ b/src/LinearMath/btAlignedObjectArray.h
@@ -202,24 +202,16 @@ protected:
 		///when the new number of elements is smaller, the destructor will be called, but memory will not be freed, to reduce performance overhead of run-time memory (de)allocations.
 		SIMD_FORCE_INLINE	void	resizeNoInitialize(int newsize)
 		{
-			int curSize = size();
-
-			if (newsize < curSize)
+			if (newsize > size())
 			{
-			} else
-			{
-				if (newsize > size())
-				{
-					reserve(newsize);
-				}
-				//leave this uninitialized
+				reserve(newsize);
 			}
 			m_size = newsize;
 		}
 	
 		SIMD_FORCE_INLINE	void	resize(int newsize, const T& fillData=T())
 		{
-			int curSize = size();
+			const register int curSize = size();
 
 			if (newsize < curSize)
 			{
@@ -229,7 +221,7 @@ protected:
 				}
 			} else
 			{
-				if (newsize > size())
+				if (newsize > curSize)
 				{
 					reserve(newsize);
 				}
@@ -246,7 +238,7 @@ protected:
 		}
 		SIMD_FORCE_INLINE	T&  expandNonInitializing( )
 		{	
-			int sz = size();
+			const register int sz = size();
 			if( sz == capacity() )
 			{
 				reserve( allocSize(size()) );
@@ -259,7 +251,7 @@ protected:
 
 		SIMD_FORCE_INLINE	T&  expand( const T& fillValue=T())
 		{	
-			int sz = size();
+			const register int sz = size();
 			if( sz == capacity() )
 			{
 				reserve( allocSize(size()) );
@@ -275,7 +267,7 @@ protected:
 
 		SIMD_FORCE_INLINE	void push_back(const T& _Val)
 		{	
-			int sz = size();
+			const register int sz = size();
 			if( sz == capacity() )
 			{
 				reserve( allocSize(size()) );


### PR DESCRIPTION
If pass children's initial capacity of CompoundShape, we can avoid memory reallocation and copy occured from Array when adding a lot of children. 
Fixed some odd code and removed needless code in Array.(Not All problems, particularly sticked outs.)