### PR TITLE
Fixed uninitialised info2->findex for btGeneric6DofSpring2Constraint.

### DIFF
--- a/src/BulletDynamics/ConstraintSolver/btGeneric6DofSpring2Constraint.cpp
+++ b/src/BulletDynamics/ConstraintSolver/btGeneric6DofSpring2Constraint.cpp
@@ -537,7 +537,7 @@ int btGeneric6DofSpring2Constraint::setLinearLimits(btConstraintInfo2* info, int
 			{
 				rotAllowed = 0;
 			}
-			row += get_limit_motor_info2(&limot, transA,transB,linVelA,linVelB,angVelA,angVelB, info, row, axis, 0, rotAllowed);
+			row += get_limit_motor_info2(&limot, transA,transB,linVelA,linVelB,angVelA,angVelB, info, row, axis, i, rotAllowed);
 
 		}
 	}
@@ -586,7 +586,7 @@ int btGeneric6DofSpring2Constraint::setAngularLimits(btConstraintInfo2 *info, in
 			{
 				m_angularLimits[i].m_motorERP = info->erp;
 			}
-			row += get_limit_motor_info2(&m_angularLimits[i],transA,transB,linVelA,linVelB,angVelA,angVelB, info,row,axis,1);
+			row += get_limit_motor_info2(&m_angularLimits[i],transA,transB,linVelA,linVelB,angVelA,angVelB, info,row,axis,3+i);
 		}
 	}
 
@@ -651,10 +651,11 @@ void btGeneric6DofSpring2Constraint::calculateJacobi(btRotationalLimitMotor2 * l
 int btGeneric6DofSpring2Constraint::get_limit_motor_info2(
 	btRotationalLimitMotor2 * limot,
 	const btTransform& transA,const btTransform& transB,const btVector3& linVelA,const btVector3& linVelB,const btVector3& angVelA,const btVector3& angVelB,
-	btConstraintInfo2 *info, int row, btVector3& ax1, int rotational,int rotAllowed)
+	btConstraintInfo2 *info, int row, btVector3& ax1, int findex,int rotAllowed)
 {
 	int count = 0;
 	int srow = row * info->rowskip;
+	int rotational = findex >= 3;
 
 	if (limot->m_currentLimit==4) 
 	{
@@ -676,6 +677,7 @@ int btGeneric6DofSpring2Constraint::get_limit_motor_info2(
 		info->m_lowerLimit[srow] = rotational ? 0 : -SIMD_INFINITY;
 		info->m_upperLimit[srow] = rotational ? SIMD_INFINITY : 0;
 		info->cfm[srow] = limot->m_stopCFM;
+		info->findex[srow] = findex;
 		srow += info->rowskip;
 		++count;
 
@@ -695,6 +697,7 @@ int btGeneric6DofSpring2Constraint::get_limit_motor_info2(
 		info->m_lowerLimit[srow] = rotational ? -SIMD_INFINITY : 0;
 		info->m_upperLimit[srow] = rotational ? 0 : SIMD_INFINITY;
 		info->cfm[srow] = limot->m_stopCFM;
+		info->findex[srow] = findex;
 		srow += info->rowskip;
 		++count;
 	} else
@@ -705,6 +708,7 @@ int btGeneric6DofSpring2Constraint::get_limit_motor_info2(
 		info->m_lowerLimit[srow] = -SIMD_INFINITY;
 		info->m_upperLimit[srow] = SIMD_INFINITY;
 		info->cfm[srow] = limot->m_stopCFM;
+		info->findex[srow] = findex;
 		srow += info->rowskip;
 		++count;
 	}
@@ -722,6 +726,7 @@ int btGeneric6DofSpring2Constraint::get_limit_motor_info2(
 		info->m_lowerLimit[srow] = -limot->m_maxMotorForce;
 		info->m_upperLimit[srow] = limot->m_maxMotorForce;
 		info->cfm[srow] = limot->m_motorCFM;
+		info->findex[srow] = findex;
 		srow += info->rowskip;
 		++count;
 	}
@@ -757,6 +762,7 @@ int btGeneric6DofSpring2Constraint::get_limit_motor_info2(
 		info->m_lowerLimit[srow] = -limot->m_maxMotorForce;
 		info->m_upperLimit[srow] = limot->m_maxMotorForce;
 		info->cfm[srow] = limot->m_motorCFM;
+		info->findex[srow] = findex;
 		srow += info->rowskip;
 		++count;
 	}
@@ -816,6 +822,7 @@ int btGeneric6DofSpring2Constraint::get_limit_motor_info2(
 		}
 
 		info->cfm[srow] = cfm;
+		info->findex[srow] = findex;
 		srow += info->rowskip;
 		++count;
 	}

--- a/src/BulletDynamics/ConstraintSolver/btGeneric6DofSpring2Constraint.h
+++ b/src/BulletDynamics/ConstraintSolver/btGeneric6DofSpring2Constraint.h
@@ -317,7 +317,7 @@ protected:
 	void calculateJacobi(btRotationalLimitMotor2* limot, const btTransform& transA,const btTransform& transB, btConstraintInfo2* info, int srow, btVector3& ax1, int rotational, int rotAllowed);
 	int get_limit_motor_info2(btRotationalLimitMotor2* limot,
 		const btTransform& transA,const btTransform& transB,const btVector3& linVelA,const btVector3& linVelB,const btVector3& angVelA,const btVector3& angVelB,
-		btConstraintInfo2* info, int row, btVector3& ax1, int rotational, int rotAllowed = false);
+		btConstraintInfo2* info, int row, btVector3& ax1, int findex, int rotAllowed = false);
 
 	static btScalar btGetMatrixElem(const btMatrix3x3& mat, int index);
 	static bool matrixToEulerXYZ(const btMatrix3x3& mat,btVector3& xyz);


### PR DESCRIPTION
Hi,

We recently encountered a bug with `btGeneric6DofSpring2Constraint` in which accumulated impulse was not being calculated properly. Upon further investigation we realised that `findex` in the info2 structure was not being initialised for this constraint type. Here is a patch that addresses the problem, by re-purposing the 'rotational' argument on `get_limit_motor_info2` to pass an findex value instead. Let me know what you think,

Thanks,

James Bird
Double Negative.