### PR TITLE
[WIP] Suppress compiler warnings.

### DIFF
--- a/src/BulletDynamics/ConstraintSolver/btContactConstraint.h
+++ b/src/BulletDynamics/ConstraintSolver/btContactConstraint.h
@@ -22,7 +22,8 @@ subject to the following restrictions:
 #include "BulletCollision/NarrowPhaseCollision/btPersistentManifold.h"
 
 ///btContactConstraint can be automatically created to solve contact constraints using the unified btTypedConstraint interface
-ATTRIBUTE_ALIGNED16(class) btContactConstraint : public btTypedConstraint
+ATTRIBUTE_ALIGNED128(class) btContactConstraint : public btTypedConstraint
+//ATTRIBUTE_ALIGNED16(class) btContactConstraint : public btTypedConstraint
 {
 protected:
 


### PR DESCRIPTION
Fix Visual Studio warning C4359: Alignment specifier is less than actual
alignment and will be ignored.

The original warning is caused by the fact that the member
'm_contactManifold' becomes 128-byte aligned after commit
fbc17731ec66da9626b52c7fe8830a03faf4049e.