### PR TITLE
 Fix bullet.pc when built with CMAKE_INSTALL_PREFIX #626

### DIFF
--- a/bullet.pc.cmake
+++ b/bullet.pc.cmake
@@ -3,4 +3,4 @@ Description: Bullet Continuous Collision Detection and Physics Library
 Requires:
 Version: @BULLET_VERSION@
 Libs: -L@CMAKE_INSTALL_PREFIX@/@LIB_DESTINATION@ -lBulletSoftBody -lBulletDynamics -lBulletCollision -lLinearMath
-Cflags: @BULLET_DOUBLE_DEF@ -I@CMAKE_INSTALL_PREFIX@/@INCLUDE_INSTALL_DIR@ -I@CMAKE_INSTALL_PREFIX@/include
+Cflags: @BULLET_DOUBLE_DEF@ -I@INCLUDE_INSTALL_DIR@ -I@CMAKE_INSTALL_PREFIX@/include


### PR DESCRIPTION
This makes the macro usage consitent between bullet.pc.in and
BulletConfig.cmake.in, previously if the CMAKE_INSTALL_PREFIX
was set you would end up with -I/usr/usr/include/bullet rather then
-I/usr/include/bullet