### PR TITLE
fix for broken memmove used in btDbvt.h, issue 347.

### DIFF
--- a/src/BulletCollision/BroadphaseCollision/btDbvt.h
+++ b/src/BulletCollision/BroadphaseCollision/btDbvt.h
@@ -1196,23 +1196,32 @@ inline void		btDbvt::collideOCL(	const btDbvtNode* root,
 							
 							//void * memmove ( void * destination, const void * source, size_t num );
 							
-//#if DBVT_USE_MEMMOVE
-//							memmove(&stack[j],&stack[j-1],sizeof(int)*(stack.size()-j-1));
-//#else
-							for(int k=stack.size()-1;k>j;--k) 
-							{
+#if DBVT_USE_MEMMOVE
+                     {
+                     int num_items_to_move = stack.size()-1-j;
+                     if(num_items_to_move > 0)
+                        memmove(&stack[j+1],&stack[j],sizeof(int)*num_items_to_move);
+                     }
+#else
+                     for(int k=stack.size()-1;k>j;--k) {
 								stack[k]=stack[k-1];
-							}
-//#endif
+                     }
+#endif
 							stack[j]=allocate(ifree,stock,nes[q]);
 							/* Insert 1	*/ 
 							j=nearest(&stack[0],&stock[0],nes[1-q].value,j,stack.size());
 							stack.push_back(0);
-//#if DBVT_USE_MEMMOVE
-//							memmove(&stack[j],&stack[j-1],sizeof(int)*(stack.size()-j-1));
-//#else
-							for(int k=stack.size()-1;k>j;--k) stack[k]=stack[k-1];
-//#endif
+#if DBVT_USE_MEMMOVE
+                     {
+                     int num_items_to_move = stack.size()-1-j;
+                     if(num_items_to_move > 0)
+                        memmove(&stack[j+1],&stack[j],sizeof(int)*num_items_to_move);
+                     }
+#else
+                     for(int k=stack.size()-1;k>j;--k) {
+                        stack[k]=stack[k-1];
+                     }
+#endif
 							stack[j]=allocate(ifree,stock,nes[1-q]);
 						}
 						else


### PR DESCRIPTION
Here is the isolated fix for issue #347. Basically all that was needed was to avoid the memmove if there were no bytes to move. This prevents accessing elements outside the size of "stack" which triggered the assert in btAlignedObjectArray. 

Cheers,
Ola


