### PR TITLE
cleanup main premake script

### DIFF
--- a/build3/premake4.lua
+++ b/build3/premake4.lua
@@ -1,5 +1,5 @@
 
-    solution "0_Bullet3Solution"
+	solution "0_Bullet3Solution"
 
 	local osversion = os.getversion()
 	print(string.format(" %d.%d.%d (%s)",
@@ -14,26 +14,26 @@
 
 	act = ""
 
-    if _ACTION then
-        act = _ACTION
-    end
+	if _ACTION then
+		act = _ACTION
+	end
 
-    newoption {
-        trigger     = "ios",
-        description = "Enable iOS target (requires xcode4)"
+	newoption {
+		trigger     = "ios",
+		description = "Enable iOS target (requires xcode4)"
 	}
 
 	newoption
-    {
-        trigger = "force_dlopen_opengl",
-        description = "Dynamically load OpenGL (instead of static/dynamic linking)"
-    }
+	{
+		trigger = "force_dlopen_opengl",
+		description = "Dynamically load OpenGL (instead of static/dynamic linking)"
+	}
 
 	newoption
-    {
-        trigger = "force_dlopen_x11",
-        description = "Dynamically load OpenGL (instead of static/dynamic linking)"
-    }
+	{
+		trigger = "force_dlopen_x11",
+		description = "Dynamically load OpenGL (instead of static/dynamic linking)"
+	}
 
 	newoption
 	{
@@ -49,17 +49,17 @@
 
 --	--_OPTIONS["midi"] = "1";
 
-    newoption
-    {
-        trigger = "no-demos",
-        description = "Don't build demos"
-    }
+	newoption
+	{
+		trigger = "no-demos",
+		description = "Don't build demos"
+	}
 
-    newoption
-    {
-        trigger = "no-extras",
-        description = "Don't build Extras"
-    }
+	newoption
+	{
+		trigger = "no-extras",
+		description = "Don't build Extras"
+	}
 
 	newoption
 	{
@@ -74,10 +74,10 @@
 	}
 
 	newoption {
-        trigger     = "targetdir",
-        value       = "path such as ../bin",
-        description = "Set the output location for the generated project files"
-    }
+		trigger     = "targetdir",
+		value       = "path such as ../bin",
+		description = "Set the output location for the generated project files"
+	}
 
 	newoption
 	{
@@ -91,11 +91,11 @@
 		description = "Disable unit tests using gtest"
 	}
 
-    newoption
-    {
-        trigger = "no-bullet3",
-        description = "Do not build bullet3 libs"
-    }
+	newoption
+	{
+		trigger = "no-bullet3",
+		description = "Do not build bullet3 libs"
+	}
 
 	configurations {"Release", "Debug"}
 	configuration "Release"
@@ -130,25 +130,25 @@
 	postfix=""
 
 	if _ACTION == "xcode4" then
-        if _OPTIONS["ios"] then
-            _OPTIONS["no-bullet3"] = "1"
-            _OPTIONS["no-gtest"] = "1"
+		if _OPTIONS["ios"] then
+			_OPTIONS["no-bullet3"] = "1"
+			_OPTIONS["no-gtest"] = "1"
 
-            postfix = "ios";
-            xcodebuildsettings
-            {
-                'INFOPLIST_FILE = "../../test/Bullet2/Info.plist"',
-                'CODE_SIGN_IDENTITY = "iPhone Developer"',
-                "SDKROOT = iphoneos",
-                'ARCHS = "armv7"',
-                'TARGETED_DEVICE_FAMILY = "1,2"',
-                'VALID_ARCHS = "armv7"',
-            }
+			postfix = "ios";
+			xcodebuildsettings
+			{
+				'INFOPLIST_FILE = "../../test/Bullet2/Info.plist"',
+				'CODE_SIGN_IDENTITY = "iPhone Developer"',
+				"SDKROOT = iphoneos",
+				'ARCHS = "armv7"',
+				'TARGETED_DEVICE_FAMILY = "1,2"',
+				'VALID_ARCHS = "armv7"',
+			}
 		else
 			xcodebuildsettings
 			{
-        		'ARCHS = "$(ARCHS_STANDARD_32_BIT) $(ARCHS_STANDARD_64_BIT)"',
-        		'VALID_ARCHS = "x86_64 i386"',
+				'ARCHS = "$(ARCHS_STANDARD_32_BIT) $(ARCHS_STANDARD_64_BIT)"',
+				'VALID_ARCHS = "x86_64 i386"',
 --			'SDKROOT = "macosx10.9"',
 			}
 		end
@@ -176,73 +176,73 @@
 
 	language "C++"
 
-    if _OPTIONS["no-bullet3"] then
-        print "--no-bullet3 implies --no-demos"
-        _OPTIONS["no-demos"] = "1"
-    else 
-        include "../src/Bullet3Common"
-        include "../src/Bullet3Geometry"
-        include "../src/Bullet3Collision"
-        include "../src/Bullet3Dynamics"
-        include "../src/Bullet3OpenCL"
-        include "../src/Bullet3Serialize/Bullet2FileLoader"
-    end
+	if _OPTIONS["no-bullet3"] then
+		print "--no-bullet3 implies --no-demos"
+		_OPTIONS["no-demos"] = "1"
+	else
+		include "../src/Bullet3Common"
+		include "../src/Bullet3Geometry"
+		include "../src/Bullet3Collision"
+		include "../src/Bullet3Dynamics"
+		include "../src/Bullet3OpenCL"
+		include "../src/Bullet3Serialize/Bullet2FileLoader"
+	end
 
-    if _OPTIONS["no-extras"] then
-        print "--no-extras implies --no-demos"
-        _OPTIONS["no-demos"] = "1"
-    else
-        include "../Extras"
-    end
+	if _OPTIONS["no-extras"] then
+		print "--no-extras implies --no-demos"
+		_OPTIONS["no-demos"] = "1"
+	else
+		include "../Extras"
+	end
 
-    if not _OPTIONS["no-demos"] then
-        include "../examples/ExampleBrowser"
-        include "../examples/OpenGLWindow"
-        include "../examples/ThirdPartyLibs/Gwen"
+	if not _OPTIONS["no-demos"] then
+		include "../examples/ExampleBrowser"
+		include "../examples/OpenGLWindow"
+		include "../examples/ThirdPartyLibs/Gwen"
 
-        include "../examples/HelloWorld"
-        include "../examples/BasicDemo"
+		include "../examples/HelloWorld"
+		include "../examples/BasicDemo"
 
-        include "../examples/SharedMemory"
-        include "../examples/MultiThreading"
+		include "../examples/SharedMemory"
+		include "../examples/MultiThreading"
 
-        if _OPTIONS["lua"] then
-           include "../examples/ThirdPartyLibs/lua-5.2.3"
-        end
+		if _OPTIONS["lua"] then
+		   include "../examples/ThirdPartyLibs/lua-5.2.3"
+		end
 
-        if not _OPTIONS["no-test"] then
-            include "../test/SharedMemory"
-            if _OPTIONS["enet"] then
-                include "../examples/ThirdPartyLibs/enet"
-                include "../test/enet/client"
-                include "../test/enet/server"
-            end
-        end
-    end
+		if not _OPTIONS["no-test"] then
+			include "../test/SharedMemory"
+			if _OPTIONS["enet"] then
+				include "../examples/ThirdPartyLibs/enet"
+				include "../test/enet/client"
+				include "../test/enet/server"
+			end
+		end
+	end
 
-    if not _OPTIONS["no-test"] then
-	    include "../test/Bullet2"
+	if not _OPTIONS["no-test"] then
+		include "../test/Bullet2"
 
-        if not _OPTIONS["no-gtest"] then
-            include "../test/gtest-1.7.0"
---            include "../test/hello_gtest"
-            include "../test/collision"
-            if not _OPTIONS["no-bullet3"] then
-                if not _OPTIONS["no-extras"] then
-                    include "../test/InverseDynamics"
-                end
-                include "../test/TestBullet3OpenCL"
-            end
-            if not _OPTIONS["no-demos"] then
-                -- Gwen is only used for demos
-                include "../test/GwenOpenGLTest"
-            end
-        end
-    end
+		if not _OPTIONS["no-gtest"] then
+			include "../test/gtest-1.7.0"
+--			include "../test/hello_gtest"
+			include "../test/collision"
+			if not _OPTIONS["no-bullet3"] then
+				if not _OPTIONS["no-extras"] then
+					include "../test/InverseDynamics"
+				end
+				include "../test/TestBullet3OpenCL"
+			end
+			if not _OPTIONS["no-demos"] then
+				-- Gwen is only used for demos
+				include "../test/GwenOpenGLTest"
+			end
+		end
+	end
 
 	include "../src/BulletInverseDynamics"
  	include "../src/BulletSoftBody"
-    include "../src/BulletDynamics"
-    include "../src/BulletCollision"
-    include "../src/LinearMath"
+	include "../src/BulletDynamics"
+	include "../src/BulletCollision"
+	include "../src/LinearMath"
 

--- a/build3/premake4.lua
+++ b/build3/premake4.lua
@@ -1,11 +1,11 @@
 
-  solution "0_Bullet3Solution"
+    solution "0_Bullet3Solution"
 
 	local osversion = os.getversion()
-		print(string.format(" %d.%d.%d (%s)", 
+	print(string.format(" %d.%d.%d (%s)",
    		osversion.majorversion, osversion.minorversion, osversion.revision,
    		osversion.description))
-	
+
 
 	-- Multithreaded compiling
 	if _ACTION == "vs2010" or _ACTION=="vs2008" then
@@ -18,22 +18,22 @@
         act = _ACTION
     end
 
-	  newoption {
-    		trigger     = "ios",
-    		description = "Enable iOS target (requires xcode4)"
+    newoption {
+        trigger     = "ios",
+        description = "Enable iOS target (requires xcode4)"
 	}
 
 	newoption
-        {
-                trigger = "force_dlopen_opengl",
-                description = "Dynamically load OpenGL (instead of static/dynamic linking)"
-        }
+    {
+        trigger = "force_dlopen_opengl",
+        description = "Dynamically load OpenGL (instead of static/dynamic linking)"
+    }
 
 	newoption
-        {
-                trigger = "force_dlopen_x11",
-                description = "Dynamically load OpenGL (instead of static/dynamic linking)"
-        }
+    {
+        trigger = "force_dlopen_x11",
+        description = "Dynamically load OpenGL (instead of static/dynamic linking)"
+    }
 
 	newoption
 	{
@@ -49,35 +49,47 @@
 
 --	--_OPTIONS["midi"] = "1";
 
-	newoption
-	{
-		trigger = "bullet2demos",
-		description = "Compile the Bullet 2 demos (Demo/Extra folder)"
-	}
+    newoption
+    {
+        trigger = "no-demos",
+        description = "Don't build demos"
+    }
 
 	newoption
 	{
 		trigger = "enet",
 		description = "Enable enet NAT punchthrough test"
 	}
+
 	newoption
 	{
 		trigger = "lua",
 		description = "Enable Lua scipting support in Example Browser"
 	}
 
-	 newoption {
-    trigger     = "targetdir",
-    value       = "path such as ../bin",
-    description = "Set the output location for the generated project files"
-  }
-	
-	
+	newoption {
+        trigger     = "targetdir",
+        value       = "path such as ../bin",
+        description = "Set the output location for the generated project files"
+    }
+
 	newoption
 	{
-		trigger = "without-gtest",
+		trigger = "no-test",
+		description = "Disable all tests"
+	}
+
+	newoption
+	{
+		trigger = "no-gtest",
 		description = "Disable unit tests using gtest"
 	}
+
+    newoption
+    {
+        trigger = "no-bullet3",
+        description = "Do not build bullet3 libs"
+    }
 
 	configurations {"Release", "Debug"}
 	configuration "Release"
@@ -85,7 +97,7 @@
 	configuration "Debug"
 		defines {"_DEBUG=1"}
 		flags { "Symbols", "StaticRuntime" , "NoMinimalRebuild", "NoEditAndContinue" ,"FloatFast"}
-	
+
 	if os.is("Linux") or os.is("macosx") then
 		if os.is64bit() then
 			platforms {"x64"}
@@ -112,25 +124,25 @@
 	postfix=""
 
 	if _ACTION == "xcode4" then
-			 if _OPTIONS["ios"] then
-                        postfix = "ios";
-                        xcodebuildsettings
-                        {
-                                'INFOPLIST_FILE = "../../test/Bullet2/Info.plist"',
-                                'CODE_SIGN_IDENTITY = "iPhone Developer"',
-                                "SDKROOT = iphoneos",
-                                'ARCHS = "armv7"',
-                                'TARGETED_DEVICE_FAMILY = "1,2"',
-                                'VALID_ARCHS = "armv7"',
-                        }       
-			else
+        if _OPTIONS["ios"] then
+            postfix = "ios";
+            xcodebuildsettings
+            {
+                'INFOPLIST_FILE = "../../test/Bullet2/Info.plist"',
+                'CODE_SIGN_IDENTITY = "iPhone Developer"',
+                "SDKROOT = iphoneos",
+                'ARCHS = "armv7"',
+                'TARGETED_DEVICE_FAMILY = "1,2"',
+                'VALID_ARCHS = "armv7"',
+            }
+		else
 			xcodebuildsettings
 			{
         		'ARCHS = "$(ARCHS_STANDARD_32_BIT) $(ARCHS_STANDARD_64_BIT)"',
         		'VALID_ARCHS = "x86_64 i386"',
 --			'SDKROOT = "macosx10.9"',
 			}
-			end
+		end
 	end
 
 -- comment-out for now, URDF reader needs exceptions
@@ -148,57 +160,83 @@
 	dofile ("findOpenCL.lua")
 	dofile ("findDirectX11.lua")
 	dofile ("findOpenGLGlewGlut.lua")
-	
+
 	if (not findOpenGL3()) then
 		defines {"NO_OPENGL3"}
 	end
 
 	language "C++"
 
-if not _OPTIONS["ios"] then
+    if _OPTIONS["ios"] then
+        _OPTIONS["no-bullet3"] = "1"
+        _OPTIONS["no-gtest"] = "1"
+    end
 
-	include "../examples/ExampleBrowser"
-	include "../examples/OpenGLWindow"
-	include "../examples/SharedMemory"
-	include "../examples/MultiThreading"
-	include "../examples/ThirdPartyLibs/Gwen"
-	include "../Extras"
+    if _OPTIONS["no-bullet3"] then
+        _OPTIONS["no-demos"] = "1"
+    else 
+        include "../src/Bullet3Common"
+        include "../src/Bullet3Geometry"
+        include "../src/Bullet3Collision"
+        include "../src/Bullet3Dynamics"
+        include "../src/Bullet3OpenCL"
+        include "../src/Bullet3Serialize/Bullet2FileLoader"
+    end
 
-	include "../examples/HelloWorld"
-	include "../examples/BasicDemo"
-	include "../test/SharedMemory"
-	
-	if _OPTIONS["enet"] then
-		include "../examples/ThirdPartyLibs/enet"
-		include "../test/enet/client"
-		include "../test/enet/server"	
-	end
+    if _OPTIONS["no-extras"] then
+        _OPTIONS["no-demos"] = "1"
+    else
+        include "../Extras"
+    end
 
-	if _OPTIONS["lua"] then
-		include "../examples/ThirdPartyLibs/lua-5.2.3"
-	end
-	
-	include "../src/Bullet3Common"
-	include "../src/Bullet3Geometry"
-	include "../src/Bullet3Collision"
-	include "../src/Bullet3Dynamics"
-	include "../src/Bullet3OpenCL"
-	include "../src/Bullet3Serialize/Bullet2FileLoader"
+    if not _OPTIONS["no-demos"] then
+        include "../examples/ExampleBrowser"
+        include "../examples/OpenGLWindow"
+        include "../examples/ThirdPartyLibs/Gwen"
 
- 	if not _OPTIONS["without-gtest"] then
-                include "../test/gtest-1.7.0"
---              include "../test/hello_gtest"
-                include "../test/collision"
-		include "../test/InverseDynamics"
-                include "../test/TestBullet3OpenCL"
-                include "../test/GwenOpenGLTest"
+        include "../examples/HelloWorld"
+        include "../examples/BasicDemo"
+
+        include "../examples/SharedMemory"
+        include "../examples/MultiThreading"
+
+        if _OPTIONS["lua"] then
+           include "../examples/ThirdPartyLibs/lua-5.2.3"
         end
-end
 
-	include "../test/Bullet2"
+        if not _OPTIONS["no-test"] then
+            include "../test/SharedMemory"
+            if _OPTIONS["enet"] then
+                include "../examples/ThirdPartyLibs/enet"
+                include "../test/enet/client"
+                include "../test/enet/server"
+            end
+        end
+    end
+
+    if not _OPTIONS["no-test"] then
+	    include "../test/Bullet2"
+
+        if not _OPTIONS["no-gtest"] then
+            include "../test/gtest-1.7.0"
+--            include "../test/hello_gtest"
+            include "../test/collision"
+            if not _OPTIONS["no-bullet3"] then
+                if _OPTIONS["no-extras"] then
+                    include "../test/InverseDynamics"
+                end
+                include "../test/TestBullet3OpenCL"
+            end
+            if not _OPTIONS["no-demos"] then
+                -- Gwen is only used for demos
+                include "../test/GwenOpenGLTest"
+            end
+        end
+    end
+
 	include "../src/BulletInverseDynamics"
  	include "../src/BulletSoftBody"
-        include "../src/BulletDynamics"
-        include "../src/BulletCollision"
-        include "../src/LinearMath"
-	
+    include "../src/BulletDynamics"
+    include "../src/BulletCollision"
+    include "../src/LinearMath"
+

--- a/build3/premake4.lua
+++ b/build3/premake4.lua
@@ -125,6 +125,9 @@
 
 	if _ACTION == "xcode4" then
         if _OPTIONS["ios"] then
+            _OPTIONS["no-bullet3"] = "1"
+            _OPTIONS["no-gtest"] = "1"
+
             postfix = "ios";
             xcodebuildsettings
             {
@@ -166,11 +169,6 @@
 	end
 
 	language "C++"
-
-    if _OPTIONS["ios"] then
-        _OPTIONS["no-bullet3"] = "1"
-        _OPTIONS["no-gtest"] = "1"
-    end
 
     if _OPTIONS["no-bullet3"] then
         _OPTIONS["no-demos"] = "1"

--- a/build3/premake4.lua
+++ b/build3/premake4.lua
@@ -228,7 +228,7 @@
 --            include "../test/hello_gtest"
             include "../test/collision"
             if not _OPTIONS["no-bullet3"] then
-                if _OPTIONS["no-extras"] then
+                if not _OPTIONS["no-extras"] then
                     include "../test/InverseDynamics"
                 end
                 include "../test/TestBullet3OpenCL"

--- a/build3/premake4.lua
+++ b/build3/premake4.lua
@@ -55,6 +55,12 @@
         description = "Don't build demos"
     }
 
+    newoption
+    {
+        trigger = "no-extras",
+        description = "Don't build Extras"
+    }
+
 	newoption
 	{
 		trigger = "enet",
@@ -171,6 +177,7 @@
 	language "C++"
 
     if _OPTIONS["no-bullet3"] then
+        print "--no-bullet3 implies --no-demos"
         _OPTIONS["no-demos"] = "1"
     else 
         include "../src/Bullet3Common"
@@ -182,6 +189,7 @@
     end
 
     if _OPTIONS["no-extras"] then
+        print "--no-extras implies --no-demos"
         _OPTIONS["no-demos"] = "1"
     else
         include "../Extras"


### PR DESCRIPTION
Cleaned up some bad indentation in the main **premake4.lua** script.

Also added some new premake options:

  --no-demos
  --no-test
  --no-bullet3
  --no-extras

The motivation for this work was to speed up complete rebuilds of the core Bullet2 libraries, by not bothering to build most of the other unnecessary stuff.

BTW, I noticed that the script indentation has a mixture of tabs and spaces.  I'm wondering what is the correct indentation coding style for Bullet.