### PR TITLE
[WIP] Suppress compiler warnings.

### DIFF
--- a/src/Bullet3OpenCL/RigidBody/b3GpuJacobiContactSolver.cpp
+++ b/src/Bullet3OpenCL/RigidBody/b3GpuJacobiContactSolver.cpp
@@ -562,7 +562,7 @@ void b3GpuJacobiContactSolver::solveGroupHost(b3RigidBodyData* bodies,b3InertiaD
 	b3AlignedObjectArray<b3Vector3> deltaAngularVelocities;
 	deltaLinearVelocities.resize(totalNumSplitBodies);
 	deltaAngularVelocities.resize(totalNumSplitBodies);
-	for (int i=0;i<totalNumSplitBodies;i++)
+	for (unsigned int i=0;i<totalNumSplitBodies;i++)
 	{
 		deltaLinearVelocities[i].setZero();
 		deltaAngularVelocities[i].setZero();


### PR DESCRIPTION
Suppress Visual Studio warning C4018: '<': signed/unsigned mismatch.