### PR TITLE
Fixed btKinematicCharacterController from clipping through walls in corners.

### DIFF
--- a/src/BulletDynamics/Character/btKinematicCharacterController.cpp
+++ b/src/BulletDynamics/Character/btKinematicCharacterController.cpp
@@ -453,16 +453,11 @@ void btKinematicCharacterController::stepForwardAndStrafe ( btCollisionWorld* co
 				break;
 			}
 
-		} else {
-//			if (!m_wasJumping)
-				// we moved whole way
-				m_currentPosition = m_targetPosition;
 		}
-		m_currentPosition = m_targetPosition;
-
-	//	if (callback.m_closestHitFraction == 0.f)
-	//		break;
-
+        else
+        {
+            m_currentPosition = m_targetPosition;
+		}
 	}
 }
 


### PR DESCRIPTION
Noticed that btKinematicCharacterController was changed, decided to give it a whirl and noticed it had a problem as it was going through walls in corners. This should fix it.