### PR TITLE
Use higher precision GJK/EPA collision tolerances in double precision mode. Fix Lua example

### DIFF
--- a/examples/ExampleBrowser/premake4.lua
+++ b/examples/ExampleBrowser/premake4.lua
@@ -178,6 +178,13 @@ project "App_BulletExampleBrowser"
 			}
 		end
 
+ if _OPTIONS["lua"] then
+                includedirs{"../ThirdPartyLibs/lua-5.2.3/src"}
+                links {"lua-5.2.3"}
+                defines {"ENABLE_LUA"}
+                files {"../LuaDemo/LuaPhysicsSetup.cpp"}
+        end
+
 	files {
 	"main.cpp",
 	"ExampleEntries.cpp",

--- a/examples/LuaDemo/LuaPhysicsSetup.cpp
+++ b/examples/LuaDemo/LuaPhysicsSetup.cpp
@@ -2,7 +2,7 @@
 
 
 #include "../CommonInterfaces/CommonMultiBodyBase.h"
-#include "../Importers/ImportURDFDemo/MyURDFImporter.h"
+#include "../Importers/ImportURDFDemo/BulletURDFImporter.h"
 #include "../Importers/ImportURDFDemo/MyMultiBodyCreator.h"
 #include "../Importers/ImportURDFDemo/URDF2Bullet.h"
 
@@ -39,7 +39,12 @@ extern "C" {
 }
 
 
-const char* sLuaFileName = "init_urdf.lua";//init_physics.lua";
+const char* sLuaFileName = "init_physics.lua";
+static int upaxis = 1;
+
+//const char* sLuaFileName = "init_urdf.lua";
+//static int upaxis = 2;
+
 
 static const float scaling=0.35f;
 static LuaPhysicsSetup* sLuaDemo = 0;
@@ -69,7 +74,10 @@ LuaPhysicsSetup::~LuaPhysicsSetup()
 static int gCreateDefaultDynamicsWorld(lua_State *L)
 {
 	sLuaDemo->createEmptyDynamicsWorld();
-	sLuaDemo->m_dynamicsWorld->setGravity(btVector3(0,0,-10));
+    btVector3 grav(0,0,0);
+    grav[upaxis] = -10;
+    
+	sLuaDemo->m_dynamicsWorld->setGravity(grav);
 	sLuaDemo->m_guiHelper->createPhysicsDebugDrawer(sLuaDemo->m_dynamicsWorld);
 	lua_pushlightuserdata (L, sLuaDemo->m_dynamicsWorld);
 	return 1;
@@ -211,8 +219,8 @@ static int gLoadMultiBodyFromUrdf(lua_State *L)
 			return 0;
 		}
 		const char* fileName = lua_tostring(L,2);
-
-		MyURDFImporter u2b(sLuaDemo->m_guiHelper);
+#if 1
+		BulletURDFImporter u2b(sLuaDemo->m_guiHelper);
 		bool loadOk =  u2b.loadURDF(fileName);
 		if (loadOk)
 		{
@@ -240,6 +248,7 @@ static int gLoadMultiBodyFromUrdf(lua_State *L)
 		{
 			b3Printf("can't find %s",fileName);
 		}
+#endif
 	}
 
 	return 0;
@@ -377,7 +386,7 @@ static void report_errors(lua_State *L, int status)
 
 void LuaPhysicsSetup::initPhysics()
 {
-	m_guiHelper->setUpAxis(2);
+	m_guiHelper->setUpAxis(upaxis);
 	const char* prefix[]={"./","./data/","../data/","../../data/","../../../data/","../../../../data/"};
 	int numPrefixes = sizeof(prefix)/sizeof(const char*);
 	char relativeFileName[1024];

--- a/src/Bullet3OpenCL/NarrowphaseCollision/b3GjkEpa.cpp
+++ b/src/Bullet3OpenCL/NarrowphaseCollision/b3GjkEpa.cpp
@@ -34,7 +34,7 @@ namespace gjkepa2_impl2
 
 	/* GJK	*/ 
 #define GJK_MAX_ITERATIONS	128
-#define GJK_ACCURARY		((b3Scalar)0.0001)
+#define GJK_ACCURACY		((b3Scalar)0.0001)
 #define GJK_MIN_DISTANCE	((b3Scalar)0.0001)
 #define GJK_DUPLICATED_EPS	((b3Scalar)0.0001)
 #define GJK_SIMPLEX2_EPS	((b3Scalar)0.0)
@@ -216,7 +216,7 @@ namespace gjkepa2_impl2
 					/* Check for termination				*/ 
 					const b3Scalar	omega=b3Dot(m_ray,w)/rl;
 					alpha=b3Max(omega,alpha);
-					if(((rl-alpha)-(GJK_ACCURARY*rl))<=0)
+					if(((rl-alpha)-(GJK_ACCURACY*rl))<=0)
 					{/* Return old simplex				*/ 
 						removevertice(m_simplices[m_current]);
 						break;
@@ -998,7 +998,7 @@ bool	b3GjkEpaSolver2::SignedDistance(const btConvexShape*	shape0,
 /* Symbols cleanup		*/ 
 
 #undef GJK_MAX_ITERATIONS
-#undef GJK_ACCURARY
+#undef GJK_ACCURACY
 #undef GJK_MIN_DISTANCE
 #undef GJK_DUPLICATED_EPS
 #undef GJK_SIMPLEX2_EPS

--- a/src/BulletCollision/NarrowPhaseCollision/btGjkEpa2.cpp
+++ b/src/BulletCollision/NarrowPhaseCollision/btGjkEpa2.cpp
@@ -41,21 +41,38 @@ namespace gjkepa2_impl
 
 	/* GJK	*/ 
 #define GJK_MAX_ITERATIONS	128
-#define GJK_ACCURARY		((btScalar)0.0001)
-#define GJK_MIN_DISTANCE	((btScalar)0.0001)
-#define GJK_DUPLICATED_EPS	((btScalar)0.0001)
+
+#ifdef BT_USE_DOUBLE_PRECISION
+	#define GJK_ACCURARY		((btScalar)1e-12)
+	#define GJK_MIN_DISTANCE	((btScalar)1e-12)
+	#define GJK_DUPLICATED_EPS	((btScalar)1e-12)
+#else
+	#define GJK_ACCURARY		((btScalar)0.0001)
+	#define GJK_MIN_DISTANCE	((btScalar)0.0001)
+	#define GJK_DUPLICATED_EPS	((btScalar)0.0001)
+#endif //BT_USE_DOUBLE_PRECISION
+
+
 #define GJK_SIMPLEX2_EPS	((btScalar)0.0)
 #define GJK_SIMPLEX3_EPS	((btScalar)0.0)
 #define GJK_SIMPLEX4_EPS	((btScalar)0.0)
 
 	/* EPA	*/ 
-#define EPA_MAX_VERTICES	64
-#define EPA_MAX_FACES		(EPA_MAX_VERTICES*2)
+#define EPA_MAX_VERTICES	128
 #define EPA_MAX_ITERATIONS	255
-#define EPA_ACCURACY		((btScalar)0.0001)
-#define EPA_FALLBACK		(10*EPA_ACCURACY)
-#define EPA_PLANE_EPS		((btScalar)0.00001)
-#define EPA_INSIDE_EPS		((btScalar)0.01)
+
+#ifdef BT_USE_DOUBLE_PRECISION
+	#define EPA_ACCURACY		((btScalar)1e-12)
+	#define EPA_FALLBACK		(10*EPA_ACCURACY)
+	#define EPA_PLANE_EPS		((btScalar)1e-14)
+	#define EPA_INSIDE_EPS		((btScalar)1e-9)
+#else
+	#define EPA_ACCURACY		((btScalar)0.0001)
+	#define EPA_PLANE_EPS		((btScalar)0.00001)
+	#define EPA_INSIDE_EPS		((btScalar)0.01)
+#endif
+
+#define EPA_MAX_FACES           (EPA_MAX_VERTICES*2)
 
 
 	// Shorthands

--- a/src/BulletCollision/NarrowPhaseCollision/btGjkEpa2.cpp
+++ b/src/BulletCollision/NarrowPhaseCollision/btGjkEpa2.cpp
@@ -43,11 +43,11 @@ namespace gjkepa2_impl
 #define GJK_MAX_ITERATIONS	128
 
 #ifdef BT_USE_DOUBLE_PRECISION
-	#define GJK_ACCURARY		((btScalar)1e-12)
+	#define GJK_ACCURACY		((btScalar)1e-12)
 	#define GJK_MIN_DISTANCE	((btScalar)1e-12)
 	#define GJK_DUPLICATED_EPS	((btScalar)1e-12)
 #else
-	#define GJK_ACCURARY		((btScalar)0.0001)
+	#define GJK_ACCURACY		((btScalar)0.0001)
 	#define GJK_MIN_DISTANCE	((btScalar)0.0001)
 	#define GJK_DUPLICATED_EPS	((btScalar)0.0001)
 #endif //BT_USE_DOUBLE_PRECISION
@@ -259,7 +259,7 @@ namespace gjkepa2_impl
 					/* Check for termination				*/ 
 					const btScalar	omega=btDot(m_ray,w)/rl;
 					alpha=btMax(omega,alpha);
-					if(((rl-alpha)-(GJK_ACCURARY*rl))<=0)
+					if(((rl-alpha)-(GJK_ACCURACY*rl))<=0)
 					{/* Return old simplex				*/ 
 						removevertice(m_simplices[m_current]);
 						break;
@@ -1032,7 +1032,7 @@ bool	btGjkEpaSolver2::SignedDistance(const btConvexShape*	shape0,
 /* Symbols cleanup		*/ 
 
 #undef GJK_MAX_ITERATIONS
-#undef GJK_ACCURARY
+#undef GJK_ACCURACY
 #undef GJK_MIN_DISTANCE
 #undef GJK_DUPLICATED_EPS
 #undef GJK_SIMPLEX2_EPS

--- a/src/BulletCollision/NarrowPhaseCollision/btGjkEpa2.cpp
+++ b/src/BulletCollision/NarrowPhaseCollision/btGjkEpa2.cpp
@@ -63,7 +63,6 @@ namespace gjkepa2_impl
 
 #ifdef BT_USE_DOUBLE_PRECISION
 	#define EPA_ACCURACY		((btScalar)1e-12)
-	#define EPA_FALLBACK		(10*EPA_ACCURACY)
 	#define EPA_PLANE_EPS		((btScalar)1e-14)
 	#define EPA_INSIDE_EPS		((btScalar)1e-9)
 #else
@@ -72,6 +71,7 @@ namespace gjkepa2_impl
 	#define EPA_INSIDE_EPS		((btScalar)0.01)
 #endif
 
+#define EPA_FALLBACK            (10*EPA_ACCURACY)
 #define EPA_MAX_FACES           (EPA_MAX_VERTICES*2)
 
 

--- a/src/BulletCollision/NarrowPhaseCollision/btGjkPairDetector.cpp
+++ b/src/BulletCollision/NarrowPhaseCollision/btGjkPairDetector.cpp
@@ -30,7 +30,11 @@ subject to the following restrictions:
 #endif
 
 //must be above the machine epsilon
-#define REL_ERROR2 btScalar(1.0e-6)
+#ifdef  BT_USE_DOUBLE_PRECISION
+	#define REL_ERROR2 btScalar(1.0e-12)
+#else
+	#define REL_ERROR2 btScalar(1.0e-6)
+#endif
 
 //temp globals, to improve GJK/EPA/penetration calculations
 int gNumDeepPenetrationChecks = 0;


### PR DESCRIPTION
See also https://github.com/billhoffman/bullet-pod/blob/ac6aae3e3ee8137de484471094a65bfe166898b4/bullet_gjk_accuracy_patch.diff

