### PR TITLE
Enable rpath on OS X when the CMake version supports it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,10 @@ SET(BULLET_VERSION 2.85)
 
 IF(COMMAND cmake_policy)
    cmake_policy(SET CMP0003 NEW)
+   if(POLICY CMP0042)
+      # Enable MACOSX_RPATH by default.
+      cmake_policy(SET COMP0042 NEW)
+   endif(POLICY CMP0042)
 ENDIF(COMMAND cmake_policy)
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ IF(COMMAND cmake_policy)
    cmake_policy(SET CMP0003 NEW)
    if(POLICY CMP0042)
       # Enable MACOSX_RPATH by default.
-      cmake_policy(SET COMP0042 NEW)
+      cmake_policy(SET CMP0042 NEW)
    endif(POLICY CMP0042)
 ENDIF(COMMAND cmake_policy)
 


### PR DESCRIPTION
CMake policy `CMP0042` changes the default value of the `MACOSX_RPATH` target property to `TRUE`, therefore setting the directory portion of the `install_name` field of a Bullet shared library to be `@rpath` on OS X and fixing issues such as
```
dyld: Library not loaded: libBulletSoftBody.2.85.dylib
  Referenced from: /path/to/executable
  Reason: image not found
```

* [CMake Documentation on `CMP0042`](https://cmake.org/cmake/help/latest/policy/CMP0042.html)
* [CMake Documentation on `MACOSX_RPATH`](https://cmake.org/cmake/help/latest/prop_tgt/MACOSX_RPATH.html)
* [Apple Documentation on `@rpath`](https://developer.apple.com/library/content/documentation/DeveloperTools/Conceptual/DynamicLibraries/100-Articles/RunpathDependentLibraries.html)