### PR TITLE
[WIP] Suppress compiler warnings.

### DIFF
--- a/examples/Benchmarks/BenchmarkDemo.cpp
+++ b/examples/Benchmarks/BenchmarkDemo.cpp
@@ -1273,7 +1273,7 @@ void	BenchmarkDemo::exitPhysics()
 
 
 
-struct CommonExampleInterface*    BenchmarkCreateFunc(struct CommonExampleOptions& options)
+CommonExampleInterface*    BenchmarkCreateFunc(struct CommonExampleOptions& options)
 {
 	return new BenchmarkDemo(options.m_guiHelper,options.m_option);
 }

--- a/examples/Importers/ImportBsp/ImportBspExample.cpp
+++ b/examples/Importers/ImportBsp/ImportBspExample.cpp
@@ -285,7 +285,7 @@ char* makeExeToBspFilename(const char* lpCmdLine)
 }
 
 
-struct CommonExampleInterface*    ImportBspCreateFunc(struct CommonExampleOptions& options)
+CommonExampleInterface*    ImportBspCreateFunc(struct CommonExampleOptions& options)
 {
 	BspDemo* demo = new BspDemo(options.m_guiHelper);
 		

--- a/examples/RenderingExamples/CoordinateSystemDemo.cpp
+++ b/examples/RenderingExamples/CoordinateSystemDemo.cpp
@@ -156,7 +156,7 @@ public:
 	}
 };
 
-struct CommonExampleInterface*    CoordinateSystemCreateFunc(struct CommonExampleOptions& options)
+CommonExampleInterface*    CoordinateSystemCreateFunc(struct CommonExampleOptions& options)
 {
 	return new CoordinateSystemDemo(options.m_guiHelper->getAppInterface());
 }


### PR DESCRIPTION
Visual Studio C4099: 'CommonExampleInterface': type name first seen using 'class' now seen using 'struct'.