### PR TITLE
There were some casts in the modified files that were very sketchy, i…

### DIFF
--- a/Extras/Serialize/BulletFileLoader/bDNA.cpp
+++ b/Extras/Serialize/BulletFileLoader/bDNA.cpp
@@ -391,7 +391,7 @@ void bDNA::init(char *data, int len, bool swap)
 
 	
 	{
-		nr= (long)cp;
+    	        nr= atol(cp);
 	//long mask=3;
 		nr= ((nr+3)&~3)-nr;
 		while (nr--)
@@ -427,7 +427,7 @@ void bDNA::init(char *data, int len, bool swap)
 	}
 
 {
-		nr= (long)cp;
+                nr= atol(cp);
 	//	long mask=3;
 		nr= ((nr+3)&~3)-nr;
 		while (nr--)

--- a/Extras/Serialize/BulletFileLoader/bFile.cpp
+++ b/Extras/Serialize/BulletFileLoader/bFile.cpp
@@ -461,7 +461,7 @@ void bFile::swapDNA(char* ptr)
 
 	
 	{
-		nr= (long)cp;
+	  nr= atol(cp);
 	//long mask=3;
 		nr= ((nr+3)&~3)-nr;
 		while (nr--)
@@ -498,7 +498,7 @@ void bFile::swapDNA(char* ptr)
 	}
 
 {
-		nr= (long)cp;
+        nr= atol(cp);
 	//	long mask=3;
 		nr= ((nr+3)&~3)-nr;
 		while (nr--)

--- a/src/Bullet3Serialize/Bullet2FileLoader/b3DNA.cpp
+++ b/src/Bullet3Serialize/Bullet2FileLoader/b3DNA.cpp
@@ -390,7 +390,7 @@ void bDNA::init(char *data, int len, bool swap)
 
 	
 	{
-		nr= (long)cp;
+	        nr= atol(cp);
 	//long mask=3;
 		nr= ((nr+3)&~3)-nr;
 		while (nr--)
@@ -426,7 +426,7 @@ void bDNA::init(char *data, int len, bool swap)
 	}
 
 {
-		nr= (long)cp;
+                nr= atol(cp);
 	//	long mask=3;
 		nr= ((nr+3)&~3)-nr;
 		while (nr--)

--- a/src/Bullet3Serialize/Bullet2FileLoader/b3File.cpp
+++ b/src/Bullet3Serialize/Bullet2FileLoader/b3File.cpp
@@ -429,7 +429,7 @@ void bFile::swapDNA(char* ptr)
 
 
 	{
-		nr= (long)cp;
+	        nr= atol(cp);
 	//long mask=3;
 		nr= ((nr+3)&~3)-nr;
 		while (nr--)
@@ -466,7 +466,7 @@ void bFile::swapDNA(char* ptr)
 	}
 
 {
-		nr= (long)cp;
+                nr= atol(cp);
 	//	long mask=3;
 		nr= ((nr+3)&~3)-nr;
 		while (nr--)


### PR DESCRIPTION
…nsomuch that they were causing compiler errors for me on windows. (I am done cross compiling for now)

Basically the standard libraries have a function called atol that will convert the char to a long in a much cleaner way than an old style cast will. I went through and replaced them so I would stop getting the compiler errors; this is also most likely a better practice than old style casting, since it is in the standard libraries