### PR TITLE
Make installation of generated CMake files optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -286,7 +286,12 @@ configure_file ( ${CMAKE_CURRENT_SOURCE_DIR}/BulletConfig.cmake.in
                  ${CMAKE_CURRENT_BINARY_DIR}/BulletConfig.cmake
                  @ONLY ESCAPE_QUOTES
                )
-install ( FILES ${CMAKE_CURRENT_SOURCE_DIR}/UseBullet.cmake
-                ${CMAKE_CURRENT_BINARY_DIR}/BulletConfig.cmake
-          DESTINATION ${BULLET_CONFIG_CMAKE_PATH}
-        )
+
+OPTION(INSTALL_CMAKE_FILES "Install generated CMake files" ON)
+
+IF (INSTALL_CMAKE_FILES)
+   install ( FILES ${CMAKE_CURRENT_SOURCE_DIR}/UseBullet.cmake
+                   ${CMAKE_CURRENT_BINARY_DIR}/BulletConfig.cmake
+             DESTINATION ${BULLET_CONFIG_CMAKE_PATH}
+           )
+ENDIF (INSTALL_CMAKE_FILES)


### PR DESCRIPTION
When bullet is used as a subproject, installation of the generated CMake files is not always desired. This change makes it optional (enabled by default).
