### PR TITLE
workaround for wrong gjk/epa contact normal, add 'replay' command log feature: no mouse interaction during replay etc.

### DIFF
--- a/examples/OpenGLWindow/GLInstancingRenderer.cpp
+++ b/examples/OpenGLWindow/GLInstancingRenderer.cpp
@@ -19,7 +19,7 @@ subject to the following restrictions:
 bool useShadowMap=true;//false;//true;
 int shadowMapWidth=8192;
 int shadowMapHeight=8192;
-float shadowMapWorldSize=100;
+float shadowMapWorldSize=10;
 
 #define MAX_POINTS_IN_BATCH 1024
 #define MAX_LINES_IN_BATCH 1024

--- a/examples/SharedMemory/PhysicsServerExample.cpp
+++ b/examples/SharedMemory/PhysicsServerExample.cpp
@@ -18,6 +18,7 @@ class PhysicsServerExample : public SharedMemoryCommon
 
     bool m_isConnected;
     btClock m_clock;
+	bool m_replay;
 	
 public:
     
@@ -36,6 +37,7 @@ public:
 
 	void replayFromLogFile()
 	{
+		m_replay = true;
 		m_physicsServer.replayFromLogFile("BulletPhysicsCommandLog.bin");
 	}
 	
@@ -61,6 +63,9 @@ public:
 	
 	virtual bool	mouseMoveCallback(float x,float y)
 	{
+		if (m_replay)
+			return false;
+
 		CommonRenderInterface* renderer = m_guiHelper->getRenderInterface();
 		
 		if (!renderer)
@@ -78,6 +83,9 @@ public:
 
 	virtual bool	mouseButtonCallback(int button, int state, float x, float y)
 	{
+		if (m_replay)
+			return false;
+
 		CommonRenderInterface* renderer = m_guiHelper->getRenderInterface();
 		
 		if (!renderer)
@@ -128,7 +136,8 @@ public:
 PhysicsServerExample::PhysicsServerExample(GUIHelperInterface* helper)
 :SharedMemoryCommon(helper),
 m_wantsShutdown(false),
-m_isConnected(false)
+m_isConnected(false),
+m_replay(false)
 {
 	b3Printf("Started PhysicsServer\n");
 }
@@ -178,12 +187,19 @@ bool PhysicsServerExample::wantsTermination()
 
 void	PhysicsServerExample::stepSimulation(float deltaTime)
 {
-	btClock rtc;
-	btScalar endTime = rtc.getTimeMilliseconds() + deltaTime*btScalar(800);
-
-	while (rtc.getTimeMilliseconds()<endTime)
+	if (m_replay)
 	{
-		m_physicsServer.processClientCommands();
+		for (int i=0;i<100;i++)
+			m_physicsServer.processClientCommands();
+	} else
+	{
+		btClock rtc;
+		btScalar endTime = rtc.getTimeMilliseconds() + deltaTime*btScalar(800);
+
+		while (rtc.getTimeMilliseconds()<endTime)
+		{
+			m_physicsServer.processClientCommands();
+		}
 	}
 }
 


### PR DESCRIPTION
… and use a fixed number of sim steps in stepSimulation.

workaround for reversed separating normal in gjk/epa when using very small shapes, detect case and revert normal.
use smaller world size (10 units versus 100) for higher resolution shadow map
use a hard-coded rolling friction of 0.2 for objects in physics server (will make this configurable)
fix loading of command log files, when platform features are different (64bit/32bit)