### PR TITLE
Remove useless const qualifiers from returns

### DIFF
--- a/Extras/HACD/hacdHACD.h
+++ b/Extras/HACD/hacdHACD.h
@@ -81,38 +81,38 @@ namespace HACD
 
 		//! Gives the triangles partitionas an array of size m_nTriangles where the i-th element specifies the cluster to which belong the i-th triangle
 		//! @return triangles partition
-		const long * const							GetPartition() const { return m_partition;}
+		const long *							GetPartition() const { return m_partition;}
         //! Sets the scale factor
 		//! @param scale scale factor
 		void										SetScaleFactor(double  scale) { m_scale = scale;}
 		//! Gives the scale factor
 		//! @return scale factor
-		const double								GetScaleFactor() const { return m_scale;}
+		double								GetScaleFactor() const { return m_scale;}
 		//! Sets the call-back function
 		//! @param callBack pointer to the call-back function
 		void										SetCallBack(CallBackFunction  callBack) { m_callBack = callBack;}
 		//! Gives the call-back function
 		//! @return pointer to the call-back function
-		const CallBackFunction                      GetCallBack() const { return m_callBack;}
-        
+		CallBackFunction                      GetCallBack() const { return m_callBack;}
+
         //! Specifies whether faces points should be added when computing the concavity
 		//! @param addFacesPoints true = faces points should be added
 		void										SetAddFacesPoints(bool  addFacesPoints) { m_addFacesPoints = addFacesPoints;}
 		//! Specifies wheter faces points should be added when computing the concavity
 		//! @return true = faces points should be added
-		const bool									GetAddFacesPoints() const { return m_addFacesPoints;}
+		bool									GetAddFacesPoints() const { return m_addFacesPoints;}
         //! Specifies whether extra points should be added when computing the concavity
 		//! @param addExteraDistPoints true = extra points should be added
 		void										SetAddExtraDistPoints(bool  addExtraDistPoints) { m_addExtraDistPoints = addExtraDistPoints;}
 		//! Specifies wheter extra points should be added when computing the concavity
 		//! @return true = extra points should be added
-		const bool									GetAddExtraDistPoints() const { return m_addExtraDistPoints;}
+		bool									GetAddExtraDistPoints() const { return m_addExtraDistPoints;}
         //! Specifies whether extra points should be added when computing the concavity
 		//! @param addExteraDistPoints true = extra points should be added
 		void										SetAddNeighboursDistPoints(bool  addNeighboursDistPoints) { m_addNeighboursDistPoints = addNeighboursDistPoints;}
 		//! Specifies wheter extra points should be added when computing the concavity
 		//! @return true = extra points should be added
-		const bool									GetAddNeighboursDistPoints() const { return m_addNeighboursDistPoints;}
+		bool									GetAddNeighboursDistPoints() const { return m_addNeighboursDistPoints;}
         //! Sets the points of the input mesh (Remark: the input points will be scaled and shifted. Use DenormalizeData() to invert those operations)
 		//! @param points pointer to the input points
 		void										SetPoints(Vec3<Real>  * points) { m_points = points;}
@@ -130,19 +130,19 @@ namespace HACD
 		void										SetNPoints(size_t nPoints) { m_nPoints = nPoints;}
 		//! Gives the number of points in the input mesh.
 		//! @return number of points the input mesh
-		const size_t								GetNPoints() const { return m_nPoints;}
+		size_t								GetNPoints() const { return m_nPoints;}
 		//! Sets the number of triangles in the input mesh.
 		//! @param nTriangles number of triangles in the input mesh
 		void										SetNTriangles(size_t nTriangles) { m_nTriangles = nTriangles;}
 		//! Gives the number of triangles in the input mesh.
 		//! @return number of triangles the input mesh
-		const size_t								GetNTriangles() const { return m_nTriangles;}
+		size_t								GetNTriangles() const { return m_nTriangles;}
 		//! Sets the minimum number of clusters to be generated.
 		//! @param nClusters minimum number of clusters
 		void										SetNClusters(size_t nClusters) { m_nMinClusters = nClusters;}
 		//! Gives the number of generated clusters.
 		//! @return number of generated clusters
-		const size_t								GetNClusters() const { return m_nClusters;}
+		size_t								GetNClusters() const { return m_nClusters;}
 		//! Sets the maximum allowed concavity.
 		//! @param concavity maximum concavity
 		void										SetConcavity(double concavity) { m_concavity = concavity;}
@@ -172,7 +172,7 @@ namespace HACD
         void										SetNVerticesPerCH(size_t nVerticesPerCH) { m_nVerticesPerCH = nVerticesPerCH;}
 		//! Gives the maximum number of vertices for each generated convex-hull.
 		//! @return maximum # vertices per CH
-		const size_t								GetNVerticesPerCH() const { return m_nVerticesPerCH;}
+		size_t								GetNVerticesPerCH() const { return m_nVerticesPerCH;}
 		//! Gives the number of vertices for the cluster number numCH.
 		//! @return number of vertices
 		size_t                                      GetNPointsCH(size_t numCH) const;

--- a/Extras/HACD/hacdVector.h
+++ b/Extras/HACD/hacdVector.h
@@ -58,7 +58,7 @@ namespace HACD
 		T					m_data[3];
 	};
     template<typename T>
-    const bool Colinear(const Vec3<T> & a, const Vec3<T> & b, const Vec3<T> & c);
+    bool Colinear(const Vec3<T> & a, const Vec3<T> & b, const Vec3<T> & c);
     template<typename T>
     const T Volume(const Vec3<T> & a, const Vec3<T> & b, const Vec3<T> & c, const Vec3<T> & d);
     

--- a/Extras/HACD/hacdVector.inl
+++ b/Extras/HACD/hacdVector.inl
@@ -162,7 +162,7 @@ namespace HACD
 	inline Vec3<T>::Vec3() {}
     
     template<typename T>
-    inline const bool Colinear(const Vec3<T> & a, const Vec3<T> & b, const Vec3<T> & c)
+    inline bool Colinear(const Vec3<T> & a, const Vec3<T> & b, const Vec3<T> & c)
     {
         return  ((c.Z() - a.Z()) * (b.Y() - a.Y()) - (b.Z() - a.Z()) * (c.Y() - a.Y()) == 0.0 /*EPS*/) &&
                 ((b.Z() - a.Z()) * (c.X() - a.X()) - (b.X() - a.X()) * (c.Z() - a.Z()) == 0.0 /*EPS*/) &&

--- a/src/BulletInverseDynamics/details/IDLinearMathInterface.hpp
+++ b/src/BulletInverseDynamics/details/IDLinearMathInterface.hpp
@@ -22,7 +22,7 @@ public:
 	vec3(const btVector3& btv) { *this = btv; }
 	idScalar& operator()(int i) { return (*this)[i]; }
 	const idScalar& operator()(int i) const { return (*this)[i]; }
-	const int size() const { return 3; }
+	int size() const { return 3; }
 	const vec3& operator=(const btVector3& rhs) {
 		*static_cast<btVector3*>(this) = rhs;
 		return *this;


### PR DESCRIPTION
Remove `const` qualifiers applied to POD return values, as these are meaningless and ignored by the compiler and are therefore potentially misleading. (They also trip `-Wignored-qualifiers`.)