### PR TITLE
Make btCompoundShape data members protected instead of private

### DIFF
--- a/src/BulletCollision/CollisionShapes/btCompoundShape.h
+++ b/src/BulletCollision/CollisionShapes/btCompoundShape.h
@@ -53,6 +53,7 @@ SIMD_FORCE_INLINE bool operator==(const btCompoundShapeChild& c1, const btCompou
 /// Currently, removal of child shapes is only supported when disabling the aabb tree (pass 'false' in the constructor of btCompoundShape)
 ATTRIBUTE_ALIGNED16(class) btCompoundShape	: public btCollisionShape
 {
+protected:
 	btAlignedObjectArray<btCompoundShapeChild> m_children;
 	btVector3						m_localAabbMin;
 	btVector3						m_localAabbMax;
@@ -64,7 +65,6 @@ ATTRIBUTE_ALIGNED16(class) btCompoundShape	: public btCollisionShape
 
 	btScalar	m_collisionMargin;
 
-protected:
 	btVector3	m_localScaling;
 
 public:


### PR DESCRIPTION
Without risk the data members of btCompoundShape can be made protected, thereby allowing derived classes to change them directly.

While it is true some data members are already exposed for modification via getDataMember() methods (such as btCompoundShape::getChildShape() and getDynamicAabbTree()) not all of them are exposed (such as btCompound::m_updateRevision).