### PR TITLE
fix shadowmap crash on some Intel GPUs, see https://github.com/bullet…

### DIFF
--- a/Extras/ConvexDecomposition/premake4.lua
+++ b/Extras/ConvexDecomposition/premake4.lua
@@ -1,7 +1,7 @@
 	project "ConvexDecomposition"
 		
 	kind "StaticLib"
-	targetdir "../../lib"
+	
 	includedirs {".","../../src"}
 	files {
 		"**.cpp",

--- a/Extras/HACD/premake4.lua
+++ b/Extras/HACD/premake4.lua
@@ -1,7 +1,7 @@
 	project "HACD"
 		
 	kind "StaticLib"
-	targetdir "../../lib"
+	
 	includedirs {"."}
 	files {
 		"**.cpp",

--- a/Extras/Serialize/BulletFileLoader/autogenerated/bullet.h
+++ b/Extras/Serialize/BulletFileLoader/autogenerated/bullet.h
@@ -600,23 +600,6 @@ typedef struct bInvalidHandle {
     };
 
 
-// -------------------------------------------------- //
-    class btDynamicsWorldDoubleData
-    {
-    public:
-        btContactSolverInfoDoubleData m_solverInfo;
-        btVector3DoubleData m_gravity;
-    };
-
-
-// -------------------------------------------------- //
-    class btDynamicsWorldFloatData
-    {
-    public:
-        btContactSolverInfoFloatData m_solverInfo;
-        btVector3FloatData m_gravity;
-    };
-
 
 // -------------------------------------------------- //
     class btRigidBodyFloatData
@@ -1134,6 +1117,24 @@ typedef struct bInvalidHandle {
         int m_splitImpulse;
         char m_padding[4];
     };
+
+	// -------------------------------------------------- //
+    class btDynamicsWorldDoubleData
+    {
+    public:
+        btContactSolverInfoDoubleData m_solverInfo;
+        btVector3DoubleData m_gravity;
+    };
+
+
+// -------------------------------------------------- //
+    class btDynamicsWorldFloatData
+    {
+    public:
+        btContactSolverInfoFloatData m_solverInfo;
+        btVector3FloatData m_gravity;
+    };
+
 
 
 // -------------------------------------------------- //

--- a/Extras/Serialize/BulletFileLoader/bFile.cpp
+++ b/Extras/Serialize/BulletFileLoader/bFile.cpp
@@ -187,87 +187,105 @@ bool bFile::ok()
 	return (mFlags &FD_OK)!=0;
 }
 
+void bFile::setFileDNA(int verboseMode, char* dnaBuffer, int dnaLen)
+{
+		mFileDNA = new bDNA();
+	
+		///mFileDNA->init will convert part of DNA file endianness to current CPU endianness if necessary
+		mFileDNA->init((char*)dnaBuffer, dnaLen, (mFlags & FD_ENDIAN_SWAP)!=0);
+		
+		if (verboseMode & FD_VERBOSE_DUMP_DNA_TYPE_DEFINITIONS)
+			mFileDNA->dumpTypeDefinitions();
+}
+
 // ----------------------------------------------------- //
 void bFile::parseInternal(int verboseMode, char* memDna,int memDnaLength)
 {
 	if ( (mFlags &FD_OK) ==0)
 		return;
 
-	char *blenderData = mFileBuffer;
-	bChunkInd dna;
-	dna.oldPtr = 0;
-
-	char *tempBuffer = blenderData;
-	for (int i=0; i<mFileLen; i++)
+	if (mFlags & FD_FILEDNA_IS_MEMDNA)
 	{
-		// looking for the data's starting position
-		// and the start of SDNA decls
+		setFileDNA(verboseMode,memDna,memDnaLength);
+	}
 
-		if (!mDataStart && strncmp(tempBuffer, "REND", 4)==0)
-			mDataStart = i;
+	if (mFileDNA==0)
+	{
+		char *blenderData = mFileBuffer;
+		bChunkInd dna;
+		dna.oldPtr = 0;
 
-		if (strncmp(tempBuffer, "DNA1", 4)==0)
+		char *tempBuffer = blenderData;
+		for (int i=0; i<mFileLen; i++)
 		{
-			// read the DNA1 block and extract SDNA
-			if (getNextBlock(&dna, tempBuffer, mFlags) > 0)
+			// looking for the data's starting position
+			// and the start of SDNA decls
+
+			if (!mDataStart && strncmp(tempBuffer, "REND", 4)==0)
+				mDataStart = i;
+
+			if (strncmp(tempBuffer, "DNA1", 4)==0)
 			{
-				if (strncmp((tempBuffer + ChunkUtils::getOffset(mFlags)), "SDNANAME", 8) ==0) 
-					dna.oldPtr = (tempBuffer + ChunkUtils::getOffset(mFlags));
+				// read the DNA1 block and extract SDNA
+				if (getNextBlock(&dna, tempBuffer, mFlags) > 0)
+				{
+					if (strncmp((tempBuffer + ChunkUtils::getOffset(mFlags)), "SDNANAME", 8) ==0) 
+						dna.oldPtr = (tempBuffer + ChunkUtils::getOffset(mFlags));
+					else dna.oldPtr = 0;
+				}
 				else dna.oldPtr = 0;
-			}
-			else dna.oldPtr = 0;
-		} 
-		// Some Bullet files are missing the DNA1 block
-		// In Blender it's DNA1 + ChunkUtils::getOffset() + SDNA + NAME
-		// In Bullet tests its SDNA + NAME
-		else if (strncmp(tempBuffer, "SDNANAME", 8) ==0)
-		{
-			dna.oldPtr = blenderData + i;
-			dna.len = mFileLen-i;
-
-			// Also no REND block, so exit now.  
-			if (mVersion==276) break;
-		}
-
-        if (mDataStart && dna.oldPtr) break;
-		tempBuffer++;
-	}
-	if (!dna.oldPtr || !dna.len)
-	{
-		//printf("Failed to find DNA1+SDNA pair\n");
-		mFlags &= ~FD_OK;
-		return;
-	}
-
-
-	mFileDNA = new bDNA();
-	
-	
-	///mFileDNA->init will convert part of DNA file endianness to current CPU endianness if necessary
-	mFileDNA->init((char*)dna.oldPtr, dna.len, (mFlags & FD_ENDIAN_SWAP)!=0);
-	
-
-	if (mVersion==276)
-	{
-		int i;
-		for (i=0;i<mFileDNA->getNumNames();i++)
-		{
-			if (strcmp(mFileDNA->getName(i),"int")==0)
+			} 
+			// Some Bullet files are missing the DNA1 block
+			// In Blender it's DNA1 + ChunkUtils::getOffset() + SDNA + NAME
+			// In Bullet tests its SDNA + NAME
+			else if (strncmp(tempBuffer, "SDNANAME", 8) ==0)
 			{
-				mFlags |= FD_BROKEN_DNA;
+				dna.oldPtr = blenderData + i;
+				dna.len = mFileLen-i;
+
+				// Also no REND block, so exit now.  
+				if (mVersion==276) break;
+			}
+
+			if (mDataStart && dna.oldPtr) break;
+			tempBuffer++;
+		}
+		if (!dna.oldPtr || !dna.len)
+		{
+			//printf("Failed to find DNA1+SDNA pair\n");
+			mFlags &= ~FD_OK;
+			return;
+		}
+
+
+		mFileDNA = new bDNA();
+	
+	
+		///mFileDNA->init will convert part of DNA file endianness to current CPU endianness if necessary
+		mFileDNA->init((char*)dna.oldPtr, dna.len, (mFlags & FD_ENDIAN_SWAP)!=0);
+	
+
+		if (mVersion==276)
+		{
+			int i;
+			for (i=0;i<mFileDNA->getNumNames();i++)
+			{
+				if (strcmp(mFileDNA->getName(i),"int")==0)
+				{
+					mFlags |= FD_BROKEN_DNA;
+				}
+			}
+			if ((mFlags&FD_BROKEN_DNA)!=0)
+			{
+				//printf("warning: fixing some broken DNA version\n");
 			}
 		}
-		if ((mFlags&FD_BROKEN_DNA)!=0)
-		{
-			//printf("warning: fixing some broken DNA version\n");
-		}
+
+
+
+		if (verboseMode & FD_VERBOSE_DUMP_DNA_TYPE_DEFINITIONS)
+			mFileDNA->dumpTypeDefinitions();
 	}
-
-
-
-	if (verboseMode & FD_VERBOSE_DUMP_DNA_TYPE_DEFINITIONS)
-		mFileDNA->dumpTypeDefinitions();
-
 	mMemoryDNA = new bDNA();
 	int littleEndian= 1;
 	littleEndian= ((char*)&littleEndian)[0];

--- a/Extras/Serialize/BulletFileLoader/bFile.h
+++ b/Extras/Serialize/BulletFileLoader/bFile.h
@@ -33,7 +33,8 @@ namespace bParse {
 		FD_BITS_VARIES    =16,
 		FD_VERSION_VARIES = 32,
 		FD_DOUBLE_PRECISION =64,
-		FD_BROKEN_DNA = 128
+		FD_BROKEN_DNA = 128,
+		FD_FILEDNA_IS_MEMDNA = 256
 	};
 
 	enum bFileVerboseMode
@@ -106,7 +107,7 @@ namespace bParse {
 		char* readStruct(char *head, class bChunkInd& chunk);
 		char *getAsString(int code);
 
-		void	parseInternal(int verboseMode, char* memDna,int memDnaLength);
+		virtual void	parseInternal(int verboseMode, char* memDna,int memDnaLength);
 
 	public:
 		bFile(const char *filename, const char headerString[7]);
@@ -126,6 +127,11 @@ namespace bParse {
 		int	getFlags() const
 		{
 			return mFlags;
+		}
+
+		void setFileDNAisMemoryDNA()
+		{
+			mFlags |= FD_FILEDNA_IS_MEMDNA;
 		}
 
 		bPtrMap&		getLibPointers()
@@ -150,6 +156,8 @@ namespace bParse {
 
 		void	dumpChunks(bDNA* dna);
 		
+		virtual void setFileDNA(int verboseMode, char* buffer, int len);
+
 		int		getVersion() const
 		{
 			return mVersion;
@@ -157,6 +165,8 @@ namespace bParse {
 		//pre-swap the endianness, so that data loaded on a target with different endianness doesn't need to be swapped
 		void preSwap();
 		void writeFile(const char* fileName);
+
+
 
 	};
 }

--- a/Extras/Serialize/BulletFileLoader/btBulletFile.cpp
+++ b/Extras/Serialize/BulletFileLoader/btBulletFile.cpp
@@ -123,7 +123,11 @@ void btBulletFile::parseData()
 	//const bool swap = (mFlags&FD_ENDIAN_SWAP)!=0;
 	
 
+	int remain = mFileLen;
+
 	mDataStart = 12;
+	remain-=12;
+	
 
 	char *dataPtr = mFileBuffer+mDataStart;
 
@@ -167,6 +171,11 @@ void btBulletFile::parseData()
 					//bListBasePtr *listID = mMain->getListBasePtr(dataChunk.code);
 					//if (listID)
 					//	listID->push_back((bStructHandle*)id);
+				}
+
+				if (dataChunk.code == BT_MULTIBODY_CODE)
+				{
+					m_multiBodies.push_back((bStructHandle*)id);
 				}
 
 				if (dataChunk.code == BT_SOFTBODY_CODE)
@@ -226,6 +235,9 @@ void btBulletFile::parseData()
 
 		
 		dataPtr += seek;
+		remain-=seek;
+		if (remain<=0)
+			break;
 
 		seek =  getNextBlock(&dataChunk, dataPtr, mFlags);
 		if (mFlags &FD_ENDIAN_SWAP) 
@@ -421,3 +433,4 @@ void	btBulletFile::addStruct(const	char* structType,void* data, int len, void* o
 	mLibPointers.insert(dataChunk.oldPtr, (bStructHandle*)data);
 	m_chunks.push_back(dataChunk);
 }
+

--- a/Extras/Serialize/BulletFileLoader/btBulletFile.h
+++ b/Extras/Serialize/BulletFileLoader/btBulletFile.h
@@ -21,6 +21,7 @@ subject to the following restrictions:
 #include "LinearMath/btAlignedObjectArray.h"
 #include "bDefines.h"
 
+
 #include "LinearMath/btSerializer.h"
 
 
@@ -37,6 +38,8 @@ namespace bParse {
 		char*	m_DnaCopy;
 				
 	public:
+
+		btAlignedObjectArray<bStructHandle*>	m_multiBodies;
 
 		btAlignedObjectArray<bStructHandle*>	m_softBodies;
 
@@ -65,7 +68,7 @@ namespace bParse {
 
 		virtual	void	addDataBlock(char* dataBlock);
 	
-
+		
 		// experimental
 		virtual int		write(const char* fileName, bool fixupPointers=false);
 

--- a/Extras/Serialize/BulletFileLoader/premake4.lua
+++ b/Extras/Serialize/BulletFileLoader/premake4.lua
@@ -1,7 +1,7 @@
 	project "BulletFileLoader"
 		
 	kind "StaticLib"
-	targetdir "../../lib"
+	
 	includedirs {
 		"../../../src"
 	}

--- a/Extras/Serialize/BulletWorldImporter/premake4.lua
+++ b/Extras/Serialize/BulletWorldImporter/premake4.lua
@@ -1,7 +1,7 @@
 	project "BulletWorldImporter"
 		
 	kind "StaticLib"
-	targetdir "../../lib"
+	
 	includedirs {
 		"../BulletFileLoader",
 		"../../../src"

--- a/Extras/Serialize/makesdna/makesdna.cpp
+++ b/Extras/Serialize/makesdna/makesdna.cpp
@@ -188,6 +188,7 @@ char *includefiles[] = {
 	"../../../src/BulletCollision/Gimpact/btGImpactShape.h",
 	"../../../src/BulletCollision/CollisionShapes/btConvexHullShape.h",
 	"../../../src/BulletCollision/CollisionDispatch/btCollisionObject.h",
+	"../../../src/BulletDynamics/ConstraintSolver/btContactSolverInfo.h",
 	"../../../src/BulletDynamics/Dynamics/btDynamicsWorld.h",
 	"../../../src/BulletDynamics/Dynamics/btRigidBody.h",
 	"../../../src/BulletDynamics/ConstraintSolver/btTypedConstraint.h",
@@ -199,7 +200,7 @@ char *includefiles[] = {
 	"../../../src/BulletDynamics/ConstraintSolver/btGeneric6DofSpring2Constraint.h",
 	"../../../src/BulletDynamics/ConstraintSolver/btSliderConstraint.h",
 	"../../../src/BulletDynamics/ConstraintSolver/btGearConstraint.h",
-	"../../../src/BulletDynamics/ConstraintSolver/btContactSolverInfo.h",
+	
 	"../../../src/BulletSoftBody/btSoftBodyData.h",
 	"../../../src/BulletDynamics/Featherstone/btMultiBody.h",
 	// empty string to indicate end of includefiles

--- a/build3/premake4.lua
+++ b/build3/premake4.lua
@@ -129,7 +129,7 @@
 -- comment-out for now, URDF reader needs exceptions
 --	flags { "NoRTTI", "NoExceptions"}
 --	defines { "_HAS_EXCEPTIONS=0" }
-	targetdir "../binserver"
+	targetdir "../bin"
 	location("./" .. act .. postfix)
 
 

--- a/build3/premake4.lua
+++ b/build3/premake4.lua
@@ -129,7 +129,7 @@
 -- comment-out for now, URDF reader needs exceptions
 --	flags { "NoRTTI", "NoExceptions"}
 --	defines { "_HAS_EXCEPTIONS=0" }
-	targetdir "../bin"
+	targetdir "../binserver"
 	location("./" .. act .. postfix)
 
 

--- a/examples/SharedMemory/PhysicsClient.cpp
+++ b/examples/SharedMemory/PhysicsClient.cpp
@@ -7,6 +7,7 @@
 #include "SharedMemoryCommon.h"
 #include "../CommonInterfaces/CommonParameterInterface.h"
 #include "../Utils/b3ResourcePath.h"
+#include "../Extras/Serialize/BulletFileLoader/btBulletFile.h"
 
 class PhysicsClient : public SharedMemoryCommon
 {
@@ -181,6 +182,57 @@ void	PhysicsClient::processServerCommands()
 			{
 				m_serverLoadUrdfOK = true;
 				b3Printf("Server loading the URDF OK\n");
+
+				if (serverCmd.m_dataStreamArguments.m_streamChunkLength>0)
+					{
+						bParse::btBulletFile* bf = new bParse::btBulletFile(this->m_testBlock1->m_bulletStreamDataServerToClient,serverCmd.m_dataStreamArguments.m_streamChunkLength);
+						bf->setFileDNAisMemoryDNA();
+						bf->parse(false);
+						for (int i=0;i<bf->m_multiBodies.size();i++)
+						{
+							int flag = bf->getFlags();
+
+							if ((flag&bParse::FD_DOUBLE_PRECISION)!=0)
+							{
+								btMultiBodyDoubleData* mb = (btMultiBodyDoubleData*)bf->m_multiBodies[i];
+								if (mb->m_baseName)
+								{
+									b3Printf("mb->m_baseName = %s\n",mb->m_baseName);
+								}
+								for (int link=0;link<mb->m_numLinks;link++)
+								{
+									if (mb->m_links[link].m_linkName)
+									{
+										b3Printf("mb->m_links[%d].m_linkName = %s\n",link,mb->m_links[link].m_linkName);
+									}
+									if (mb->m_links[link].m_jointName)
+									{
+										b3Printf("mb->m_links[%d].m_jointName = %s\n",link,mb->m_links[link].m_jointName);
+									}
+								}
+							} else
+							{
+								btMultiBodyFloatData* mb = (btMultiBodyFloatData*) bf->m_multiBodies[i];
+								if (mb->m_baseName)
+								{
+									b3Printf("mb->m_baseName = %s\n",mb->m_baseName);
+								}
+								for (int link=0;link<mb->m_numLinks;link++)
+								{
+									if (mb->m_links[link].m_linkName)
+									{
+										b3Printf("mb->m_links[%d].m_linkName = %s\n",link,mb->m_links[link].m_linkName);
+									}
+									b3Printf("link [%d] type = %d",link, mb->m_links[link].m_jointType);
+									if (mb->m_links[link].m_jointName)
+									{
+										b3Printf("mb->m_links[%d].m_jointName = %s\n",link,mb->m_links[link].m_jointName);
+									}
+								}
+							}
+						}
+						printf("ok!\n");
+					}
 				break;
 			}
 			case CMD_STEP_FORWARD_SIMULATION_COMPLETED:
@@ -196,10 +248,17 @@ void	PhysicsClient::processServerCommands()
 
 			case CMD_BULLET_DATA_STREAM_RECEIVED_COMPLETED:
 				{
+					b3Printf("Server received bullet data stream OK\n");
+
+					
+
+
 					break;
 				}
 			case CMD_BULLET_DATA_STREAM_RECEIVED_FAILED:
 				{
+					b3Printf("Server failed receiving bullet data stream\n");
+
 					break;
 				}
                     

--- a/src/Bullet3Collision/premake4.lua
+++ b/src/Bullet3Collision/premake4.lua
@@ -5,7 +5,7 @@
 	kind "StaticLib"
 		
 	includedirs {".."}
-	targetdir "../../bin"
+
 
 	files {
 		"**.cpp",

--- a/src/Bullet3Dynamics/premake4.lua
+++ b/src/Bullet3Dynamics/premake4.lua
@@ -7,7 +7,7 @@
 	includedirs {
 		".."
 	}		
-	targetdir "../../bin"
+	
 
 	files {
 		"**.cpp",

--- a/src/Bullet3Geometry/premake4.lua
+++ b/src/Bullet3Geometry/premake4.lua
@@ -5,7 +5,7 @@
 	kind "StaticLib"
 		
 	includedirs {".."}
-	targetdir "../../bin"
+	
 
 	files {
 		"**.cpp",

--- a/src/Bullet3OpenCL/premake4.lua
+++ b/src/Bullet3OpenCL/premake4.lua
@@ -9,7 +9,7 @@ function createProject(vendor)
 			
 		kind "StaticLib"
 		
-		targetdir "../../lib"
+		
 		includedirs {
 			".",".."
 		}

--- a/src/Bullet3Serialize/Bullet2FileLoader/premake4.lua
+++ b/src/Bullet3Serialize/Bullet2FileLoader/premake4.lua
@@ -1,7 +1,7 @@
 	project "Bullet2FileLoader"
 		
 	kind "StaticLib"
-	targetdir "../../../lib"
+	
 	includedirs {
 		"../../../src"
 	}

--- a/src/BulletDynamics/Featherstone/btMultiBody.cpp
+++ b/src/BulletDynamics/Featherstone/btMultiBody.cpp
@@ -2447,8 +2447,7 @@ const char*	btMultiBody::serialize(void* dataBuffer, class btSerializer* seriali
 			}
 		}
 		mbd->m_numLinks = this->getNumLinks();
-		mbd->m_links = mbd->m_numLinks? (btMultiBodyLinkData*) serializer->getUniquePointer((void*)&m_links[0]):0;
-		if (mbd->m_links)
+		if (mbd->m_numLinks)
 		{
 			int sz = sizeof(btMultiBodyLinkData);
 			int numElem = mbd->m_numLinks;
@@ -2503,6 +2502,7 @@ const char*	btMultiBody::serialize(void* dataBuffer, class btSerializer* seriali
 			}
 			serializer->finalizeChunk(chunk,btMultiBodyLinkDataName,BT_ARRAY_CODE,(void*) &m_links[0]);
 		}
-		
+		mbd->m_links = mbd->m_numLinks? (btMultiBodyLinkData*) serializer->getUniquePointer((void*)&m_links[0]):0;
+
 		return btMultiBodyDataName;
 }

--- a/src/BulletSoftBody/premake4.lua
+++ b/src/BulletSoftBody/premake4.lua
@@ -1,7 +1,7 @@
 	project "BulletSoftBody"
 		
 	kind "StaticLib"
-	targetdir "../../lib"
+	
 	includedirs {
 		"..",
 	}

--- a/src/LinearMath/btSerializer.h
+++ b/src/LinearMath/btSerializer.h
@@ -174,6 +174,7 @@ protected:
 	btAlignedObjectArray<short>			mTlens;
 	btHashMap<btHashInt, int>			mStructReverse;
 	btHashMap<btHashString,int>	mTypeLookup;
+	
 
 
 	btHashMap<btHashPtr,void*>	m_chunkP;
@@ -185,6 +186,7 @@ protected:
 
 	int					m_totalSize;
 	unsigned char*		m_buffer;
+	bool                m_ownsBuffer;
 	int					m_currentSize;
 	void*				m_dna;
 	int					m_dnaLength;
@@ -196,6 +198,7 @@ protected:
 
 protected:
 
+	
 	virtual	void*	findPointer(void* oldPtr)
 	{
 		void** ptr = m_chunkP.find(oldPtr);
@@ -384,17 +387,25 @@ protected:
 
 public:
 
+	btHashMap<btHashPtr,void*> m_skipPointers;
 
 
-
-		btDefaultSerializer(int totalSize=0)
+		btDefaultSerializer(int totalSize=0, unsigned char*	buffer=0)
 			:m_totalSize(totalSize),
 			m_currentSize(0),
 			m_dna(0),
 			m_dnaLength(0),
 			m_serializationFlags(0)
 		{
-			m_buffer = m_totalSize?(unsigned char*)btAlignedAlloc(totalSize,16):0;
+		    if (buffer==0)
+            {
+                m_buffer = m_totalSize?(unsigned char*)btAlignedAlloc(totalSize,16):0;
+                m_ownsBuffer = true;
+            } else
+            {
+                m_buffer = buffer;
+                m_ownsBuffer = false;
+            }
 
 			const bool VOID_IS_8 = ((sizeof(void*)==8));
 
@@ -429,10 +440,16 @@ public:
 
 		virtual ~btDefaultSerializer()
 		{
-			if (m_buffer)
+			if (m_buffer && m_ownsBuffer)
 				btAlignedFree(m_buffer);
 			if (m_dna)
 				btAlignedFree(m_dna);
+		}
+
+		void	insertHeader()
+		{
+			writeHeader(m_buffer);
+			m_currentSize += BT_HEADER_LENGTH;
 		}
 
 		void	writeHeader(unsigned char* buffer) const
@@ -515,6 +532,7 @@ public:
 			mTlens.clear();
 			mStructReverse.clear();
 			mTypeLookup.clear();
+			m_skipPointers.clear();
 			m_chunkP.clear();
 			m_nameMap.clear();
 			m_uniquePointers.clear();
@@ -531,6 +549,13 @@ public:
 			{
 				return uptr->m_ptr;
 			}
+
+			void** ptr2 = m_skipPointers[oldPtr];
+            if (ptr2)
+			{
+				return 0;
+			}
+
 			m_uniqueIdGenerator++;
 
 			btPointerUid uid;
@@ -684,10 +709,15 @@ struct btInMemorySerializer : public btDefaultSerializer
     btHashMap<btHashPtr,btChunk*> m_uid2ChunkPtr;
     btHashMap<btHashPtr,void*> m_orgPtr2UniqueDataPtr;
     btHashMap<btHashString,const void*> m_names2Ptr;
-    btHashMap<btHashPtr,void*> m_skipPointers;
+    
 
     btBulletSerializedArrays    m_arrays;
 
+    btInMemorySerializer(int totalSize=0, unsigned char*	buffer=0)
+    :btDefaultSerializer(totalSize,buffer)
+    {
+        
+    }
 
     virtual void startSerialization()
     {
@@ -695,6 +725,8 @@ struct btInMemorySerializer : public btDefaultSerializer
         //todo: m_arrays.clear();
         btDefaultSerializer::startSerialization();
     }
+
+    
 
     btChunk* findChunkFromUniquePointer(void* uniquePointer)
     {

--- a/test/Bullet2/premake4.lua
+++ b/test/Bullet2/premake4.lua
@@ -7,7 +7,7 @@ else
 	kind "ConsoleApp"
 end
 
-targetdir "../../bin"
+
 
 includedirs {"../../src","Source", "Source/Tests"}
 

--- a/test/GwenOpenGLTest/premake4.lua
+++ b/test/GwenOpenGLTest/premake4.lua
@@ -7,7 +7,7 @@
 	defines { "GWEN_COMPILE_STATIC" , "_HAS_EXCEPTIONS=0", "_STATIC_CPPLIB" }
 	defines { "DONT_USE_GLUT"}
 	
-	targetdir "../../bin"
+	
 	
 	includedirs 
 	{

--- a/test/OpenCL/BasicInitialize/premake4.lua
+++ b/test/OpenCL/BasicInitialize/premake4.lua
@@ -12,7 +12,7 @@ function createProject(vendor)
 				
 		
 		kind "ConsoleApp"
-		targetdir "../../../bin"
+		
 
 		includedirs {"../../../src"}
 		

--- a/test/OpenCL/KernelLaunch/premake4.lua
+++ b/test/OpenCL/KernelLaunch/premake4.lua
@@ -12,7 +12,7 @@ function createProject(vendor)
 				
 		
 		kind "ConsoleApp"
-		targetdir "../../../bin"
+		
 
 		includedirs {"../../../src"}
 		

--- a/test/OpenCL/ParallelPrimitives/premake4.lua
+++ b/test/OpenCL/ParallelPrimitives/premake4.lua
@@ -10,7 +10,7 @@ function createProject(vendor)
 		language "C++"
 				
 		kind "ConsoleApp"
-		targetdir "../../../bin"
+		
 		includedirs {".","../../../src"}
 		
 		

--- a/test/OpenCL/RadixSortBenchmark/premake4.lua
+++ b/test/OpenCL/RadixSortBenchmark/premake4.lua
@@ -10,7 +10,7 @@ function createProject(vendor)
 		language "C++"
 				
 		kind "ConsoleApp"
-		targetdir "../../../bin"
+		
 		includedirs {"..","../../../src"}
 		
 --		links {

--- a/test/TestBullet3OpenCL/premake4.lua
+++ b/test/TestBullet3OpenCL/premake4.lua
@@ -12,7 +12,7 @@ function createProject(vendor)
 	end
 	
 	
-	targetdir "../../bin"
+	
 	
 	initOpenCL(vendor)
 	

--- a/test/b3DynamicBvhBroadphase/premake4.lua
+++ b/test/b3DynamicBvhBroadphase/premake4.lua
@@ -5,7 +5,7 @@ project ("Test_b3DynamicBvhBroadphase_test")
 	language "C++"
 			
 	kind "ConsoleApp"
-	targetdir "../../bin"
+	
 	includedirs {"../../src"}
 	
 	links {"Bullet3Common", "Bullet3Collision"}		

--- a/test/clew/premake4.lua
+++ b/test/clew/premake4.lua
@@ -5,7 +5,7 @@ project ("Test_clew")
 	language "C++"
 			
 	kind "ConsoleApp"
-	targetdir "../../bin"
+	
 	includedirs {"../../src/clew"}
 	
 	if os.is("Windows") then 

--- a/test/collision/premake4.lua
+++ b/test/collision/premake4.lua
@@ -5,7 +5,7 @@
 	
 --	defines {  }
 	
---	targetdir "../../bin"
+
 	
 	includedirs 
 	{

--- a/test/enet/client/premake4.lua
+++ b/test/enet/client/premake4.lua
@@ -5,7 +5,7 @@ project ("Test_enet_client")
 	language "C++"
 			
 	kind "ConsoleApp"
-	targetdir "../../../bin"
+	
 	includedirs {"../../../examples/ThirdPartyLibs/enet/include"}
 	
 	if os.is("Windows") then 

--- a/test/enet/server/premake4.lua
+++ b/test/enet/server/premake4.lua
@@ -5,7 +5,7 @@ project ("Test_enet_server")
 	language "C++"
 			
 	kind "ConsoleApp"
-	targetdir "../../../bin"
+	
 	includedirs {"../../../examples/ThirdPartyLibs/enet/include"}
 	
 	if os.is("Windows") then 

--- a/test/gtest-1.7.0/premake4.lua
+++ b/test/gtest-1.7.0/premake4.lua
@@ -11,7 +11,7 @@
 		defines {"_VARIADIC_MAX=10"}
 	end
 	
-	--targetdir "../../lib"	
+	
 
 	includedirs {
 		".","include"


### PR DESCRIPTION
…physics/bullet3/issues/4

remove targetdir from all libraries in premake, so it is much easier to create a separate folder for all binary+lib
transmit the serialized btMultiBody data back from server to client, after the server loads a URDF file. This includes base+link+joint names
tweak the serialization routines, so it is easier to skip pointers and to serialize directly to a shared memory buffer
also tweak the serialization code to allow to process data without 'DNA' schema data (assuming file-DNA = memory DNA)