### PR TITLE
add <restitution> in <contact> settings of URDF/SDF etc

### DIFF
--- a/examples/Importers/ImportURDFDemo/URDFJointTypes.h
+++ b/examples/Importers/ImportURDFDemo/URDFJointTypes.h
@@ -22,6 +22,7 @@ enum URDF_LinkContactFlags
 	URDF_CONTACT_HAS_STIFFNESS_DAMPING=16,
     URDF_CONTACT_HAS_ROLLING_FRICTION=32,
     URDF_CONTACT_HAS_SPINNING_FRICTION=64,
+	URDF_CONTACT_HAS_RESTITUTION=128,
 
 };
 
@@ -30,6 +31,7 @@ struct URDFLinkContactInfo
 	btScalar m_lateralFriction;
 	btScalar m_rollingFriction;
     btScalar m_spinningFriction;
+	btScalar m_restitution;
     btScalar m_inertiaScaling;
 	btScalar m_contactCfm;
 	btScalar m_contactErp;
@@ -42,6 +44,7 @@ struct URDFLinkContactInfo
 		:m_lateralFriction(0.5),
 		m_rollingFriction(0),
         m_spinningFriction(0),
+		m_restitution(0),
         m_inertiaScaling(1),
 		m_contactCfm(0),
 		m_contactErp(0),

--- a/examples/Importers/ImportURDFDemo/UrdfParser.cpp
+++ b/examples/Importers/ImportURDFDemo/UrdfParser.cpp
@@ -672,6 +672,31 @@ bool UrdfParser::parseLink(UrdfModel& model, UrdfLink& link, TiXmlElement *confi
                   }
               }
           }
