### PR TITLE
pkg-config: Fixing regression introduced by e46b7b2

### DIFF
--- a/bullet.pc.cmake
+++ b/bullet.pc.cmake
@@ -3,4 +3,4 @@ Description: Bullet Continuous Collision Detection and Physics Library
 Requires:
 Version: @BULLET_VERSION@
 Libs: -L@CMAKE_INSTALL_PREFIX@/@LIB_DESTINATION@ -lBulletSoftBody -lBulletDynamics -lBulletCollision -lLinearMath
-Cflags: @BULLET_DOUBLE_DEF@ -I@INCLUDE_INSTALL_DIR@ -I@CMAKE_INSTALL_PREFIX@/include
+Cflags: @BULLET_DOUBLE_DEF@ -I@CMAKE_INSTALL_PREFIX@/@INCLUDE_INSTALL_DIR@ -I@CMAKE_INSTALL_PREFIX@/include


### PR DESCRIPTION
PR #626 introduces a regression for projects which rely on `$PREFIX/include/bullet` being in the list of include paths. The `@INCLUDE_INSTALL_DIR@` variable is always set to just `include/bullet` (a relative path) but pkg-config paths should be absolute. This commit effectively reverts @scpeters patch: d7131e9bb0df5163050f046bc432148fbd23befd

If someone relies on this pkg-config file from a CMake project, they will end up with include paths which are relative to the calling CMakeLists.txt file, which is definitely the incorrect behavior.

This PR reverts the bug introduced by e46b7b2 / #626.

@simotek @erwincoumans