### PR TITLE
Fixed linker error in Visual Studio 2015

### DIFF
--- a/src/BulletSoftBody/CMakeLists.txt
+++ b/src/BulletSoftBody/CMakeLists.txt
@@ -15,6 +15,7 @@ SET(BulletSoftBody_SRCS
 	btSoftRigidDynamicsWorld.cpp
 	btSoftSoftCollisionAlgorithm.cpp
 	btDefaultSoftBodySolver.cpp
+	btPolarDecomposition.cpp
 
 )
 

--- a/src/BulletSoftBody/CMakeLists.txt
+++ b/src/BulletSoftBody/CMakeLists.txt
@@ -15,7 +15,7 @@ SET(BulletSoftBody_SRCS
 	btSoftRigidDynamicsWorld.cpp
 	btSoftSoftCollisionAlgorithm.cpp
 	btDefaultSoftBodySolver.cpp
-	btPolarDecomposition.cpp
+	../LinearMath/btPolarDecomposition.cpp
 
 )
 


### PR DESCRIPTION
When using set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON) to generate DLLs 2 linker errors crop up from linking to LinearMath.lib. These errors are from btPolarDecomposition::DEFAULT_TOLERANCE and btPolarDecomposition::DEFAULT_MAX_ITERATIONS being declared in the header, but only defined in the btPolarDecomposition.cpp file. Therefore the definitions aren't found in btSoftBody.lib. The simple solution is to just include btPolarDecomposition.cpp into the btSoftBody compilation.