### PR TITLE
collisionObject: renamed uniqueId to worldArrayIndex

### DIFF
--- a/src/BulletCollision/CollisionDispatch/btCollisionObject.cpp
+++ b/src/BulletCollision/CollisionDispatch/btCollisionObject.cpp
@@ -28,6 +28,7 @@ btCollisionObject::btCollisionObject()
 		m_collisionFlags(btCollisionObject::CF_STATIC_OBJECT),
 		m_islandTag1(-1),
 		m_companionId(-1),
+        m_worldArrayIndex(-1),
 		m_activationState1(1),
 		m_deactivationTime(btScalar(0.)),
 		m_friction(btScalar(0.5)),

--- a/src/BulletCollision/CollisionDispatch/btCollisionObject.h
+++ b/src/BulletCollision/CollisionDispatch/btCollisionObject.h
@@ -79,7 +79,7 @@ protected:
 
 	int				m_islandTag1;
 	int				m_companionId;
-    int             m_uniqueId;
+    int             m_worldArrayIndex;  // index of object in world's collisionObjects array
 
 	mutable int				m_activationState1;
 	mutable btScalar			m_deactivationTime;
@@ -456,14 +456,15 @@ public:
 		m_companionId = id;
 	}
 
-    SIMD_FORCE_INLINE int getUniqueId() const
+    SIMD_FORCE_INLINE int getWorldArrayIndex() const
     {
-        return	m_uniqueId;
+        return	m_worldArrayIndex;
     }
 
-    void	setUniqueId( int id )
+    // only should be called by CollisionWorld
+    void setWorldArrayIndex(int ix)
     {
-        m_uniqueId = id;
+        m_worldArrayIndex = ix;
     }
 
     SIMD_FORCE_INLINE btScalar			getHitFraction() const

--- a/src/BulletDynamics/ConstraintSolver/btSequentialImpulseConstraintSolver.cpp
+++ b/src/BulletDynamics/ConstraintSolver/btSequentialImpulseConstraintSolver.cpp
@@ -751,7 +751,7 @@ int	btSequentialImpulseConstraintSolver::getOrInitSolverBody(btCollisionObject& 
         // Kinematic bodies can be in multiple islands at once, so it is a
         // race condition to write to them, so we use an alternate method
         // to record the solverBodyId
-        int uniqueId = body.getUniqueId();
+        int uniqueId = body.getWorldArrayIndex();
         const int INVALID_SOLVER_BODY_ID = -1;
         if (uniqueId >= m_kinematicBodyUniqueIdToSolverBodyTable.size())
         {

--- a/src/BulletDynamics/Dynamics/btDiscreteDynamicsWorldMt.cpp
+++ b/src/BulletDynamics/Dynamics/btDiscreteDynamicsWorldMt.cpp
@@ -149,7 +149,6 @@ void	btDiscreteDynamicsWorldMt::solveConstraints(btContactSolverInfo& solverInfo
 {
 	BT_PROFILE("solveConstraints");
 
-
 	m_solverIslandCallbackMt->setup(&solverInfo, getDebugDrawer());
 	m_constraintSolver->prepareSolve(getCollisionWorld()->getNumCollisionObjects(), getCollisionWorld()->getDispatcher()->getNumManifolds());
 
@@ -161,8 +160,3 @@ void	btDiscreteDynamicsWorldMt::solveConstraints(btContactSolverInfo& solverInfo
 }
 
 
-void btDiscreteDynamicsWorldMt::addCollisionObject(btCollisionObject* collisionObject, short int collisionFilterGroup, short int collisionFilterMask)
-{
-    collisionObject->setUniqueId(m_collisionObjects.size());
-    btDiscreteDynamicsWorld::addCollisionObject(collisionObject, collisionFilterGroup, collisionFilterMask);
-}

--- a/src/BulletDynamics/Dynamics/btDiscreteDynamicsWorldMt.h
+++ b/src/BulletDynamics/Dynamics/btDiscreteDynamicsWorldMt.h
@@ -35,8 +35,6 @@ protected:
 public:
 	BT_DECLARE_ALIGNED_ALLOCATOR();
 
-    virtual void addCollisionObject(btCollisionObject* collisionObject,short int collisionFilterGroup=btBroadphaseProxy::StaticFilter,short int collisionFilterMask=btBroadphaseProxy::AllFilter ^ btBroadphaseProxy::StaticFilter);
-
 	btDiscreteDynamicsWorldMt(btDispatcher* dispatcher,btBroadphaseInterface* pairCache,btConstraintSolver* constraintSolver,btCollisionConfiguration* collisionConfiguration);
 	virtual ~btDiscreteDynamicsWorldMt();
 };


### PR DESCRIPTION
This fixes a bug in the multithreaded dynamics world when objects are removed.
The uniqueId field in collision object has been replaced by a more aptly named worldArrayIndex.
The worldArrayIndex is -1 if the object is not in the world array.

I took the opportunity to use the worldArrayIndex to avoid a linear search through the collisionObjects array in CollisionWorld::removeCollisionObject().