### PR TITLE
Run tests on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,10 @@ script:
   - cmake . -G "Unix Makefiles" -DBUILD_SHARED_LIBS=ON
   - make -j8
   - sudo make install
+  - git clean -d -x -ff .
+  - cd build3
+  - case "$TRAVIS_OS_NAME" in linux) ./premake4_linux64 gmake;; osx) ./premake4_osx gmake;; esac
+  - cd gmake
+  - make
+  - cd ../..
+  - S=0; for T in $(ls bin/Test_* | grep -v '^bin/Test_Gwen_OpenGL'); do echo "Running test '$T'..."; "./$T"; SS=$?; echo "Test '$T' exited with status '$SS'"; [ $S -eq 0 ] && S=$SS; done; exit $S


### PR DESCRIPTION
clang on Linux reports false negative i.e. Travis CI reports passed but test actually fails miserably.

```
$ make

==== Building gwen (release64) ====

Creating ../../bin

Creating obj/x64/Release/gwen

glew.c

inputhandler.cpp

events.cpp

Utility.cpp

ToolTip.cpp

Skin.cpp

In file included from ../../examples/ThirdPartyLibs/Gwen/Skin.cpp:9:

In file included from /usr/include/math.h:427:

/usr/include/x86_64-linux-gnu/bits/math-finite.h:177:1: error: unknown type name

      '__extern_always_inline'

__extern_always_inline double __NTH (lgamma (double __d))

^
...
18 errors generated.

make[1]: *** [obj/x64/Release/gwen/Skin.o] Error 1

make: *** [gwen] Error 2

The command "make" exited with 2.
```