### PR TITLE
[WIP] Suppress compiler warnings.

### DIFF
--- a/Extras/InverseDynamics/DillCreator.cpp
+++ b/Extras/InverseDynamics/DillCreator.cpp
@@ -44,7 +44,7 @@ int DillCreator::getNumBodies(int* num_bodies) const {
     return 0;
 }
 
-int DillCreator::getBody(int body_index, int* parent_index, JointType* joint_type,
+int DillCreator::getBody(const int body_index, int* parent_index, JointType* joint_type,
                          vec3* parent_r_parent_body_ref, mat33* body_T_parent_ref,
                          vec3* body_axis_of_motion, idScalar* mass, vec3* body_r_body_com,
                          mat33* body_I_body, int* user_int, void** user_ptr) const {

--- a/Extras/InverseDynamics/DillCreator.hpp
+++ b/Extras/InverseDynamics/DillCreator.hpp
@@ -22,7 +22,7 @@ public:
     ///\copydoc MultiBodyTreeCreator::getNumBodies
     int getNumBodies(int* num_bodies) const;
     ///\copydoc MultiBodyTreeCreator::getBody
-    int getBody(int body_index, int* parent_index, JointType* joint_type,
+    int getBody(const int body_index, int* parent_index, JointType* joint_type,
                 vec3* parent_r_parent_body_ref, mat33* body_T_parent_ref, vec3* body_axis_of_motion,
                 idScalar* mass, vec3* body_r_body_com, mat33* body_I_body, int* user_int,
                 void** user_ptr) const;

--- a/Extras/InverseDynamics/btMultiBodyTreeCreator.cpp
+++ b/Extras/InverseDynamics/btMultiBodyTreeCreator.cpp
@@ -237,7 +237,7 @@ int btMultiBodyTreeCreator::getNumBodies(int *num_bodies) const {
     return 0;
 }
 
-int btMultiBodyTreeCreator::getBody(int body_index, int *parent_index, JointType *joint_type,
+int btMultiBodyTreeCreator::getBody(const int body_index, int *parent_index, JointType *joint_type,
                                     vec3 *parent_r_parent_body_ref, mat33 *body_T_parent_ref,
                                     vec3 *body_axis_of_motion, idScalar *mass,
                                     vec3 *body_r_body_com, mat33 *body_I_body, int *user_int,

--- a/Extras/InverseDynamics/btMultiBodyTreeCreator.hpp
+++ b/Extras/InverseDynamics/btMultiBodyTreeCreator.hpp
@@ -25,7 +25,7 @@ public:
     /// \copydoc MultiBodyTreeCreator::getNumBodies
     int getNumBodies(int *num_bodies) const;
     ///\copydoc MultiBodyTreeCreator::getBody
-    int getBody(int body_index, int *parent_index, JointType *joint_type,
+    int getBody(const int body_index, int *parent_index, JointType *joint_type,
                 vec3 *parent_r_parent_body_ref, mat33 *body_T_parent_ref, vec3 *body_axis_of_motion,
                 idScalar *mass, vec3 *body_r_body_com, mat33 *body_I_body, int *user_int,
                 void **user_ptr) const;


### PR DESCRIPTION
Fix Visual Studio warning C4373: previous versions of the compiler did
not override when parameters only differed by const/volatile qualifiers.