### PR TITLE
cppcheck: fix some reports

### DIFF
--- a/Extras/Serialize/BulletXmlWorldImporter/tinyxml.h
+++ b/Extras/Serialize/BulletXmlWorldImporter/tinyxml.h
@@ -348,7 +348,7 @@ protected:
 		{
 			//strncpy( _value, p, *length );	// lots of compilers don't like this function (unsafe),
 												// and the null terminator isn't needed
-			for( int i=0; p[i] && i<*length; ++i ) {
+			for( int i=0; i<*length && p[i]; ++i ) {
 				_value[i] = p[i];
 			}
 			return p + (*length);

--- a/Extras/Serialize/HeaderGenerator/apiGen.cpp
+++ b/Extras/Serialize/HeaderGenerator/apiGen.cpp
@@ -183,14 +183,14 @@ void writeTemplate(short *structData)
 	while (vars!= dataTypes.end())
 	{
 		fprintf(dump, "%s.dataTypes.append('%s %s')\n", fileName.c_str(), vars->dataType.c_str(), vars->variableName.c_str());
-		vars++;
+		++vars;
 	}
 
 	bStringMap::iterator inc = includeFiles.begin();
 	while (inc != includeFiles.end())
 	{
 		fprintf(dump, "%s.includes.append('%s.h')\n", fileName.c_str(), inc->second.c_str());
-		inc++;
+		++inc;
 	}
 	fprintf(dump, "DataTypeList.append(%s)\n", fileName.c_str());
 }
@@ -342,6 +342,7 @@ int main(int argc,char** argv)
 	}
 
 	delete mDNA;
+        fclose(fp);
 	fclose(dump);
 	return 0;
 }

--- a/examples/Importers/ImportColladaDemo/LoadMeshFromCollada.cpp
+++ b/examples/Importers/ImportColladaDemo/LoadMeshFromCollada.cpp
@@ -739,7 +739,7 @@ void LoadMeshFromColladaAssimp(const char* relativeFileName, btAlignedObjectArra
 				}
 			}
 		}
-		
+		fclose(file);
 	}
 	
 }

--- a/examples/Importers/ImportSTLDemo/LoadMeshFromSTL.h
+++ b/examples/Importers/ImportSTLDemo/LoadMeshFromSTL.h
@@ -46,6 +46,7 @@ static GLInstanceGraphicsShape* LoadMeshFromSTL(const char* relativeFileName)
 							int expectedBinaryFileSize = numTriangles* 50 + 84;
 							if (expectedBinaryFileSize != size)
 							{
+								fclose(file);
 								return 0;
 							}
 

