### PR TITLE
Fixed btAssert warning message on printf in MSVC.

### DIFF
--- a/src/LinearMath/btScalar.h
+++ b/src/LinearMath/btScalar.h
@@ -104,7 +104,7 @@ inline int	btGetVersion()
 #ifdef BT_DEBUG
 	#ifdef _MSC_VER
 		#include <stdio.h>
-		#define btAssert(x) { if(!(x)){printf("Assert "__FILE__ ":%u ("#x")\n", __LINE__);__debugbreak();	}}
+		#define btAssert(x) { if(!(x)){printf("Assert "__FILE__ ":%u (%s)\n", __LINE__, #x);__debugbreak();	}}
 	#else//_MSC_VER
 		#include <assert.h>
 		#define btAssert assert


### PR DESCRIPTION
Hi, we noticed the current implementation of btAssert in MSVC may cause warning message if the expression to test contains "%". For example, we got the following error for BulletDynamics\MLCPSolvers\btDantzigLCP.cpp, line 1568:

1>..\..\src\BulletDynamics\MLCPSolvers\btDantzigLCP.cpp(1568): warning C4473: 'printf' : not enough arguments passed for format string
1>  ..\..\src\BulletDynamics\MLCPSolvers\btDantzigLCP.cpp(1568): note: placeholders and their parameters expect 2 variadic arguments, but 1 were provided
1>  ..\..\src\BulletDynamics\MLCPSolvers\btDantzigLCP.cpp(1568): note: the missing variadic argument 2 is required by format string '% s'

The proposed change moves the expression string outside of the format string. Thanks!