### PR TITLE
example browser: slider widget improvements

### DIFF
--- a/examples/CommonInterfaces/CommonParameterInterface.h
+++ b/examples/CommonInterfaces/CommonParameterInterface.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-typedef void (*SliderParamChangedCallback) (float newVal);
+typedef void (*SliderParamChangedCallback) (float newVal, void* userPointer);
 #include "LinearMath/btScalar.h"
 
 struct SliderParams
@@ -16,6 +16,7 @@ struct SliderParams
 	btScalar* m_paramValuePointer;
 	void* m_userPointer;
 	bool m_clampToNotches;
+    bool m_clampToIntegers;
     bool m_showValues;
     
 	SliderParams(const char* name, btScalar* targetValuePointer)
@@ -26,6 +27,7 @@ struct SliderParams
 	m_paramValuePointer(targetValuePointer),
 	m_userPointer(0),
 	m_clampToNotches(true),
+    m_clampToIntegers(false),
     m_showValues(true)
 	{
 	}

--- a/examples/Evolution/NN3DWalkers.cpp
+++ b/examples/Evolution/NN3DWalkers.cpp
@@ -552,10 +552,6 @@ struct WalkerFilterCallback : public btOverlapFilterCallback
 	}
 };
 
-void floorNNSliderValue(float notUsed) {
-	gParallelEvaluations = floor(gParallelEvaluations);
-}
-
 void NN3DWalkersExample::initPhysics()
 {
 
@@ -657,8 +653,7 @@ void NN3DWalkersExample::initPhysics()
 		SliderParams slider("Parallel evaluations", &gParallelEvaluations);
 		slider.m_minVal = 1;
 		slider.m_maxVal = NUM_WALKERS;
-		slider.m_clampToNotches = false;
-		slider.m_callback = floorNNSliderValue; // hack to get integer values
+        slider.m_clampToIntegers = true;
 		m_guiHelper->getParameterInterface()->registerSliderFloatParameter(
 			slider);
 	}

--- a/examples/Evolution/NN3DWalkersTimeWarpBase.h
+++ b/examples/Evolution/NN3DWalkersTimeWarpBase.h
@@ -138,19 +138,15 @@ static btScalar gCFMSingularityAvoidance = 0;
 
 //GUI related parameter changing helpers
 
