### PR TITLE
Render image with camera_pos, target_pos, camera_up vector as arguments

### DIFF
--- a/examples/pybullet/pybullet.c
+++ b/examples/pybullet/pybullet.c
@@ -1033,8 +1033,9 @@ static PyObject* pybullet_renderImage(PyObject* self, PyObject* args)
   float cameraUp[3];
 
   float left, right, bottom, top, aspect;
-  float nearVal = .001;
-  float farVal = 1000;
+  float nearVal, farVal;
+  // float nearVal = .001;
+  // float farVal = 1000;
 
   // inialize cmd
   b3SharedMemoryCommandHandle command;
@@ -1073,32 +1074,33 @@ static PyObject* pybullet_renderImage(PyObject* self, PyObject* args)
 
    if (size==5) // set camera resoluation and view and projection matrix
    {
-     if (PyArg_ParseTuple(args, "iiOOO", &width, &height, &objCameraPos, &objTargetPos, &objCameraUp))
+     if (PyArg_ParseTuple(args, "iiOOOii", &width, &height, &objCameraPos, &objTargetPos, &objCameraUp, &nearVal, %farVal))
      {
        b3RequestCameraImageSetPixelResolution(command,width,height);
        if (pybullet_internalSetVector(objCameraPos, cameraPos) &&
            pybullet_internalSetVector(objTargetPos, targetPos) &&
            pybullet_internalSetVector(objCameraUp, cameraUp))
            {
-              printf("\ncamera pos:\n");
-                for(int i =0;i<3; i++) {
-                  printf(" %f", cameraPos[i]);
-                }
-  
-                printf("\ntargetPos pos:\n");
-                  for(int i =0;i<3; i++) {
-                    printf(" %f", targetPos[i]);
-                  }
-
-                printf("\ncameraUp pos:\n");
-                  for(int i =0;i<3; i++) {
-                    printf(" %f", cameraUp[i]);
-                  }
-                  printf("\n");
+              // printf("\ncamera pos:\n");
+              //   for(int i =0;i<3; i++) {
+              //     printf(" %f", cameraPos[i]);
+              //   }
+              // 
+              //   printf("\ntargetPos pos:\n");
+              //     for(int i =0;i<3; i++) {
+              //       printf(" %f", targetPos[i]);
+              //     }
+              // 
+              //   printf("\ncameraUp pos:\n");
+              //     for(int i =0;i<3; i++) {
+              //       printf(" %f", cameraUp[i]);
+              //     }
+              //     printf("\n");
                 b3RequestCameraImageSetViewMatrix(command, cameraPos, targetPos, cameraUp);
-                printf("\n");
+                // printf("\n");
 
            }
+           
            aspect = width/height;
            left = -aspect * nearVal;
            right = aspect * nearVal;
@@ -1106,7 +1108,7 @@ static PyObject* pybullet_renderImage(PyObject* self, PyObject* args)
            top = nearVal;
            
            b3RequestCameraImageSetProjectionMatrix(command, left, right, bottom, top, nearVal, farVal);
-           printf("\n");
+          //  printf("\n");
 
       }
     }

--- a/examples/pybullet/pybullet.c
+++ b/examples/pybullet/pybullet.c
@@ -1074,7 +1074,7 @@ static PyObject* pybullet_renderImage(PyObject* self, PyObject* args)
 
    if (size==5) // set camera resoluation and view and projection matrix
    {
-     if (PyArg_ParseTuple(args, "iiOOOii", &width, &height, &objCameraPos, &objTargetPos, &objCameraUp, &nearVal, %farVal))
+     if (PyArg_ParseTuple(args, "iiOOOii", &width, &height, &objCameraPos, &objTargetPos, &objCameraUp, &nearVal, &farVal))
      {
        b3RequestCameraImageSetPixelResolution(command,width,height);
        if (pybullet_internalSetVector(objCameraPos, cameraPos) &&

--- a/examples/pybullet/pybullet.c
+++ b/examples/pybullet/pybullet.c
@@ -1225,7 +1225,7 @@ static PyMethodDef SpamMethods[] = {
     //applyLinkForce
      
 	{"renderImage", pybullet_renderImage, METH_VARARGS,
-	"Render an image (given the pixel resolution width & height and camera view & projection matrices), and return the 8-8-8bit RGB pixel data and floating point depth values"},	
+	"Render an image (given the pixel resolution width, height, view matrix, projection matrix, near and far vlues), and return the 8-8-8bit RGB pixel data and floating point depth values"},	
 	
     {NULL, NULL, 0, NULL}        /* Sentinel */
 };


### PR DESCRIPTION
- adding internal set vector as helper to renderImage with three vectors
- ability to call renderImage with three vectors: camera position, target position, and up vector

successfully tested by comparing view and projection matrix generated from C-API and python camera.py code:

➜  bullet_experiments python test_renderImage.py

camera pos:
 2.000000 0.000000 1.000000
targetPos pos:
 0.000000 0.000000 0.000000
cameraUp pos:
 0.000000 0.000000 1.000000

printing python viewMatrix:
[[ 0.         -0.4472136   0.89442719  0.        ]
 [ 1.          0.         -0.          0.        ]
 [-0.          0.89442719  0.4472136   0.        ]
 [-0.         -0.         -2.23606798  1.        ]]
printing python projectionMatrix
[[ 1.         0.         0.         0.       ]
 [ 0.         1.         0.         0.       ]
 [ 0.         0.        -1.00002   -1.       ]
 [ 0.         0.        -0.0200002  0.       ]]

printing b3RequestCameraImageSetViewMatrix:

 0.000000 -0.447214 0.894427 0.000000
 1.000000 0.000000 -0.000000 0.000000
 -0.000000 0.894427 0.447214 0.000000
 -0.000000 -0.000000 -2.236068 1.000000

printing b3RequestCameraImageSetProjectionMatrix:

 1.000000 0.000000 0.000000 0.000000
 0.000000 1.000000 0.000000 0.000000
 0.000000 0.000000 -1.000002 -1.000000
 0.000000 0.000000 -0.002000 0.000000