--- a/examples/Importers/ImportURDFDemo/ROSURDFImporter.cpp
+++ b/examples/Importers/ImportURDFDemo/ROSURDFImporter.cpp
@@ -40,7 +40,7 @@ static void ROSprintTreeInternal(my_shared_ptr<const Link> link,int level = 0)
 {
     level+=2;
     int count = 0;
-    for (std::vector<my_shared_ptr<Link> >::const_iterator child = link->child_links.begin(); child != link->child_links.end(); child++)
+    for (std::vector<my_shared_ptr<Link> >::const_iterator child = link->child_links.begin(); child != link->child_links.end(); ++child)
     {
         if (*child)
         {

--- a/examples/ThirdPartyLibs/stb_image/stb_image.cpp
+++ b/examples/ThirdPartyLibs/stb_image/stb_image.cpp
@@ -2966,7 +2966,10 @@ static stbi_uc *tga_load(stbi *s, int *x, int *y, int *comp, int req_comp)
       skip(s, tga_palette_start );
       //   load the palette
       tga_palette = (unsigned char*)malloc( tga_palette_len * tga_palette_bits / 8 );
-      if (!tga_palette) return epuc("outofmem", "Out of memory");
+      if (!tga_palette) {
+         free(tga_data);
+         return epuc("outofmem", "Out of memory");
+      }
       if (!getn(s, tga_palette, tga_palette_len * tga_palette_bits / 8 )) {
          free(tga_data);
          free(tga_palette);

--- a/examples/ThirdPartyLibs/tinyxml/tinyxml.h
+++ b/examples/ThirdPartyLibs/tinyxml/tinyxml.h
@@ -348,7 +348,7 @@ protected:
 		{
 			//strncpy( _value, p, *length );	// lots of compilers don't like this function (unsafe),
 												// and the null terminator isn't needed
-			for( int i=0; p[i] && i<*length; ++i ) {
+			for( int i=0; i<*length && p[i] ; ++i ) {
 				_value[i] = p[i];
 			}
 			return p + (*length);

--- a/examples/ThirdPartyLibs/urdf/urdfdom/urdf_parser/src/check_urdf.cpp
+++ b/examples/ThirdPartyLibs/urdf/urdfdom/urdf_parser/src/check_urdf.cpp
@@ -44,7 +44,7 @@ void printTree(my_shared_ptr<const Link> link,int level = 0)
 {
   level+=2;
   int count = 0;
-  for (std::vector<my_shared_ptr<Link> >::const_iterator child = link->child_links.begin(); child != link->child_links.end(); child++)
+  for (std::vector<my_shared_ptr<Link> >::const_iterator child = link->child_links.begin(); child != link->child_links.end(); ++child)
   {
     if (*child)
     {

--- a/examples/VoronoiFracture/VoronoiFractureDemo.cpp
+++ b/examples/VoronoiFracture/VoronoiFractureDemo.cpp
@@ -339,7 +339,7 @@ void VoronoiFractureDemo::voronoiBBShatter(const btAlignedObjectArray<btVector3>
 				for (k=0; k < numplaneIndices; k++) {
 					if (k != *planeIndicesIter)
 						planes[k] = planes[*planeIndicesIter];
-					planeIndicesIter++;
+					++planeIndicesIter;
 				}
 				planes.resize(numplaneIndices);
 			}
@@ -484,7 +484,7 @@ void VoronoiFractureDemo::voronoiConvexHullShatter(const btAlignedObjectArray<bt
 				for (k=0; k < numplaneIndices; k++) {
 					if (k != *planeIndicesIter)
 						planes[k] = planes[*planeIndicesIter];
-					planeIndicesIter++;
+					++planeIndicesIter;
 				}
 				planes.resize(numplaneIndices);
 			}

--- a/test/OpenGLTrueTypeFont/main.cpp
+++ b/test/OpenGLTrueTypeFont/main.cpp
@@ -396,13 +396,13 @@ int main(int argc, char* argv[])
     const char* fontPath = "./";
 #endif
     
+#ifdef LOAD_FONT_FROM_FILE
     char fullFontFileName[1024];
     sprintf(fullFontFileName,"%s%s",fontPath,"DroidSerif-Regular.ttf");//cour.ttf");//times.ttf");//DroidSerif-Regular.ttf");
 	//sprintf(fullFontFileName,"%s%s",fontPath,"arial.ttf");//cour.ttf");//times.ttf");//DroidSerif-Regular.ttf");
     
 	fp = fopen(fullFontFileName, "rb");
-#ifdef LOAD_FONT_FROM_FILE
-		unsigned char* data;
+	unsigned char* data;
     err = glGetError();
     b3Assert(err==GL_NO_ERROR);
     


### PR DESCRIPTION
[Extras/Serialize/HeaderGenerator/apiGen.cpp:346]: (error) Resource leak: fp
[examples/Importers/ImportColladaDemo/LoadMeshFromCollada.cpp:745]: (error) Resource leak: file
[examples/Importers/ImportSTLDemo/LoadMeshFromSTL.h:49]: (error) Resource leak: file
[examples/ThirdPartyLibs/stb_image/stb_image.cpp:2969]: (error) Memory leak: tga_data
[test/OpenGLTrueTypeFont/main.cpp:675]: (error) Resource leak: fp
[Extras/Serialize/BulletXmlWorldImporter/tinyxml.h:351]: (style) Array index 'i' is used before limits check.
[examples/ThirdPartyLibs/tinyxml/tinyxml.h:351]: (style) Array index 'i' is used before limits check.
[Extras/Serialize/HeaderGenerator/apiGen.cpp:186]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[Extras/Serialize/HeaderGenerator/apiGen.cpp:193]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[examples/Importers/ImportURDFDemo/ROSURDFImporter.cpp:43]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[examples/ThirdPartyLibs/urdf/urdfdom/urdf_parser/src/check_urdf.cpp:47]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[examples/VoronoiFracture/VoronoiFractureDemo.cpp:342]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[examples/VoronoiFracture/VoronoiFractureDemo.cpp:487]: (performance) Prefer prefix ++/-- operators for non-primitive types.