-inline void floorSliderValues(float notUsed) { // floor values that should be ints
-	gSolverIterations = floor(gSolverIterations);
-}
-
-inline void twxChangePhysicsStepsPerSecond(float physicsStepsPerSecond) { // function to change simulation physics steps per second
+inline void twxChangePhysicsStepsPerSecond(float physicsStepsPerSecond, void*) { // function to change simulation physics steps per second
 	gPhysicsStepsPerSecond = physicsStepsPerSecond;
 }
 
-inline void twxChangeFPS(float framesPerSecond) {
+inline void twxChangeFPS(float framesPerSecond, void*) {
 	gFramesPerSecond = framesPerSecond;
 }
 
-inline void twxChangeERPCFM(float notUsed) { // function to change ERP/CFM appropriately
+inline void twxChangeERPCFM(float notUsed, void*) { // function to change ERP/CFM appropriately
 	gChangeErpCfm = true;
 }
 
@@ -166,13 +162,12 @@ inline void changeSolver(int comboboxId, const char* item, void* userPointer) { 
 }
 
 
-inline void twxChangeSolverIterations(float notUsed){ // change the solver iterations
+inline void twxChangeSolverIterations(float notUsed, void* userPtr) { // change the solver iterations
 
-	floorSliderValues(0); // floor the values set by slider
 
 }
 
-inline void clampToCustomSpeedNotches(float speed) { // function to clamp to custom speed notches
+inline void clampToCustomSpeedNotches(float speed, void*) { // function to clamp to custom speed notches
 	double minSpeed = 0;
 	double minSpeedDist = SimulationSpeeds::MAX_SPEED;
 	for (int i = 0; i < SimulationSpeeds::NUM_SPEEDS; i++) {
@@ -200,7 +195,7 @@ inline void switchMaximumSpeed(int buttonId, bool buttonState, void* userPointer
 //	b3Printf("Run maximum speed %s", gMaximumSpeed?"on":"off");
 }
 
-inline void setApplicationTick(float frequency){ // set internal application tick
+inline void setApplicationTick(float frequency, void*){ // set internal application tick
 	gApplicationTick = 1000.0f/frequency;
 }
 
@@ -383,7 +378,7 @@ struct NN3DWalkersTimeWarpBase: public CommonRigidBodyBase {
 			slider.m_minVal = 0;
 			slider.m_maxVal = 1000;
 			slider.m_callback = twxChangePhysicsStepsPerSecond;
-			slider.m_clampToNotches = false;
+            slider.m_clampToIntegers = true;
 			m_guiHelper->getParameterInterface()->registerSliderFloatParameter(
 				slider);
 		}

--- a/examples/ExtendedTutorials/InclinedPlane.cpp
+++ b/examples/ExtendedTutorials/InclinedPlane.cpp
@@ -69,19 +69,19 @@ struct InclinedPlaneExample : public CommonRigidBodyBase
 
 };
 
-void onBoxFrictionChanged(float friction);
+void onBoxFrictionChanged(float friction, void* userPtr);
 
-void onBoxRestitutionChanged(float restitution);
+void onBoxRestitutionChanged(float restitution, void* userPtr);
 
-void onSphereFrictionChanged(float friction);
+void onSphereFrictionChanged(float friction, void* userPtr);
 
-void onSphereRestitutionChanged(float restitution);
+void onSphereRestitutionChanged(float restitution, void* userPtr);
 
-void onRampInclinationChanged(float inclination);
+void onRampInclinationChanged(float inclination, void* userPtr);
 
-void onRampFrictionChanged(float friction);
+void onRampFrictionChanged(float friction, void* userPtr);
 
-void onRampRestitutionChanged(float restitution);
+void onRampRestitutionChanged(float restitution, void* userPtr);
 
 void InclinedPlaneExample::initPhysics()
 {
@@ -306,35 +306,35 @@ bool InclinedPlaneExample::keyboardCallback(int key, int state) {
 
 
 // GUI parameter modifiers
-void onBoxFrictionChanged(float friction){
+void onBoxFrictionChanged(float friction, void*){
 	if(gBox){
 		gBox->setFriction(friction);
 //		b3Printf("Friction of box changed to %f",friction );
 	}
 }
 
-void onBoxRestitutionChanged(float restitution){
+void onBoxRestitutionChanged(float restitution, void*){
 	if(gBox){
 		gBox->setRestitution(restitution);
 		//b3Printf("Restitution of box changed to %f",restitution);
 	}
 }
 
-void onSphereFrictionChanged(float friction){
+void onSphereFrictionChanged(float friction, void*){
 	if(gSphere){
 		gSphere->setFriction(friction);
 		//b3Printf("Friction of sphere changed to %f",friction );
 	}
 }
 
-void onSphereRestitutionChanged(float restitution){
+void onSphereRestitutionChanged(float restitution, void*){
 	if(gSphere){
 		gSphere->setRestitution(restitution);
 		//b3Printf("Restitution of sphere changed to %f",restitution);
 	}
 }
 
-void onRampInclinationChanged(float inclination){
+void onRampInclinationChanged(float inclination, void*){
 	if(ramp){
 		btTransform startTransform;
 		startTransform.setIdentity();
@@ -351,14 +351,14 @@ void onRampInclinationChanged(float inclination){
 	}
 }
 
-void onRampFrictionChanged(float friction){
+void onRampFrictionChanged(float friction, void*){
 	if(ramp){
 		ramp->setFriction(friction);
 		//b3Printf("Friction of ramp changed to %f \n",friction );
 	}
 }
 
-void onRampRestitutionChanged(float restitution){
+void onRampRestitutionChanged(float restitution, void*){
 	if(ramp){
 		ramp->setRestitution(restitution);
 		//b3Printf("Restitution of ramp changed to %f \n",restitution);

--- a/examples/ExtendedTutorials/MultiPendulum.cpp
+++ b/examples/ExtendedTutorials/MultiPendulum.cpp
@@ -71,11 +71,9 @@ struct MultiPendulumExample: public CommonRigidBodyBase {
 
 static MultiPendulumExample* mex = NULL; // Handle to the example to access it via functions. Do not use this in your simulation!
 
-void onMultiPendulaLengthChanged(float pendulaLength); // Change the pendula length
+void onMultiPendulaLengthChanged(float pendulaLength, void*); // Change the pendula length
 
-void onMultiPendulaRestitutionChanged(float pendulaRestitution); // change the pendula restitution
-
-void floorMSliderValue(float notUsed); // floor the slider values which should be integers
+void onMultiPendulaRestitutionChanged(float pendulaRestitution, void*); // change the pendula restitution
 
 void applyMForceWithForceScalar(float forceScalar);
 
@@ -85,8 +83,7 @@ void MultiPendulumExample::initPhysics() { // Setup your physics scene
 		SliderParams slider("Number of Pendula", &gPendulaQty);
 		slider.m_minVal = 1;
 		slider.m_maxVal = 50;
-		slider.m_callback = floorMSliderValue; // hack to get integer values
-		slider.m_clampToNotches = false;
+        slider.m_clampToIntegers = true;
 		m_guiHelper->getParameterInterface()->registerSliderFloatParameter(
 			slider);
 	}
@@ -95,8 +92,7 @@ void MultiPendulumExample::initPhysics() { // Setup your physics scene
 		SliderParams slider("Number of Displaced Pendula", &gDisplacedPendula);
 		slider.m_minVal = 0;
 		slider.m_maxVal = 49;
-		slider.m_callback = floorMSliderValue; // hack to get integer values
-		slider.m_clampToNotches = false;
+        slider.m_clampToIntegers = true;
 		m_guiHelper->getParameterInterface()->registerSliderFloatParameter(
 			slider);
 	}
@@ -397,7 +393,7 @@ void MultiPendulumExample::applyPendulumForce(btScalar pendulumForce){
 
 // GUI parameter modifiers
 
-void onMultiPendulaLengthChanged(float pendulaLength) { // Change the pendula length
+void onMultiPendulaLengthChanged(float pendulaLength, void*) { // Change the pendula length
 	if (mex){
 		mex->changePendulaLength(pendulaLength);
 	}
@@ -405,16 +401,11 @@ void onMultiPendulaLengthChanged(float pendulaLength) { // Change the pendula le
 
 }
 
-void onMultiPendulaRestitutionChanged(float pendulaRestitution) { // change the pendula restitution
+void onMultiPendulaRestitutionChanged(float pendulaRestitution, void*) { // change the pendula restitution
 	if (mex){
 		mex->changePendulaRestitution(pendulaRestitution);
 	}
 
-}
-
-void floorMSliderValue(float notUsed) { // floor the slider values which should be integers
-	gPendulaQty = floor(gPendulaQty);
-	gDisplacedPendula = floor(gDisplacedPendula);
 }
 
 void applyMForceWithForceScalar(float forceScalar) {

--- a/examples/ExtendedTutorials/NewtonsCradle.cpp
+++ b/examples/ExtendedTutorials/NewtonsCradle.cpp
@@ -71,11 +71,9 @@ struct NewtonsCradleExample: public CommonRigidBodyBase {
 
 static NewtonsCradleExample* nex = NULL;
 
-void onPendulaLengthChanged(float pendulaLength); // Change the pendula length
+void onPendulaLengthChanged(float pendulaLength, void* userPtr); // Change the pendula length
 
-void onPendulaRestitutionChanged(float pendulaRestitution); // change the pendula restitution
-
-void floorSliderValue(float notUsed); // floor the slider values which should be integers
+void onPendulaRestitutionChanged(float pendulaRestitution, void* userPtr); // change the pendula restitution
 
 void applyForceWithForceScalar(float forceScalar);
 
@@ -85,8 +83,7 @@ void NewtonsCradleExample::initPhysics() {
 		SliderParams slider("Number of Pendula", &gPendulaQty);
 		slider.m_minVal = 1;
 		slider.m_maxVal = 50;
-		slider.m_callback = floorSliderValue; // hack to get integer values
-		slider.m_clampToNotches = false;
+        slider.m_clampToIntegers = true;
 		m_guiHelper->getParameterInterface()->registerSliderFloatParameter(
 			slider);
 	}
@@ -95,8 +92,7 @@ void NewtonsCradleExample::initPhysics() {
 		SliderParams slider("Number of Displaced Pendula", &gDisplacedPendula);
 		slider.m_minVal = 0;
 		slider.m_maxVal = 49;
-		slider.m_callback = floorSliderValue; // hack to get integer values
-		slider.m_clampToNotches = false;
+        slider.m_clampToIntegers = true;
 		m_guiHelper->getParameterInterface()->registerSliderFloatParameter(
 			slider);
 	}
@@ -343,23 +339,17 @@ void NewtonsCradleExample::applyPendulumForce(btScalar pendulumForce){
 
 // GUI parameter modifiers
 
-void onPendulaLengthChanged(float pendulaLength) {
+void onPendulaLengthChanged(float pendulaLength, void*) {
 	if (nex){
 		nex->changePendulaLength(pendulaLength);
 		//b3Printf("Pendula length changed to %f \n",sliderValue );
 	}
 }
 
-void onPendulaRestitutionChanged(float pendulaRestitution) {
+void onPendulaRestitutionChanged(float pendulaRestitution, void*) {
 	if (nex){
 		nex->changePendulaRestitution(pendulaRestitution);
 	}
-}
-
-void floorSliderValue(float notUsed) {
-	gPendulaQty = floor(gPendulaQty);
-	gDisplacedPendula = floor(gDisplacedPendula);
-
 }
 
 void applyForceWithForceScalar(float forceScalar) {

--- a/examples/ExtendedTutorials/NewtonsRopeCradle.cpp
+++ b/examples/ExtendedTutorials/NewtonsRopeCradle.cpp
@@ -105,9 +105,7 @@ struct NewtonsRopeCradleExample : public CommonRigidBodyBase {
 
 static NewtonsRopeCradleExample* nex = NULL;
 
-void onRopePendulaRestitutionChanged(float pendulaRestitution);
-
-void floorRSliderValue(float notUsed);
+void onRopePendulaRestitutionChanged(float pendulaRestitution, void*);
 
 void applyRForceWithForceScalar(float forceScalar);
 
@@ -118,8 +116,7 @@ void NewtonsRopeCradleExample::initPhysics()
 		SliderParams slider("Number of Pendula", &gPendulaQty);
 		slider.m_minVal = 1;
 		slider.m_maxVal = 50;
-		slider.m_callback = floorRSliderValue; // hack to get integer values
-		slider.m_clampToNotches = false;
+        slider.m_clampToIntegers = true;
 		m_guiHelper->getParameterInterface()->registerSliderFloatParameter(
 			slider);
 	}
@@ -128,8 +125,7 @@ void NewtonsRopeCradleExample::initPhysics()
 		SliderParams slider("Number of Displaced Pendula", &gDisplacedPendula);
 		slider.m_minVal = 0;
 		slider.m_maxVal = 49;
-		slider.m_callback = floorRSliderValue; // hack to get integer values
-		slider.m_clampToNotches = false;
+        slider.m_clampToIntegers = true;
 		m_guiHelper->getParameterInterface()->registerSliderFloatParameter(
 			slider);
 	}
@@ -148,8 +144,7 @@ void NewtonsRopeCradleExample::initPhysics()
 		SliderParams slider("Rope Resolution", &gRopeResolution);
 		slider.m_minVal = 1;
 		slider.m_maxVal = 20;
-		slider.m_clampToNotches = false;
-		slider.m_callback = floorRSliderValue;
+        slider.m_clampToIntegers = true;
 		m_guiHelper->getParameterInterface()->registerSliderFloatParameter(
 			slider);
 	}
@@ -357,16 +352,10 @@ void NewtonsRopeCradleExample::applyPendulumForce(btScalar pendulumForce){
 
 // GUI parameter modifiers
 
-void onRopePendulaRestitutionChanged(float pendulaRestitution) {
+void onRopePendulaRestitutionChanged(float pendulaRestitution, void*) {
 	if (nex){
 		nex->changePendulaRestitution(pendulaRestitution);
 	}
-}
-
-void floorRSliderValue(float notUsed) {
-	gPendulaQty = floor(gPendulaQty);
-	gDisplacedPendula = floor(gDisplacedPendula);
-	gRopeResolution = floor(gRopeResolution);
 }
 
 void applyRForceWithForceScalar(float forceScalar) {

--- a/examples/MultiThreadedDemo/CommonRigidBodyMTBase.cpp
+++ b/examples/MultiThreadedDemo/CommonRigidBodyMTBase.cpp
@@ -633,7 +633,7 @@ void apiSelectButtonCallback(int buttonId, bool buttonState, void* userPointer)
     }
 }
 
-void setThreadCountCallback(float val)
+void setThreadCountCallback(float val, void* userPtr)
 {
     if (gTaskMgr.getApi()==TaskManager::apiNone)
     {
@@ -642,7 +642,14 @@ void setThreadCountCallback(float val)
     else
     {
         gTaskMgr.setNumThreads( int( gSliderNumThreads ) );
-        gSliderNumThreads = float(gTaskMgr.getNumThreads());
+    }
+}
+
+void setSolverIterationCountCallback(float val, void* userPtr)
+{
+    if (btDiscreteDynamicsWorld* world = reinterpret_cast<btDiscreteDynamicsWorld*>(userPtr))
+    {
+       	world->getSolverInfo().m_numIterations = btMax(1, int(gSliderSolverIterations));
     }
 }
 
@@ -728,6 +735,15 @@ void CommonRigidBodyMTBase::createDefaultParameters()
         button.m_callback = boolPtrButtonCallback;
         m_guiHelper->getParameterInterface()->registerButtonParameter( button );
     }
+    {
+        SliderParams slider( "Solver iterations", &gSliderSolverIterations );
+        slider.m_minVal = 1.0f;
+        slider.m_maxVal = 30.0f;
+        slider.m_callback = setSolverIterationCountCallback;
+        slider.m_userPointer = m_dynamicsWorld;
+        slider.m_clampToIntegers = true;
+        m_guiHelper->getParameterInterface()->registerSliderFloatParameter( slider );
+    }
     if (m_multithreadedWorld)
     {
         // create a button for each supported threading API
@@ -750,7 +766,7 @@ void CommonRigidBodyMTBase::createDefaultParameters()
 			slider.m_minVal = 1.0f;
 			slider.m_maxVal = float(gTaskMgr.getMaxNumThreads()*2);
 			slider.m_callback = setThreadCountCallback;
-			slider.m_clampToNotches = false;
+            slider.m_clampToIntegers = true;
             m_guiHelper->getParameterInterface()->registerSliderFloatParameter( slider );
         }
     }

--- a/examples/MultiThreadedDemo/CommonRigidBodyMTBase.cpp
+++ b/examples/MultiThreadedDemo/CommonRigidBodyMTBase.cpp
@@ -590,6 +590,8 @@ public:
 static bool gMultithreadedWorld = false;
 static bool gDisplayProfileInfo = false;
 static btScalar gSliderNumThreads = 1.0f;  // should be int
+static btScalar gSliderSolverIterations = 10.0f; // should be int
+
 
 ////////////////////////////////////
 CommonRigidBodyMTBase::CommonRigidBodyMTBase( struct GUIHelperInterface* helper )

--- a/examples/MultiThreadedDemo/MultiThreadedDemo.cpp
+++ b/examples/MultiThreadedDemo/MultiThreadedDemo.cpp
@@ -90,7 +90,7 @@ MultiThreadedDemo::MultiThreadedDemo(struct GUIHelperInterface* helper)
 
 static btScalar gSliderStackRows = 8.0f;
 static btScalar gSliderStackColumns = 6.0f;
-
+static btScalar gSliderStackHeight = 15.0f;
 
 void MultiThreadedDemo::initPhysics()
 {

--- a/examples/MultiThreadedDemo/MultiThreadedDemo.cpp
+++ b/examples/MultiThreadedDemo/MultiThreadedDemo.cpp
@@ -99,17 +99,24 @@ void MultiThreadedDemo::initPhysics()
     m_dynamicsWorld->setGravity( btVector3( 0, -10, 0 ) );
 
     {
+        SliderParams slider( "Stack height", &gSliderStackHeight );
+        slider.m_minVal = 1.0f;
+        slider.m_maxVal = 30.0f;
+        slider.m_clampToIntegers = true;
+        m_guiHelper->getParameterInterface()->registerSliderFloatParameter( slider );
+    }
+    {
         SliderParams slider( "Stack rows", &gSliderStackRows );
         slider.m_minVal = 1.0f;
         slider.m_maxVal = 20.0f;
-        slider.m_clampToNotches = false;
+        slider.m_clampToIntegers = true;
         m_guiHelper->getParameterInterface()->registerSliderFloatParameter( slider );
     }
     {
         SliderParams slider( "Stack columns", &gSliderStackColumns );
         slider.m_minVal = 1.0f;
         slider.m_maxVal = 20.0f;
-        slider.m_clampToNotches = false;
+        slider.m_clampToIntegers = true;
         m_guiHelper->getParameterInterface()->registerSliderFloatParameter( slider );
     }
 	


### PR DESCRIPTION
- Added a void* parameter to the Slider's callback which is used to pass the user pointer
- Added a 'clamp-to-integers' option to the slider (and cleaned up various hacky workarounds)

