### PR TITLE
rename m_jointForce -> m_jointMotorForce to separate the name from m_…

### DIFF
--- a/examples/SharedMemory/PhysicsClientC_API.cpp
+++ b/examples/SharedMemory/PhysicsClientC_API.cpp
@@ -218,7 +218,7 @@ void b3GetJointState(b3PhysicsClientHandle physClient, b3SharedMemoryStatusHandl
 	  for (int ii(0); ii < 6; ++ii) {
 		state->m_jointForceTorque[ii] = status->m_sendActualStateArgs.m_jointReactionForces[6 * jointIndex + ii];
 	  }
-      state->m_jointTorque = status->m_sendActualStateArgs.m_jointMotorForce[jointIndex];
+      state->m_jointMotorTorque = status->m_sendActualStateArgs.m_jointMotorForce[jointIndex];
   }
 }
 

--- a/examples/SharedMemory/SharedMemoryPublic.h
+++ b/examples/SharedMemory/SharedMemoryPublic.h
@@ -94,7 +94,7 @@ struct b3JointSensorState
   double m_jointPosition;
   double m_jointVelocity;
   double m_jointForceTorque[6];  /* note to roboticists: this is NOT the motor torque/force, but the spatial reaction force vector at joint */
-  double m_jointTorque;
+  double m_jointMotorTorque;
 };
 
 struct b3DebugLines


### PR DESCRIPTION
…jointForceTorque (which should have been called m_jointReactionForce)