### PR TITLE
Fix the Bullet Raycast sample. Closes #450.

### DIFF
--- a/examples/Raycast/RaytestDemo.cpp
+++ b/examples/Raycast/RaytestDemo.cpp
@@ -126,7 +126,7 @@ void RaytestDemo::castRays()
 			btCollisionWorld::ClosestRayResultCallback	closestResults(from,to);
 			closestResults.m_flags |= btTriangleRaycastCallback::kF_FilterBackfaces;
 			
-
+			m_dynamicsWorld->rayTest(from,to,closestResults);
 
 			if (closestResults.hasHit())
 			{


### PR DESCRIPTION
This closes #450.

The first hit example is missing a

`m_dynamicsWorld->rayTest(from,to,closestResults);`

so instead of


			btVector3 from(-30,1.2,0);
			btVector3 to(30,1.2,0);
			m_dynamicsWorld->getDebugDrawer()->drawLine(from,to,btVector4(0,0,1,1));

			btCollisionWorld::ClosestRayResultCallback	closestResults(from,to);
			closestResults.m_flags |= btTriangleRaycastCallback::kF_FilterBackfaces;
			
			if (closestResults.hasHit())
			{
				
				btVector3 p = from.lerp(to,closestResults.m_closestHitFraction);
				m_dynamicsWorld->getDebugDrawer()->drawSphere(p,0.1,blue);
				m_dynamicsWorld->getDebugDrawer()->drawLine(p,p+closestResults.m_hitNormalWorld,blue);

			}


it should be


			btVector3 from(-30,1.2,0);
			btVector3 to(30,1.2,0);
			m_dynamicsWorld->getDebugDrawer()->drawLine(from,to,btVector4(0,0,1,1));

			btCollisionWorld::ClosestRayResultCallback	closestResults(from,to);
			closestResults.m_flags |= btTriangleRaycastCallback::kF_FilterBackfaces;
			
			m_dynamicsWorld->rayTest(from,to,closestResults);

			if (closestResults.hasHit())
			{
				
				btVector3 p = from.lerp(to,closestResults.m_closestHitFraction);
				m_dynamicsWorld->getDebugDrawer()->drawSphere(p,0.1,blue);
				m_dynamicsWorld->getDebugDrawer()->drawLine(p,p+closestResults.m_hitNormalWorld,blue);

			}
It is missing here:
https://github.com/bulletphysics/bullet3/blob/master/examples/Raycast/RaytestDemo.cpp