### PR TITLE
Apply gravity to each simulation sub step

### DIFF
--- a/src/BulletDynamics/Dynamics/btDiscreteDynamicsWorld.cpp
+++ b/src/BulletDynamics/Dynamics/btDiscreteDynamicsWorld.cpp
@@ -447,12 +447,9 @@ int	btDiscreteDynamicsWorld::stepSimulation( btScalar timeStep,int maxSubSteps, 
 
 		saveKinematicState(fixedTimeStep*clampedSimulationSteps);
 
-		applyGravity();
-
-
-
 		for (int i=0;i<clampedSimulationSteps;i++)
 		{
+			applyGravity();
 			internalSingleStepSimulation(fixedTimeStep);
 			synchronizeMotionStates();
 		}


### PR DESCRIPTION
btDiscreteDynamicsWorld::applyGravity() is only being executed once but needs to be executed for each simulation sub step. Either inside the for loop or inside btDiscreteDynamicsWorld::internalSingleStepSimulation()