### PR TITLE
Remove deprecated reference to _STATIC_CPPLIB VS2015+

### DIFF
--- a/examples/ThirdPartyLibs/Gwen/CMakeLists.txt
+++ b/examples/ThirdPartyLibs/Gwen/CMakeLists.txt
@@ -15,7 +15,10 @@ IF(NOT WIN32 AND NOT APPLE)
         ADD_DEFINITIONS("-DDYNAMIC_LOAD_X11_FUNCTIONS=1")
 ENDIF()
 
-ADD_DEFINITIONS( -DGLEW_STATIC -DGWEN_COMPILE_STATIC -D_HAS_EXCEPTIONS=0 -D_STATIC_CPPLIB )
+ADD_DEFINITIONS( -DGLEW_STATIC -DGWEN_COMPILE_STATIC -D_HAS_EXCEPTIONS=0 )
+if( MSVC_VERSION LESS 1900 )
+ADD_DEFINITIONS( -D_STATIC_CPPLIB )
+endif( MSVC_VERSION LESS 1900 )
 
 FILE(GLOB gwen_SRCS "*.cpp" "Controls/*.cpp" "Controls/Dialog/*.cpp" "Controls/Dialogs/*.cpp" "Controls/Layout/*.cpp" "Controls/Property/*.cpp" "Input/*.cpp" "Platforms/*.cpp" "Renderers/*.cpp" "Skins/*.cpp")
 FILE(GLOB gwen_HDRS "*.h" "Controls/*.h" "Controls/Dialog/*.h" "Controls/Dialogs/*.h" "Controls/Layout/*.h" "Controls/Property/*.h" "Input/*.h" "Platforms/*.h" "Renderers/*.h" "Skins/*.h")

--- a/examples/ThirdPartyLibs/Gwen/CMakeLists.txt
+++ b/examples/ThirdPartyLibs/Gwen/CMakeLists.txt
@@ -17,7 +17,7 @@ ENDIF()
 
 ADD_DEFINITIONS( -DGLEW_STATIC -DGWEN_COMPILE_STATIC -D_HAS_EXCEPTIONS=0 )
 if( MSVC_VERSION LESS 1900 )
-ADD_DEFINITIONS( -D_STATIC_CPPLIB )
+   ADD_DEFINITIONS( -D_STATIC_CPPLIB )
 endif( MSVC_VERSION LESS 1900 )
 
 FILE(GLOB gwen_SRCS "*.cpp" "Controls/*.cpp" "Controls/Dialog/*.cpp" "Controls/Dialogs/*.cpp" "Controls/Layout/*.cpp" "Controls/Property/*.cpp" "Input/*.cpp" "Platforms/*.cpp" "Renderers/*.cpp" "Skins/*.cpp")


### PR DESCRIPTION
 which causes duplicate…… symbol conflicts when linking now, because those get exposed and cause linker failures now.
Perhaps there's another way; but this works.
App Example Browser builds without issue...
