### PR TITLE
add_missing_stdio_h

### DIFF
--- a/src/LinearMath/btMatrixX.h
+++ b/src/LinearMath/btMatrixX.h
@@ -19,6 +19,7 @@ subject to the following restrictions:
 
 #include "LinearMath/btQuickprof.h"
 #include "LinearMath/btAlignedObjectArray.h"
+#include <stdio.h>
 
 //#define BT_DEBUG_OSTREAM
 #ifdef BT_DEBUG_OSTREAM


### PR DESCRIPTION
Add missing <stdio.h> include in src/LinearMath/btMatrixX.h for printf() access. (missing in Emscripten/musl libc builds otherwise)