### PR TITLE
Added .gitignore - osx for right now

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+
+# Files
+
+*.cmake
+*.dylib
+*.a
+CMakeCache.txt
+CMakeFiles
+Makefile
+install_manifest.txt
+bullet.pc
+
+
+# Examples
+
+examples/BasicDemo/AppBasicExampleGui
+examples/BasicDemo/App_BasicExample
+examples/ExampleBrowser/App_ExampleBrowser
+examples/HelloWorld/App_HelloWorld
+
+
+# Tests
+
+test/BulletDynamics/pendulum/Test_BulletDynamics
+test/InverseDynamics/Test_BulletInverseDynamics
+test/SharedMemory/Test_PhysicsClientServer
+test/collision/Test_Collision


### PR DESCRIPTION
I noticed bullet doesn't have a `.gitignore` file. I think it would be helpful to have one. I don't see any downsides with having one here.

I did look to see if anyone else made a PR to add `.gitignore`, and it was rejected as it looks like you are supposed to build out of source. If that's the way it is, that's fine, but if the documentation to build the source involves a bunch of files to appear as untracked, then we should add documentation on building out of source or even doing it automatically for you on build.
