### PR TITLE
Fix slow simulation in PhysicsServerExample

### DIFF
--- a/examples/SharedMemory/PhysicsServerExample.cpp
+++ b/examples/SharedMemory/PhysicsServerExample.cpp
@@ -170,9 +170,8 @@ void	PhysicsServerExample::stepSimulation(float deltaTime)
 {
 	btClock rtc;
 	btScalar endTime = rtc.getTimeMilliseconds() + deltaTime*btScalar(800);
-	int maxSteps = 10;
 
-	while (maxSteps-- && rtc.getTimeMilliseconds()<endTime)
+	while (rtc.getTimeMilliseconds()<endTime)
 	{
 		m_physicsServer.processClientCommands();
 	}


### PR DESCRIPTION
This change removes maxSteps to regain simulation speed in PhysicsServerExample.

I thought it is unintentionally committed debugging code in #488 . If you have any reason to limit the number of client commands per one draw, I'd like to know it.