### PR TITLE
SSE support for SIMD.js and some micro-optimizations.

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -35,5 +35,6 @@ Marten Svanfeldt
 Pierre Terdiman
 Steven Thompson
 Tamas Umenhoffer
+Jukka Jylänki
 
 If your name is missing, please send an email to erwin.coumans@gmail.com or file an issue at http://github.com/bulletphysics/bullet3

--- a/src/Bullet3Common/b3Matrix3x3.h
+++ b/src/Bullet3Common/b3Matrix3x3.h
@@ -237,7 +237,7 @@ public:
 		Y = b3CastiTo128f(_mm_shuffle_epi32 (NQi, B3_SHUFFLE(3,2,0,3)));	// -W -Z -X -W
 		Z = b3CastiTo128f(_mm_shuffle_epi32 (Qi, B3_SHUFFLE(1,0,1,3)));	//  Y  X  Y  W
 
-		vs = _mm_load_ss(&s);
+		vs = _mm_set_ss(s);
 		V21 = V21 * Y;
 		V31 = V31 * Z;
 
@@ -853,7 +853,7 @@ B3_FORCE_INLINE b3Matrix3x3
 operator*(const b3Matrix3x3& m, const b3Scalar & k)
 {
 #if (defined (B3_USE_SSE_IN_API) && defined (B3_USE_SSE))
-    __m128 vk = b3_splat_ps(_mm_load_ss((float *)&k), 0x80);
+    __m128 vk = b3_splat_ps(_mm_set_ss(k), 0x80);
     return b3Matrix3x3(
                 _mm_mul_ps(m[0].mVec128, vk), 
                 _mm_mul_ps(m[1].mVec128, vk), 

--- a/src/Bullet3Common/b3Quaternion.h
+++ b/src/Bullet3Common/b3Quaternion.h
@@ -185,7 +185,7 @@ public:
 	b3Quaternion& operator*=(const b3Scalar& s)
 	{
 #if defined (B3_USE_SSE_IN_API) && defined (B3_USE_SSE)
-		__m128	vs = _mm_load_ss(&s);	//	(S 0 0 0)
+		__m128	vs = _mm_set_ss(s);	//	(S 0 0 0)
 		vs = b3_pshufd_ps(vs, 0);	//	(S S S S)
 		mVec128 = _mm_mul_ps(mVec128, vs);
 #elif defined(B3_USE_NEON)
@@ -354,7 +354,7 @@ public:
 	operator*(const b3Scalar& s) const
 	{
 #if defined (B3_USE_SSE_IN_API) && defined (B3_USE_SSE)
-		__m128	vs = _mm_load_ss(&s);	//	(S 0 0 0)
+		__m128	vs = _mm_set_ss(s);	//	(S 0 0 0)
 		vs = b3_pshufd_ps(vs, 0x00);	//	(S S S S)
 		
 		return b3Quaternion(_mm_mul_ps(mVec128, vs));

--- a/src/Bullet3Common/b3Vector3.h
+++ b/src/Bullet3Common/b3Vector3.h
@@ -171,7 +171,7 @@ public:
 	B3_FORCE_INLINE b3Vector3& operator*=(const b3Scalar& s)
 	{
 #if defined(B3_USE_SSE_IN_API) && defined (B3_USE_SSE)
-		__m128	vs = _mm_load_ss(&s);	//	(S 0 0 0)
+		__m128	vs = _mm_set_ss(s);	//	(S 0 0 0)
 		vs = b3_pshufd_ps(vs, 0x80);	//	(S S S 0.0)
 		mVec128 = _mm_mul_ps(mVec128, vs);
 #elif defined(B3_USE_NEON)
@@ -192,7 +192,7 @@ public:
 
 #if 0 //defined(B3_USE_SSE_IN_API)
 // this code is not faster !
-		__m128 vs = _mm_load_ss(&s);
+		__m128 vs = _mm_set_ss(s);
 		vs = _mm_div_ss(b3v1110, vs);
 		vs = b3_pshufd_ps(vs, 0x00);	//	(S S S S)
 
@@ -455,9 +455,9 @@ public:
 	B3_FORCE_INLINE void setInterpolate3(const b3Vector3& v0, const b3Vector3& v1, b3Scalar rt)
 	{
 #if defined(B3_USE_SSE_IN_API) && defined (B3_USE_SSE)
-		__m128	vrt = _mm_load_ss(&rt);	//	(rt 0 0 0)
+		__m128	vrt = _mm_set_ss(rt);	//	(rt 0 0 0)
 		b3Scalar s = b3Scalar(1.0) - rt;
-		__m128	vs = _mm_load_ss(&s);	//	(S 0 0 0)
+		__m128	vs = _mm_set_ss(s);	//	(S 0 0 0)
 		vs = b3_pshufd_ps(vs, 0x80);	//	(S S S 0.0)
 		__m128 r0 = _mm_mul_ps(v0.mVec128, vs);
 		vrt = b3_pshufd_ps(vrt, 0x80);	//	(rt rt rt 0.0)
@@ -484,7 +484,7 @@ public:
 	B3_FORCE_INLINE b3Vector3 lerp(const b3Vector3& v, const b3Scalar& t) const
 	{
 #if defined(B3_USE_SSE_IN_API) && defined (B3_USE_SSE)
-		__m128	vt = _mm_load_ss(&t);	//	(t 0 0 0)
+		__m128	vt = _mm_set_ss(t);	//	(t 0 0 0)
 		vt = b3_pshufd_ps(vt, 0x80);	//	(rt rt rt 0.0)
 		__m128 vl = _mm_sub_ps(v.mVec128, mVec128);
 		vl = _mm_mul_ps(vl, vt);
@@ -777,7 +777,7 @@ B3_FORCE_INLINE b3Vector3
 operator*(const b3Vector3& v, const b3Scalar& s)
 {
 #if defined(B3_USE_SSE_IN_API) && defined (B3_USE_SSE)
-	__m128	vs = _mm_load_ss(&s);	//	(S 0 0 0)
+	__m128	vs = _mm_set_ss(s);	//	(S 0 0 0)
 	vs = b3_pshufd_ps(vs, 0x80);	//	(S S S 0.0)
 	return b3MakeVector3(_mm_mul_ps(v.mVec128, vs));
 #elif defined(B3_USE_NEON)
@@ -802,7 +802,7 @@ operator/(const b3Vector3& v, const b3Scalar& s)
 	b3FullAssert(s != b3Scalar(0.0));
 #if 0 //defined(B3_USE_SSE_IN_API)
 // this code is not faster !
-	__m128 vs = _mm_load_ss(&s);
+	__m128 vs = _mm_set_ss(s);
     vs = _mm_div_ss(b3v1110, vs);
 	vs = b3_pshufd_ps(vs, 0x00);	//	(S S S S)
 
@@ -930,8 +930,8 @@ B3_FORCE_INLINE b3Vector3 b3Vector3::rotate( const b3Vector3& wAxis, const b3Sca
 	O = _mm_and_ps(O, b3vFFF0fMask);
     b3Scalar scos = b3Cos( _angle );
 
-	__m128 vsin = _mm_load_ss(&ssin);	//	(S 0 0 0)
-    __m128 vcos = _mm_load_ss(&scos);	//	(S 0 0 0)
+	__m128 vsin = _mm_set_ss(ssin);	//	(S 0 0 0)
+    __m128 vcos = _mm_set_ss(scos);	//	(S 0 0 0)
 
 	__m128 Y = b3_pshufd_ps(O, 0xC9);	//	(Y Z X 0)
 	__m128 Z = b3_pshufd_ps(O, 0xD2);	//	(Z X Y 0)

--- a/src/BulletCollision/BroadphaseCollision/btDbvt.h
+++ b/src/BulletCollision/BroadphaseCollision/btDbvt.h
@@ -521,8 +521,8 @@ DBVT_INLINE bool		Intersect(	const btDbvtAabbMm& a,
 								  const btDbvtAabbMm& b)
 {
 #if	DBVT_INT0_IMPL == DBVT_IMPL_SSE
-	const __m128	rt(_mm_or_ps(	_mm_cmplt_ps(_mm_load_ps(b.mx),_mm_load_ps(a.mi)),
-		_mm_cmplt_ps(_mm_load_ps(a.mx),_mm_load_ps(b.mi))));
+	const __m128	rt(_mm_or_ps(	_mm_cmplt_ps(b.mx.mVec128, a.mi.mVec128),
+		_mm_cmplt_ps(a.mx.mVec128, b.mi.mVec128)));
 #if defined (_WIN32)
 	const __int32*	pu((const __int32*)&rt);
 #else
@@ -592,27 +592,19 @@ DBVT_INLINE int			Select(	const btDbvtAabbMm& o,
 	   int			ints[4];
 	};
 
-	__m128	omi(_mm_load_ps(o.mi));
-	omi=_mm_add_ps(omi,_mm_load_ps(o.mx));
-	__m128	ami(_mm_load_ps(a.mi));
-	ami=_mm_add_ps(ami,_mm_load_ps(a.mx));
-	ami=_mm_sub_ps(ami,omi);
-	ami=_mm_and_ps(ami,_mm_load_ps((const float*)mask));
-	__m128	bmi(_mm_load_ps(b.mi));
-	bmi=_mm_add_ps(bmi,_mm_load_ps(b.mx));
-	bmi=_mm_sub_ps(bmi,omi);
-	bmi=_mm_and_ps(bmi,_mm_load_ps((const float*)mask));
-	__m128	t0(_mm_movehl_ps(ami,ami));
-	ami=_mm_add_ps(ami,t0);
-	ami=_mm_add_ss(ami,_mm_shuffle_ps(ami,ami,1));
-	__m128 t1(_mm_movehl_ps(bmi,bmi));
-	bmi=_mm_add_ps(bmi,t1);
-	bmi=_mm_add_ss(bmi,_mm_shuffle_ps(bmi,bmi,1));
-	
-	btSSEUnion tmp;
-	tmp.ssereg = _mm_cmple_ss(bmi,ami);
-	return tmp.ints[0]&1;
-
+	const __m128 mmask = _mm_castsi128_ps(_mm_set1_epi32(0x7FFFFFFF));
+	__m128 omi = _mm_add_ps(o.mi.mVec128, o.mx.mVec128);
+	__m128 ami = _mm_add_ps(a.mi.mVec128, a.mx.mVec128);
+	ami = _mm_sub_ps(ami, omi);
+	ami = _mm_and_ps(ami, mmask);
+	__m128	bmi = _mm_add_ps(b.mi.mVec128, b.mx.mVec128);
+	bmi = _mm_sub_ps(bmi, omi);
+	bmi = _mm_and_ps(bmi, mmask);
+	bmi = _mm_sub_ps(bmi, ami);
+	__m128 z = _mm_movehl_ps(bmi, bmi);
+	__m128 y = _mm_shuffle_ps(bmi, bmi, 1);
+	bmi = _mm_add_ss(y, _mm_add_ss(bmi, z));
+	return _mm_cvtss_f32(bmi) <= 0.f;
 #else
 	ATTRIBUTE_ALIGNED16(__int32	r[1]);
 	__asm

--- a/src/BulletDynamics/ConstraintSolver/btSequentialImpulseConstraintSolver.cpp
+++ b/src/BulletDynamics/ConstraintSolver/btSequentialImpulseConstraintSolver.cpp
@@ -148,35 +148,34 @@ static inline __m128 btSimdDot3( __m128 vec0, __m128 vec1 )
 #endif
 #endif
 
+#define sum_xyz_ps(a) _mm_add_ss(_mm_add_ss((a), _mm_shuffle_ps((a), (a), _MM_SHUFFLE(1, 1, 1, 1))), _mm_movehl_ps((a), (a)))
+#define xxxw_ps(a) _mm_shuffle_ps((a), (a), _MM_SHUFFLE(3, 0, 0, 0))
+
 // Project Gauss Seidel or the equivalent Sequential Impulse
 static btSimdScalar gResolveSingleConstraintRowGeneric_sse2(btSolverBody& body1, btSolverBody& body2, const btSolverConstraint& c)
 {
-	__m128 cpAppliedImp = _mm_set1_ps(c.m_appliedImpulse);
-	__m128	lowerLimit1 = _mm_set1_ps(c.m_lowerLimit);
-	__m128	upperLimit1 = _mm_set1_ps(c.m_upperLimit);
-	btSimdScalar deltaImpulse = _mm_sub_ps(_mm_set1_ps(c.m_rhs), _mm_mul_ps(_mm_set1_ps(c.m_appliedImpulse), _mm_set1_ps(c.m_cfm)));
-	__m128 deltaVel1Dotn = _mm_add_ps(btSimdDot3(c.m_contactNormal1.mVec128, body1.internalGetDeltaLinearVelocity().mVec128), btSimdDot3(c.m_relpos1CrossNormal.mVec128, body1.internalGetDeltaAngularVelocity().mVec128));
-	__m128 deltaVel2Dotn = _mm_add_ps(btSimdDot3(c.m_contactNormal2.mVec128, body2.internalGetDeltaLinearVelocity().mVec128), btSimdDot3(c.m_relpos2CrossNormal.mVec128, body2.internalGetDeltaAngularVelocity().mVec128));
-	deltaImpulse = _mm_sub_ps(deltaImpulse, _mm_mul_ps(deltaVel1Dotn, _mm_set1_ps(c.m_jacDiagABInv)));
-	deltaImpulse = _mm_sub_ps(deltaImpulse, _mm_mul_ps(deltaVel2Dotn, _mm_set1_ps(c.m_jacDiagABInv)));
-	btSimdScalar sum = _mm_add_ps(cpAppliedImp, deltaImpulse);
-	btSimdScalar resultLowerLess, resultUpperLess;
-	resultLowerLess = _mm_cmplt_ps(sum, lowerLimit1);
-	resultUpperLess = _mm_cmplt_ps(sum, upperLimit1);
-	__m128 lowMinApplied = _mm_sub_ps(lowerLimit1, cpAppliedImp);
-	deltaImpulse = _mm_or_ps(_mm_and_ps(resultLowerLess, lowMinApplied), _mm_andnot_ps(resultLowerLess, deltaImpulse));
-	c.m_appliedImpulse = _mm_or_ps(_mm_and_ps(resultLowerLess, lowerLimit1), _mm_andnot_ps(resultLowerLess, sum));
-	__m128 upperMinApplied = _mm_sub_ps(upperLimit1, cpAppliedImp);
-	deltaImpulse = _mm_or_ps(_mm_and_ps(resultUpperLess, deltaImpulse), _mm_andnot_ps(resultUpperLess, upperMinApplied));
-	c.m_appliedImpulse = _mm_or_ps(_mm_and_ps(resultUpperLess, c.m_appliedImpulse), _mm_andnot_ps(resultUpperLess, upperLimit1));
-	__m128	linearComponentA = _mm_mul_ps(c.m_contactNormal1.mVec128, body1.internalGetInvMass().mVec128);
-	__m128	linearComponentB = _mm_mul_ps((c.m_contactNormal2).mVec128, body2.internalGetInvMass().mVec128);
-	__m128 impulseMagnitude = deltaImpulse;
-	body1.internalGetDeltaLinearVelocity().mVec128 = _mm_add_ps(body1.internalGetDeltaLinearVelocity().mVec128, _mm_mul_ps(linearComponentA, impulseMagnitude));
-	body1.internalGetDeltaAngularVelocity().mVec128 = _mm_add_ps(body1.internalGetDeltaAngularVelocity().mVec128, _mm_mul_ps(c.m_angularComponentA.mVec128, impulseMagnitude));
-	body2.internalGetDeltaLinearVelocity().mVec128 = _mm_add_ps(body2.internalGetDeltaLinearVelocity().mVec128, _mm_mul_ps(linearComponentB, impulseMagnitude));
-	body2.internalGetDeltaAngularVelocity().mVec128 = _mm_add_ps(body2.internalGetDeltaAngularVelocity().mVec128, _mm_mul_ps(c.m_angularComponentB.mVec128, impulseMagnitude));
+// Explicitly use SSE2 versions for multiply-add instructions in this function.
+#define mnadd_ss(a, b, c) _mm_sub_ss((c), _mm_mul_ss((a), (b)))
+#define madd_ps(a, b, c) _mm_add_ps((c), _mm_mul_ps((a), (b)))
+	__m128 appliedImpulse = c.m_appliedImpulse;
+	__m128 deltaImpulse = mnadd_ss(appliedImpulse, _mm_set_ss(c.m_cfm), _mm_set_ss(c.m_rhs));
+	__m128 m1 = _mm_mul_ps(c.m_contactNormal1.mVec128, body1.internalGetDeltaLinearVelocity().mVec128);
+	m1 = madd_ps(c.m_relpos1CrossNormal.mVec128, body1.internalGetDeltaAngularVelocity().mVec128, m1);
+	m1 = madd_ps(c.m_contactNormal2.mVec128, body2.internalGetDeltaLinearVelocity().mVec128, m1);
+	m1 = madd_ps(c.m_relpos2CrossNormal.mVec128, body2.internalGetDeltaAngularVelocity().mVec128, m1);
+	m1 = sum_xyz_ps(m1);
+	deltaImpulse = mnadd_ss(m1, _mm_set_ss(c.m_jacDiagABInv), deltaImpulse);
+	__m128 newAppliedImpulse = _mm_min_ss(_mm_set_ss(c.m_upperLimit), _mm_max_ss(_mm_set_ss(c.m_lowerLimit), _mm_add_ss(appliedImpulse, deltaImpulse)));
+	deltaImpulse = _mm_sub_ss(newAppliedImpulse, appliedImpulse);
+	deltaImpulse = xxxw_ps(deltaImpulse);
+	c.m_appliedImpulse = xxxw_ps(newAppliedImpulse);
+	body1.m_deltaLinearVelocity.mVec128 = madd_ps(_mm_mul_ps(c.m_contactNormal1.mVec128, body1.internalGetInvMass().mVec128), _mm_mul_ps(deltaImpulse, body1.m_linearFactor.mVec128), body1.m_deltaLinearVelocity.mVec128);
+	body1.m_deltaAngularVelocity.mVec128 = madd_ps(c.m_angularComponentA.mVec128, _mm_mul_ps(deltaImpulse, body1.m_angularFactor.mVec128), body1.m_deltaAngularVelocity.mVec128);
+	body2.m_deltaLinearVelocity.mVec128 = madd_ps(_mm_mul_ps(c.m_contactNormal2.mVec128, body2.internalGetInvMass().mVec128), _mm_mul_ps(deltaImpulse, body2.m_linearFactor.mVec128), body2.m_deltaLinearVelocity.mVec128);
+	body2.m_deltaAngularVelocity.mVec128 = madd_ps(c.m_angularComponentB.mVec128, _mm_mul_ps(deltaImpulse, body2.m_angularFactor.mVec128), body2.m_deltaAngularVelocity.mVec128);
 	return deltaImpulse;
+#undef mnadd_ss
+#undef madd_ps
 }
 
 
@@ -184,24 +183,27 @@ static btSimdScalar gResolveSingleConstraintRowGeneric_sse2(btSolverBody& body1,
 static btSimdScalar gResolveSingleConstraintRowGeneric_sse4_1_fma3(btSolverBody& body1, btSolverBody& body2, const btSolverConstraint& c)
 {
 #if defined (BT_ALLOW_SSE4)
-	__m128 tmp					= _mm_set_ps1(c.m_jacDiagABInv);
-	__m128 deltaImpulse			= _mm_set_ps1(c.m_rhs - btScalar(c.m_appliedImpulse)*c.m_cfm);
-	const __m128 lowerLimit		= _mm_set_ps1(c.m_lowerLimit);
-	const __m128 upperLimit		= _mm_set_ps1(c.m_upperLimit);
-	const __m128 deltaVel1Dotn	= _mm_add_ps(DOT_PRODUCT(c.m_contactNormal1.mVec128, body1.internalGetDeltaLinearVelocity().mVec128), DOT_PRODUCT(c.m_relpos1CrossNormal.mVec128, body1.internalGetDeltaAngularVelocity().mVec128));
-	const __m128 deltaVel2Dotn	= _mm_add_ps(DOT_PRODUCT(c.m_contactNormal2.mVec128, body2.internalGetDeltaLinearVelocity().mVec128), DOT_PRODUCT(c.m_relpos2CrossNormal.mVec128, body2.internalGetDeltaAngularVelocity().mVec128));
-	deltaImpulse				= FMNADD(deltaVel1Dotn, tmp, deltaImpulse);
-	deltaImpulse				= FMNADD(deltaVel2Dotn, tmp, deltaImpulse);
-	tmp							= _mm_add_ps(c.m_appliedImpulse, deltaImpulse); // sum
-	const __m128 maskLower		= _mm_cmpgt_ps(tmp, lowerLimit);
-	const __m128 maskUpper		= _mm_cmpgt_ps(upperLimit, tmp);
-	deltaImpulse				= _mm_blendv_ps(_mm_sub_ps(lowerLimit, c.m_appliedImpulse), _mm_blendv_ps(_mm_sub_ps(upperLimit, c.m_appliedImpulse), deltaImpulse, maskUpper), maskLower);
-	c.m_appliedImpulse			= _mm_blendv_ps(lowerLimit, _mm_blendv_ps(upperLimit, tmp, maskUpper), maskLower);
-	body1.internalGetDeltaLinearVelocity().mVec128	= FMADD(_mm_mul_ps(c.m_contactNormal1.mVec128, body1.internalGetInvMass().mVec128), deltaImpulse, body1.internalGetDeltaLinearVelocity().mVec128);
-	body1.internalGetDeltaAngularVelocity().mVec128 = FMADD(c.m_angularComponentA.mVec128, deltaImpulse, body1.internalGetDeltaAngularVelocity().mVec128);
-	body2.internalGetDeltaLinearVelocity().mVec128	= FMADD(_mm_mul_ps(c.m_contactNormal2.mVec128, body2.internalGetInvMass().mVec128), deltaImpulse, body2.internalGetDeltaLinearVelocity().mVec128);
-	body2.internalGetDeltaAngularVelocity().mVec128 = FMADD(c.m_angularComponentB.mVec128, deltaImpulse, body2.internalGetDeltaAngularVelocity().mVec128);
+#define mnadd_ss(a, b, c) FMNADD((a), (b), (c))
+#define madd_ps(a, b, c) FMADD((a), (b), (c))
+	__m128 appliedImpulse = c.m_appliedImpulse;
+	__m128 deltaImpulse = mnadd_ss(appliedImpulse, _mm_set_ss(c.m_cfm), _mm_set_ss(c.m_rhs));
+	__m128 m1 = _mm_mul_ps(c.m_contactNormal1.mVec128, body1.internalGetDeltaLinearVelocity().mVec128);
+	m1 = madd_ps(c.m_relpos1CrossNormal.mVec128, body1.internalGetDeltaAngularVelocity().mVec128, m1);
+	m1 = madd_ps(c.m_contactNormal2.mVec128, body2.internalGetDeltaLinearVelocity().mVec128, m1);
+	m1 = madd_ps(c.m_relpos2CrossNormal.mVec128, body2.internalGetDeltaAngularVelocity().mVec128, m1);
+	m1 = sum_xyz_ps(m1);
+	deltaImpulse = mnadd_ss(m1, _mm_set_ss(c.m_jacDiagABInv), deltaImpulse);
+	__m128 newAppliedImpulse = _mm_min_ss(_mm_set_ss(c.m_upperLimit), _mm_max_ss(_mm_set_ss(c.m_lowerLimit), _mm_add_ss(appliedImpulse, deltaImpulse)));
+	deltaImpulse = _mm_sub_ss(newAppliedImpulse, appliedImpulse);
+	deltaImpulse = xxxw_ps(deltaImpulse);
+	c.m_appliedImpulse = xxxw_ps(newAppliedImpulse);
+	body1.m_deltaLinearVelocity.mVec128 = madd_ps(_mm_mul_ps(c.m_contactNormal1.mVec128, body1.internalGetInvMass().mVec128), _mm_mul_ps(deltaImpulse, body1.m_linearFactor.mVec128), body1.m_deltaLinearVelocity.mVec128);
+	body1.m_deltaAngularVelocity.mVec128 = madd_ps(c.m_angularComponentA.mVec128, _mm_mul_ps(deltaImpulse, body1.m_angularFactor.mVec128), body1.m_deltaAngularVelocity.mVec128);
+	body2.m_deltaLinearVelocity.mVec128 = madd_ps(_mm_mul_ps(c.m_contactNormal2.mVec128, body2.internalGetInvMass().mVec128), _mm_mul_ps(deltaImpulse, body2.m_linearFactor.mVec128), body2.m_deltaLinearVelocity.mVec128);
+	body2.m_deltaAngularVelocity.mVec128 = madd_ps(c.m_angularComponentB.mVec128, _mm_mul_ps(deltaImpulse, body2.m_angularFactor.mVec128), body2.m_deltaAngularVelocity.mVec128);
 	return deltaImpulse;
+#undef mnadd_ss
+#undef madd_ps
 #else
 	return gResolveSingleConstraintRowGeneric_sse2(body1,body2,c);
 #endif
@@ -211,29 +213,28 @@ static btSimdScalar gResolveSingleConstraintRowGeneric_sse4_1_fma3(btSolverBody&
 
 static btSimdScalar gResolveSingleConstraintRowLowerLimit_sse2(btSolverBody& body1, btSolverBody& body2, const btSolverConstraint& c)
 {
-	__m128 cpAppliedImp = _mm_set1_ps(c.m_appliedImpulse);
-	__m128	lowerLimit1 = _mm_set1_ps(c.m_lowerLimit);
-	__m128	upperLimit1 = _mm_set1_ps(c.m_upperLimit);
-	btSimdScalar deltaImpulse = _mm_sub_ps(_mm_set1_ps(c.m_rhs), _mm_mul_ps(_mm_set1_ps(c.m_appliedImpulse), _mm_set1_ps(c.m_cfm)));
-	__m128 deltaVel1Dotn = _mm_add_ps(btSimdDot3(c.m_contactNormal1.mVec128, body1.internalGetDeltaLinearVelocity().mVec128), btSimdDot3(c.m_relpos1CrossNormal.mVec128, body1.internalGetDeltaAngularVelocity().mVec128));
-	__m128 deltaVel2Dotn = _mm_add_ps(btSimdDot3(c.m_contactNormal2.mVec128, body2.internalGetDeltaLinearVelocity().mVec128), btSimdDot3(c.m_relpos2CrossNormal.mVec128, body2.internalGetDeltaAngularVelocity().mVec128));
-	deltaImpulse = _mm_sub_ps(deltaImpulse, _mm_mul_ps(deltaVel1Dotn, _mm_set1_ps(c.m_jacDiagABInv)));
-	deltaImpulse = _mm_sub_ps(deltaImpulse, _mm_mul_ps(deltaVel2Dotn, _mm_set1_ps(c.m_jacDiagABInv)));
-	btSimdScalar sum = _mm_add_ps(cpAppliedImp, deltaImpulse);
-	btSimdScalar resultLowerLess, resultUpperLess;
-	resultLowerLess = _mm_cmplt_ps(sum, lowerLimit1);
-	resultUpperLess = _mm_cmplt_ps(sum, upperLimit1);
-	__m128 lowMinApplied = _mm_sub_ps(lowerLimit1, cpAppliedImp);
-	deltaImpulse = _mm_or_ps(_mm_and_ps(resultLowerLess, lowMinApplied), _mm_andnot_ps(resultLowerLess, deltaImpulse));
-	c.m_appliedImpulse = _mm_or_ps(_mm_and_ps(resultLowerLess, lowerLimit1), _mm_andnot_ps(resultLowerLess, sum));
-	__m128	linearComponentA = _mm_mul_ps(c.m_contactNormal1.mVec128, body1.internalGetInvMass().mVec128);
-	__m128	linearComponentB = _mm_mul_ps(c.m_contactNormal2.mVec128, body2.internalGetInvMass().mVec128);
-	__m128 impulseMagnitude = deltaImpulse;
-	body1.internalGetDeltaLinearVelocity().mVec128 = _mm_add_ps(body1.internalGetDeltaLinearVelocity().mVec128, _mm_mul_ps(linearComponentA, impulseMagnitude));
-	body1.internalGetDeltaAngularVelocity().mVec128 = _mm_add_ps(body1.internalGetDeltaAngularVelocity().mVec128, _mm_mul_ps(c.m_angularComponentA.mVec128, impulseMagnitude));
-	body2.internalGetDeltaLinearVelocity().mVec128 = _mm_add_ps(body2.internalGetDeltaLinearVelocity().mVec128, _mm_mul_ps(linearComponentB, impulseMagnitude));
-	body2.internalGetDeltaAngularVelocity().mVec128 = _mm_add_ps(body2.internalGetDeltaAngularVelocity().mVec128, _mm_mul_ps(c.m_angularComponentB.mVec128, impulseMagnitude));
+	// Explicitly use SSE2 versions for multiply-add instructions in this function.
+#define mnadd_ss(a, b, c) _mm_sub_ss((c), _mm_mul_ss((a), (b)))
+#define madd_ps(a, b, c) _mm_add_ps((c), _mm_mul_ps((a), (b)))
+	__m128 appliedImpulse = c.m_appliedImpulse;
+	__m128 deltaImpulse = mnadd_ss(appliedImpulse, _mm_set_ss(c.m_cfm), _mm_set_ss(c.m_rhs));
+	__m128 m1 = _mm_mul_ps(c.m_contactNormal1.mVec128, body1.internalGetDeltaLinearVelocity().mVec128);
+	m1 = madd_ps(c.m_relpos1CrossNormal.mVec128, body1.internalGetDeltaAngularVelocity().mVec128, m1);
+	m1 = madd_ps(c.m_contactNormal2.mVec128, body2.internalGetDeltaLinearVelocity().mVec128, m1);
+	m1 = madd_ps(c.m_relpos2CrossNormal.mVec128, body2.internalGetDeltaAngularVelocity().mVec128, m1);
+	m1 = sum_xyz_ps(m1);
+	deltaImpulse = mnadd_ss(m1, _mm_set_ss(c.m_jacDiagABInv), deltaImpulse);
+	__m128 newAppliedImpulse = _mm_max_ss(_mm_set_ss(c.m_lowerLimit), _mm_add_ss(appliedImpulse, deltaImpulse));
+	deltaImpulse = _mm_sub_ss(newAppliedImpulse, appliedImpulse);
+	deltaImpulse = xxxw_ps(deltaImpulse);
+	c.m_appliedImpulse = xxxw_ps(newAppliedImpulse);
+	body1.m_deltaLinearVelocity.mVec128 = madd_ps(_mm_mul_ps(c.m_contactNormal1.mVec128, body1.internalGetInvMass().mVec128), _mm_mul_ps(deltaImpulse, body1.m_linearFactor.mVec128), body1.m_deltaLinearVelocity.mVec128);
+	body1.m_deltaAngularVelocity.mVec128 = madd_ps(c.m_angularComponentA.mVec128, _mm_mul_ps(deltaImpulse, body1.m_angularFactor.mVec128), body1.m_deltaAngularVelocity.mVec128);
+	body2.m_deltaLinearVelocity.mVec128 = madd_ps(_mm_mul_ps(c.m_contactNormal2.mVec128, body2.internalGetInvMass().mVec128), _mm_mul_ps(deltaImpulse, body2.m_linearFactor.mVec128), body2.m_deltaLinearVelocity.mVec128);
+	body2.m_deltaAngularVelocity.mVec128 = madd_ps(c.m_angularComponentB.mVec128, _mm_mul_ps(deltaImpulse, body2.m_angularFactor.mVec128), body2.m_deltaAngularVelocity.mVec128);
 	return deltaImpulse;
+#undef mnadd_ss
+#undef madd_ps
 }
 
 
@@ -241,22 +242,27 @@ static btSimdScalar gResolveSingleConstraintRowLowerLimit_sse2(btSolverBody& bod
 static btSimdScalar gResolveSingleConstraintRowLowerLimit_sse4_1_fma3(btSolverBody& body1, btSolverBody& body2, const btSolverConstraint& c)
 {
 #ifdef BT_ALLOW_SSE4
-	__m128 tmp					= _mm_set_ps1(c.m_jacDiagABInv);
-	__m128 deltaImpulse			= _mm_set_ps1(c.m_rhs - btScalar(c.m_appliedImpulse)*c.m_cfm);
-	const __m128 lowerLimit		= _mm_set_ps1(c.m_lowerLimit);
-	const __m128 deltaVel1Dotn	= _mm_add_ps(DOT_PRODUCT(c.m_contactNormal1.mVec128, body1.internalGetDeltaLinearVelocity().mVec128), DOT_PRODUCT(c.m_relpos1CrossNormal.mVec128, body1.internalGetDeltaAngularVelocity().mVec128));
-	const __m128 deltaVel2Dotn	= _mm_add_ps(DOT_PRODUCT(c.m_contactNormal2.mVec128, body2.internalGetDeltaLinearVelocity().mVec128), DOT_PRODUCT(c.m_relpos2CrossNormal.mVec128, body2.internalGetDeltaAngularVelocity().mVec128));
-	deltaImpulse				= FMNADD(deltaVel1Dotn, tmp, deltaImpulse);
-	deltaImpulse				= FMNADD(deltaVel2Dotn, tmp, deltaImpulse);
-	tmp							= _mm_add_ps(c.m_appliedImpulse, deltaImpulse);
-	const __m128 mask			= _mm_cmpgt_ps(tmp, lowerLimit);
-	deltaImpulse				= _mm_blendv_ps(_mm_sub_ps(lowerLimit, c.m_appliedImpulse), deltaImpulse, mask);
-	c.m_appliedImpulse			= _mm_blendv_ps(lowerLimit, tmp, mask);
-	body1.internalGetDeltaLinearVelocity().mVec128	= FMADD(_mm_mul_ps(c.m_contactNormal1.mVec128, body1.internalGetInvMass().mVec128), deltaImpulse, body1.internalGetDeltaLinearVelocity().mVec128);
-	body1.internalGetDeltaAngularVelocity().mVec128 = FMADD(c.m_angularComponentA.mVec128, deltaImpulse, body1.internalGetDeltaAngularVelocity().mVec128);
-	body2.internalGetDeltaLinearVelocity().mVec128	= FMADD(_mm_mul_ps(c.m_contactNormal2.mVec128, body2.internalGetInvMass().mVec128), deltaImpulse, body2.internalGetDeltaLinearVelocity().mVec128);
-	body2.internalGetDeltaAngularVelocity().mVec128 = FMADD(c.m_angularComponentB.mVec128, deltaImpulse, body2.internalGetDeltaAngularVelocity().mVec128);
+#define mnadd_ss(a, b, c) FMNADD((a), (b), (c))
+#define madd_ps(a, b, c) FMADD((a), (b), (c))
+	__m128 appliedImpulse = c.m_appliedImpulse;
+	__m128 deltaImpulse = mnadd_ss(appliedImpulse, _mm_set_ss(c.m_cfm), _mm_set_ss(c.m_rhs));
+	__m128 m1 = _mm_mul_ps(c.m_contactNormal1.mVec128, body1.internalGetDeltaLinearVelocity().mVec128);
+	m1 = madd_ps(c.m_relpos1CrossNormal.mVec128, body1.internalGetDeltaAngularVelocity().mVec128, m1);
+	m1 = madd_ps(c.m_contactNormal2.mVec128, body2.internalGetDeltaLinearVelocity().mVec128, m1);
+	m1 = madd_ps(c.m_relpos2CrossNormal.mVec128, body2.internalGetDeltaAngularVelocity().mVec128, m1);
+	m1 = sum_xyz_ps(m1);
+	deltaImpulse = mnadd_ss(m1, _mm_set_ss(c.m_jacDiagABInv), deltaImpulse);
+	__m128 newAppliedImpulse = _mm_max_ss(_mm_set_ss(c.m_lowerLimit), _mm_add_ss(appliedImpulse, deltaImpulse));
+	deltaImpulse = _mm_sub_ss(newAppliedImpulse, appliedImpulse);
+	deltaImpulse = xxxw_ps(deltaImpulse);
+	c.m_appliedImpulse = xxxw_ps(newAppliedImpulse);
+	body1.m_deltaLinearVelocity.mVec128 = madd_ps(_mm_mul_ps(c.m_contactNormal1.mVec128, body1.internalGetInvMass().mVec128), _mm_mul_ps(deltaImpulse, body1.m_linearFactor.mVec128), body1.m_deltaLinearVelocity.mVec128);
+	body1.m_deltaAngularVelocity.mVec128 = madd_ps(c.m_angularComponentA.mVec128, _mm_mul_ps(deltaImpulse, body1.m_angularFactor.mVec128), body1.m_deltaAngularVelocity.mVec128);
+	body2.m_deltaLinearVelocity.mVec128 = madd_ps(_mm_mul_ps(c.m_contactNormal2.mVec128, body2.internalGetInvMass().mVec128), _mm_mul_ps(deltaImpulse, body2.m_linearFactor.mVec128), body2.m_deltaLinearVelocity.mVec128);
+	body2.m_deltaAngularVelocity.mVec128 = madd_ps(c.m_angularComponentB.mVec128, _mm_mul_ps(deltaImpulse, body2.m_angularFactor.mVec128), body2.m_deltaAngularVelocity.mVec128);
 	return deltaImpulse;
+#undef mnadd_ss
+#undef madd_ps
 #else
 	return gResolveSingleConstraintRowLowerLimit_sse2(body1,body2,c);
 #endif //BT_ALLOW_SSE4

--- a/src/LinearMath/btMatrix3x3.h
+++ b/src/LinearMath/btMatrix3x3.h
@@ -242,7 +242,7 @@ public:
 		Y = btCastiTo128f(_mm_shuffle_epi32 (NQi, BT_SHUFFLE(3,2,0,3)));	// -W -Z -X -W
 		Z = btCastiTo128f(_mm_shuffle_epi32 (Qi, BT_SHUFFLE(1,0,1,3)));	//  Y  X  Y  W
 
-		vs = _mm_load_ss(&s);
+		vs = _mm_set_ss(s);
 		V21 = V21 * Y;
 		V31 = V31 * Z;
 

--- a/src/LinearMath/btMatrix3x3.h
+++ b/src/LinearMath/btMatrix3x3.h
@@ -360,7 +360,7 @@ public:
 
         v1 = _mm_shuffle_ps(v0, v2, BT_SHUFFLE(2, 3, 1, 3) );	// y0 y1 y2 0
         v0 = _mm_shuffle_ps(v0, v2, BT_SHUFFLE(0, 1, 0, 3) );	// x0 x1 x2 0
-        v2 = btCastdTo128f(_mm_move_sd(btCastfTo128d(v2), btCastfTo128d(vT)));	// z0 z1 z2 0
+        v2 = _mm_shuffle_ps(vT, v2, BT_SHUFFLE(0, 1, 2, 3));	// z0 z1 z2 0
 
         vm[0] = v0;
         vm[1] = v1;
@@ -1013,7 +1013,7 @@ btMatrix3x3::transpose() const
 
     v1 = _mm_shuffle_ps(v0, v2, BT_SHUFFLE(2, 3, 1, 3) );	// y0 y1 y2 0
     v0 = _mm_shuffle_ps(v0, v2, BT_SHUFFLE(0, 1, 0, 3) );	// x0 x1 x2 0
-    v2 = btCastdTo128f(_mm_move_sd(btCastfTo128d(v2), btCastfTo128d(vT)));	// z0 z1 z2 0
+    v2 = _mm_shuffle_ps(vT, v2, BT_SHUFFLE(0, 1, 2, 3));	// z0 z1 z2 0
 
 
     return btMatrix3x3( v0, v1, v2 );

--- a/src/LinearMath/btQuaternion.h
+++ b/src/LinearMath/btQuaternion.h
@@ -196,7 +196,7 @@ public:
 	btQuaternion& operator*=(const btScalar& s)
 	{
 #if defined (BT_USE_SSE_IN_API) && defined (BT_USE_SSE)
-		__m128	vs = _mm_load_ss(&s);	//	(S 0 0 0)
+		__m128	vs = _mm_set_ss(s);	//	(S 0 0 0)
 		vs = bt_pshufd_ps(vs, 0);	//	(S S S S)
 		mVec128 = _mm_mul_ps(mVec128, vs);
 #elif defined(BT_USE_NEON)
@@ -365,7 +365,7 @@ public:
 	operator*(const btScalar& s) const
 	{
 #if defined (BT_USE_SSE_IN_API) && defined (BT_USE_SSE)
-		__m128	vs = _mm_load_ss(&s);	//	(S 0 0 0)
+		__m128	vs = _mm_set_ss(s);	//	(S 0 0 0)
 		vs = bt_pshufd_ps(vs, 0x00);	//	(S S S S)
 		
 		return btQuaternion(_mm_mul_ps(mVec128, vs));

--- a/src/LinearMath/btVector3.h
+++ b/src/LinearMath/btVector3.h
@@ -197,7 +197,7 @@ public:
 	SIMD_FORCE_INLINE btVector3& operator*=(const btScalar& s)
 	{
 #if defined(BT_USE_SSE_IN_API) && defined (BT_USE_SSE)
-		__m128	vs = _mm_load_ss(&s);	//	(S 0 0 0)
+		__m128	vs = _mm_set_ss(s);	//	(S 0 0 0)
 		vs = bt_pshufd_ps(vs, 0x80);	//	(S S S 0.0)
 		mVec128 = _mm_mul_ps(mVec128, vs);
 #elif defined(BT_USE_NEON)
@@ -218,7 +218,7 @@ public:
 
 #if 0 //defined(BT_USE_SSE_IN_API)
 // this code is not faster !
-		__m128 vs = _mm_load_ss(&s);
+		__m128 vs = _mm_set_ss(s);
 		vs = _mm_div_ss(v1110, vs);
 		vs = bt_pshufd_ps(vs, 0x00);	//	(S S S S)
 
@@ -493,7 +493,7 @@ public:
 #if defined(BT_USE_SSE_IN_API) && defined (BT_USE_SSE)
 		__m128	vrt = _mm_load_ss(&rt);	//	(rt 0 0 0)
 		btScalar s = btScalar(1.0) - rt;
-		__m128	vs = _mm_load_ss(&s);	//	(S 0 0 0)
+		__m128	vs = _mm_set_ss(s);	//	(S 0 0 0)
 		vs = bt_pshufd_ps(vs, 0x80);	//	(S S S 0.0)
 		__m128 r0 = _mm_mul_ps(v0.mVec128, vs);
 		vrt = bt_pshufd_ps(vrt, 0x80);	//	(rt rt rt 0.0)
@@ -520,7 +520,7 @@ public:
 	SIMD_FORCE_INLINE btVector3 lerp(const btVector3& v, const btScalar& t) const 
 	{
 #if defined(BT_USE_SSE_IN_API) && defined (BT_USE_SSE)
-		__m128	vt = _mm_load_ss(&t);	//	(t 0 0 0)
+		__m128	vt = _mm_set_ss(t);	//	(t 0 0 0)
 		vt = bt_pshufd_ps(vt, 0x80);	//	(rt rt rt 0.0)
 		__m128 vl = _mm_sub_ps(v.mVec128, mVec128);
 		vl = _mm_mul_ps(vl, vt);
@@ -819,7 +819,7 @@ SIMD_FORCE_INLINE btVector3
 operator*(const btVector3& v, const btScalar& s)
 {
 #if defined(BT_USE_SSE_IN_API) && defined (BT_USE_SSE)
-	__m128	vs = _mm_load_ss(&s);	//	(S 0 0 0)
+	__m128	vs = _mm_set_ss(s);	//	(S 0 0 0)
 	vs = bt_pshufd_ps(vs, 0x80);	//	(S S S 0.0)
 	return btVector3(_mm_mul_ps(v.mVec128, vs));
 #elif defined(BT_USE_NEON)
@@ -844,7 +844,7 @@ operator/(const btVector3& v, const btScalar& s)
 	btFullAssert(s != btScalar(0.0));
 #if 0 //defined(BT_USE_SSE_IN_API)
 // this code is not faster !
-	__m128 vs = _mm_load_ss(&s);
+	__m128 vs = _mm_set_ss(s);
     vs = _mm_div_ss(v1110, vs);
 	vs = bt_pshufd_ps(vs, 0x00);	//	(S S S S)
 
@@ -968,8 +968,8 @@ SIMD_FORCE_INLINE btVector3 btVector3::rotate( const btVector3& wAxis, const btS
 	O = _mm_and_ps(O, btvFFF0fMask);
     btScalar scos = btCos( _angle );
 	
-	__m128 vsin = _mm_load_ss(&ssin);	//	(S 0 0 0)
-    __m128 vcos = _mm_load_ss(&scos);	//	(S 0 0 0)
+	__m128 vsin = _mm_set_ss(ssin);	//	(S 0 0 0)
+    __m128 vcos = _mm_set_ss(scos);	//	(S 0 0 0)
 	
 	__m128 Y = bt_pshufd_ps(O, 0xC9);	//	(Y Z X 0)
 	__m128 Z = bt_pshufd_ps(O, 0xD2);	//	(Z X Y 0)

--- a/src/LinearMath/btVector3.h
+++ b/src/LinearMath/btVector3.h
@@ -729,7 +729,7 @@ public:
         __m128 r = _mm_movelh_ps( b0, b2 );
         r = _mm_add_ps( r, _mm_movehl_ps( b2, b0 ));
         a2 = _mm_and_ps( a2, btvxyzMaskf);
-        r = _mm_add_ps( r, btCastdTo128f (_mm_move_sd( btCastfTo128d(a2), btCastfTo128d(b1) )));
+        r = _mm_add_ps( r, _mm_shuffle_ps(b1, a2, BT_SHUFFLE(0, 1, 2, 3)));
         return btVector3(r);
         
 #elif defined(BT_USE_NEON)

--- a/test/Bullet2/vectormath/sse/mat_aos.h
+++ b/test/Bullet2/vectormath/sse/mat_aos.h
@@ -853,7 +853,7 @@ VECTORMATH_FORCE_INLINE const Matrix4 inverse( const Matrix4 & mat )
 	__m128 mtL3 = _mm_xor_ps(sum,Sign_PNPN);
 
 	// Dividing is FASTER than rcp_nr! (Because rcp_nr causes many register-memory RWs).
-	RDet = _mm_div_ss(_mm_load_ss((float *)&_vmathZERONE), Det); // TODO: just 1.0f?
+	RDet = _mm_div_ss(_mm_set_ss(_vmathZERONE), Det); // TODO: just 1.0f?
 	RDet = _mm_shuffle_ps(RDet,RDet,0x00);
 
 	// Devide the first 12 minterms with the determinant.


### PR DESCRIPTION
Took an afternoon to play around with the SSE code path. This pull request carries some SSE optimizations, especially related to #482. From Emscripten perspective, it is important to remove the `_mm_move_sd` instructions, which are not really needed, since the same can be achieved with `_mm_shuffle_ps`. (I presume there was no special reason to use `_mm_move_sd`) Other commits improve instruction counts in hot paths shown by AMD CodeXL, hopefully translating to a few percents win in real world cases.

I have not run any tests on this, except my custom build. How does one run the tests? I checked README.md and the pdf docs, but couldn't catch any instructions there.