+
+		  {
+			  TiXmlElement *restitution_xml = ci->FirstChildElement("restitution");
+			  if (restitution_xml)
+			  {
+				  if (m_parseSDF)
+				  {
+					  link.m_contactInfo.m_restitution = urdfLexicalCast<double>(restitution_xml->GetText());
+					  link.m_contactInfo.m_flags |= URDF_CONTACT_HAS_RESTITUTION;
+				  }
+				  else
+				  {
+					  if (!restitution_xml->Attribute("value"))
+					  {
+						  logger->reportError("Link/contact: restitution element must have value attribute");
+						  return false;
+					  }
+
+					  link.m_contactInfo.m_restitution = urdfLexicalCast<double>(restitution_xml->Attribute("value"));
+					  link.m_contactInfo.m_flags |= URDF_CONTACT_HAS_RESTITUTION;
+
+				  }
+			  }
+		  }
+
           {
               TiXmlElement *spinning_xml = ci->FirstChildElement("spinning_friction");
               if (spinning_xml)

--- a/examples/SharedMemory/PhysicsClientC_API.cpp
+++ b/examples/SharedMemory/PhysicsClientC_API.cpp
@@ -317,6 +317,26 @@ int     b3PhysicsParamSetInternalSimFlags(b3SharedMemoryCommandHandle commandHan
 	return 0;
 }
 
+int b3PhysicsParamSetUseSplitImpulse(b3SharedMemoryCommandHandle commandHandle, int useSplitImpulse)
+{
+	struct SharedMemoryCommand* command = (struct SharedMemoryCommand*) commandHandle;
+	b3Assert(command->m_type == CMD_SEND_PHYSICS_SIMULATION_PARAMETERS);
+
+	command->m_physSimParamArgs.m_useSplitImpulse = useSplitImpulse;
+	command->m_updateFlags |= SIM_PARAM_UPDATE_USE_SPLIT_IMPULSE;
+	return 0;
+}
+
+int b3PhysicsParamSetSplitImpulsePenetrationThreshold(b3SharedMemoryCommandHandle commandHandle, double splitImpulsePenetrationThreshold)
+{
+	struct SharedMemoryCommand* command = (struct SharedMemoryCommand*) commandHandle;
+	b3Assert(command->m_type == CMD_SEND_PHYSICS_SIMULATION_PARAMETERS);
+
+	command->m_physSimParamArgs.m_splitImpulsePenetrationThreshold = splitImpulsePenetrationThreshold;
+	command->m_updateFlags |= SIM_PARAM_UPDATE_SPLIT_IMPULSE_PENETRATION_THRESHOLD;
+	return 0;
+}
+
 int b3PhysicsParamSetNumSolverIterations(b3SharedMemoryCommandHandle commandHandle, int numSolverIterations)
 {
 	struct SharedMemoryCommand* command = (struct SharedMemoryCommand*) commandHandle;

--- a/examples/SharedMemory/PhysicsClientC_API.h
+++ b/examples/SharedMemory/PhysicsClientC_API.h
@@ -163,6 +163,9 @@ int	b3PhysicsParamSetDefaultContactERP(b3SharedMemoryCommandHandle commandHandle
 int	b3PhysicsParamSetNumSubSteps(b3SharedMemoryCommandHandle commandHandle, int numSubSteps);
 int b3PhysicsParamSetRealTimeSimulation(b3SharedMemoryCommandHandle commandHandle, int enableRealTimeSimulation);
 int b3PhysicsParamSetNumSolverIterations(b3SharedMemoryCommandHandle commandHandle, int numSolverIterations);
+int b3PhysicsParamSetUseSplitImpulse(b3SharedMemoryCommandHandle commandHandle, int useSplitImpulse);
+int b3PhysicsParamSetSplitImpulsePenetrationThreshold(b3SharedMemoryCommandHandle commandHandle, double splitImpulsePenetrationThreshold);
+
 
 //b3PhysicsParamSetInternalSimFlags is for internal/temporary/easter-egg/experimental demo purposes
 //Use at own risk: magic things may or my not happen when calling this API

--- a/examples/SharedMemory/SharedMemoryCommands.h
+++ b/examples/SharedMemory/SharedMemoryCommands.h
@@ -287,7 +287,9 @@ enum EnumSimParamUpdateFlags
 	SIM_PARAM_UPDATE_NUM_SIMULATION_SUB_STEPS=8,
 	SIM_PARAM_UPDATE_REAL_TIME_SIMULATION = 16,
 	SIM_PARAM_UPDATE_DEFAULT_CONTACT_ERP=32,
-	SIM_PARAM_UPDATE_INTERNAL_SIMULATION_FLAGS=64
+	SIM_PARAM_UPDATE_INTERNAL_SIMULATION_FLAGS=64,
+	SIM_PARAM_UPDATE_USE_SPLIT_IMPULSE=128,
+	SIM_PARAM_UPDATE_SPLIT_IMPULSE_PENETRATION_THRESHOLD = 256,
 };
 
 enum EnumLoadBunnyUpdateFlags
@@ -312,6 +314,8 @@ struct SendPhysicsSimulationParameters
 	int m_numSimulationSubSteps;
 	int m_numSolverIterations;
 	bool m_allowRealTimeSimulation;
+	int m_useSplitImpulse;
+	double m_splitImpulsePenetrationThreshold;
 	int m_internalSimFlags;
 	double m_defaultContactERP;
 };

--- a/src/BulletDynamics/Featherstone/btMultiBodyConstraint.cpp
+++ b/src/BulletDynamics/Featherstone/btMultiBodyConstraint.cpp
@@ -378,7 +378,9 @@ btScalar btMultiBodyConstraint::fillMultiBodyConstraint(	btMultiBodySolverConstr
         
         
         btScalar erp = infoGlobal.m_erp2;
-        if (!infoGlobal.m_splitImpulse || (penetration > infoGlobal.m_splitImpulsePenetrationThreshold))
+		
+		//split impulse is not implemented yet for btMultiBody*
+		//if (!infoGlobal.m_splitImpulse || (penetration > infoGlobal.m_splitImpulsePenetrationThreshold))
         {
             erp = infoGlobal.m_erp;
         }
@@ -388,19 +390,23 @@ btScalar btMultiBodyConstraint::fillMultiBodyConstraint(	btMultiBodySolverConstr
         btScalar  penetrationImpulse = positionalError*solverConstraint.m_jacDiagABInv;
         btScalar velocityImpulse = velocityError *solverConstraint.m_jacDiagABInv;
         
-        if (!infoGlobal.m_splitImpulse || (penetration > infoGlobal.m_splitImpulsePenetrationThreshold))
+		//split impulse is not implemented yet for btMultiBody*
+
+      //  if (!infoGlobal.m_splitImpulse || (penetration > infoGlobal.m_splitImpulsePenetrationThreshold))
         {
             //combine position and velocity into rhs
             solverConstraint.m_rhs = penetrationImpulse+velocityImpulse;
             solverConstraint.m_rhsPenetration = 0.f;
             
-        } else
+        } 
+		/*else
         {
             //split position and velocity into rhs and m_rhsPenetration
             solverConstraint.m_rhs = velocityImpulse;
             solverConstraint.m_rhsPenetration = penetrationImpulse;
         }
-        
+        */
+
         solverConstraint.m_cfm = 0.f;
         solverConstraint.m_lowerLimit = lowerLimit;
         solverConstraint.m_upperLimit = upperLimit;

--- a/src/BulletDynamics/Featherstone/btMultiBodyConstraintSolver.cpp
+++ b/src/BulletDynamics/Featherstone/btMultiBodyConstraintSolver.cpp
@@ -528,19 +528,20 @@ void btMultiBodyConstraintSolver::setupMultiBodyContactConstraint(btMultiBodySol
 
 		if(!isFriction)
 		{
-			if (!infoGlobal.m_splitImpulse || (penetration > infoGlobal.m_splitImpulsePenetrationThreshold))
+		//	if (!infoGlobal.m_splitImpulse || (penetration > infoGlobal.m_splitImpulsePenetrationThreshold))
 			{
 				//combine position and velocity into rhs
 				solverConstraint.m_rhs = penetrationImpulse+velocityImpulse;
 				solverConstraint.m_rhsPenetration = 0.f;
 
-			} else
+			}
+		/*else
 			{
 				//split position and velocity into rhs and m_rhsPenetration
 				solverConstraint.m_rhs = velocityImpulse;
 				solverConstraint.m_rhsPenetration = penetrationImpulse;
 			}
-
+			*/
 			solverConstraint.m_lowerLimit = 0;
 			solverConstraint.m_upperLimit = 1e10f;
 		}

--- a/src/BulletDynamics/Featherstone/btMultiBodyDynamicsWorld.cpp
+++ b/src/BulletDynamics/Featherstone/btMultiBodyDynamicsWorld.cpp
@@ -384,7 +384,7 @@ btMultiBodyDynamicsWorld::btMultiBodyDynamicsWorld(btDispatcher* dispatcher,btBr
 	m_multiBodyConstraintSolver(constraintSolver)
 {
 	//split impulse is not yet supported for Featherstone hierarchies
-	getSolverInfo().m_splitImpulse = false;
+//	getSolverInfo().m_splitImpulse = false;
 	getSolverInfo().m_solverMode |=SOLVER_USE_2_FRICTION_DIRECTIONS;
 	m_solverMultiBodyIslandCallback = new MultiBodyInplaceSolverIslandCallback(constraintSolver,dispatcher);
 }


### PR DESCRIPTION
allow 'useMaximalCoordinates' and 'useFixedBase' in pybullet.loadURDF.
enable split impulse for btRigidBody, even in btMultiBodyDynamicsWorld.
allow initialization of velocity and apply force for btRigidBody in pybullet/shared memory API.
process contact parameters in URDF also for btRigidBody (friction, restitution etc)
add pybullet.setPhysicsEngineParameter with numSolverIterations, useSplitImpulse etc.