### PR TITLE
Remove unused members (collision world)

### DIFF
--- a/src/BulletCollision/CollisionDispatch/btCollisionWorld.cpp
+++ b/src/BulletCollision/CollisionDispatch/btCollisionWorld.cpp
@@ -850,7 +850,7 @@ struct btSingleRayCallback : public btBroadphaseRayCallback
 	btVector3	m_rayToWorld;
 	btTransform	m_rayFromTrans;
 	btTransform	m_rayToTrans;
-	btVector3	m_hitNormal;
+	//btVector3	m_hitNormal; // unused
 
 	const btCollisionWorld*	m_world;
 	btCollisionWorld::RayResultCallback&	m_resultCallback;
@@ -945,7 +945,7 @@ struct btSingleSweepCallback : public btBroadphaseRayCallback
 
 	btTransform	m_convexFromTrans;
 	btTransform	m_convexToTrans;
-	btVector3	m_hitNormal;
+	//btVector3	m_hitNormal;  // unused
 	const btCollisionWorld*	m_world;
 	btCollisionWorld::ConvexResultCallback&	m_resultCallback;
 	btScalar	m_allowedCcdPenetration;

--- a/src/BulletCollision/CollisionDispatch/btCompoundCompoundCollisionAlgorithm.cpp
+++ b/src/BulletCollision/CollisionDispatch/btCompoundCompoundCollisionAlgorithm.cpp
@@ -369,30 +369,22 @@ void btCompoundCompoundCollisionAlgorithm::processCollision (const btCollisionOb
 				btCollisionAlgorithm* algo = (btCollisionAlgorithm*)pairs[i].m_userPointer;
 
 				{
-					btTransform	orgTrans0;
 					const btCollisionShape* childShape0 = 0;
 					
 					btTransform	newChildWorldTrans0;
-					btTransform	orgInterpolationTrans0;
 					childShape0 = compoundShape0->getChildShape(pairs[i].m_indexA);
-					orgTrans0 = col0ObjWrap->getWorldTransform();
-					orgInterpolationTrans0 = col0ObjWrap->getWorldTransform();
 					const btTransform& childTrans0 = compoundShape0->getChildTransform(pairs[i].m_indexA);
-					newChildWorldTrans0 = orgTrans0*childTrans0 ;
+					newChildWorldTrans0 = col0ObjWrap->getWorldTransform()*childTrans0 ;
 					childShape0->getAabb(newChildWorldTrans0,aabbMin0,aabbMax0);
 				}
 
 				{
-					btTransform	orgInterpolationTrans1;
 					const btCollisionShape* childShape1 = 0;
-					btTransform	orgTrans1;
 					btTransform	newChildWorldTrans1;
 
 					childShape1 = compoundShape1->getChildShape(pairs[i].m_indexB);
-					orgTrans1 = col1ObjWrap->getWorldTransform();
-					orgInterpolationTrans1 = col1ObjWrap->getWorldTransform();
 					const btTransform& childTrans1 = compoundShape1->getChildTransform(pairs[i].m_indexB);
-					newChildWorldTrans1 = orgTrans1*childTrans1 ;
+					newChildWorldTrans1 = col1ObjWrap->getWorldTransform()*childTrans1 ;
 					childShape1->getAabb(newChildWorldTrans1,aabbMin1,aabbMax1);
 				}
 				

--- a/src/BulletDynamics/ConstraintSolver/btSequentialImpulseConstraintSolver.cpp
+++ b/src/BulletDynamics/ConstraintSolver/btSequentialImpulseConstraintSolver.cpp
@@ -1326,9 +1326,6 @@ btScalar btSequentialImpulseConstraintSolver::solveGroupCacheFriendlySetup(btCol
 
 				if (constraints[i]->isEnabled())
 				{
-				}
-				if (constraints[i]->isEnabled())
-				{
 					constraints[i]->getInfo1(&info1);
 				} else
 				{


### PR DESCRIPTION
Remove unused member in hittest
Remove redundant if test (seq impulse solver) (redundant if isEnabled() )

Remove unused matrix copies. 
 Remove extra matrix copy and just use the original reference in computation.
orgInterpolationTrans[0/1] was entirely unused.
orgTrans[0/1] was just a copy of col[0/1]ObjWrap->getWorldTransform() and otherwise unused.
