### PR TITLE
FIX: kinematic objects treated as static when BT_THREADSAFE is defined

### DIFF
--- a/examples/MultiThreadedDemo/CommonRigidBodyMTBase.h
+++ b/examples/MultiThreadedDemo/CommonRigidBodyMTBase.h
@@ -406,6 +406,17 @@ struct CommonRigidBodyMTBase : public CommonExampleInterface
 		return body;
 	}
 
+    btRigidBody* createKinematicBody(const btTransform& startTransform, btCollisionShape* shape)
+    {
+        btAssert( ( !shape || shape->getShapeType() != INVALID_SHAPE_PROXYTYPE ) );
+
+        btRigidBody* body = new btRigidBody( 0.0f, NULL, shape );
+        body->setWorldTransform( startTransform );
+        body->setCollisionFlags( body->getCollisionFlags() | btCollisionObject::CF_KINEMATIC_OBJECT );
+        body->setUserIndex( -1 );
+        m_dynamicsWorld->addRigidBody( body );
+        return body;
+    }
 
 	
 	virtual void renderScene()

--- a/src/BulletDynamics/ConstraintSolver/btSequentialImpulseConstraintSolver.cpp
+++ b/src/BulletDynamics/ConstraintSolver/btSequentialImpulseConstraintSolver.cpp
@@ -738,20 +738,12 @@ int	btSequentialImpulseConstraintSolver::getOrInitSolverBody(btCollisionObject& 
             }
         }
     }
-    else if ( body.isStaticObject() )
+    else if (body.isKinematicObject())
     {
-        // all fixed bodies (inf mass) get mapped to a single solver id
-        if ( m_fixedBodyId < 0 )
-        {
-            m_fixedBodyId = m_tmpSolverBodyPool.size();
-            btSolverBody& fixedBody = m_tmpSolverBodyPool.expand();
-            initSolverBody( &fixedBody, 0, timeStep );
-        }
-        solverBodyId = m_fixedBodyId;
-    }
-    else
-    {
-        // kinematic
+        //
+        // NOTE: must test for kinematic before static because some kinematic objects also
+        //   identify as "static"
+        //
         // Kinematic bodies can be in multiple islands at once, so it is a
         // race condition to write to them, so we use an alternate method
         // to record the solverBodyId
@@ -772,6 +764,17 @@ int	btSequentialImpulseConstraintSolver::getOrInitSolverBody(btCollisionObject& 
             initSolverBody( &solverBody, &body, timeStep );
             m_kinematicBodyUniqueIdToSolverBodyTable[ uniqueId ] = solverBodyId;
         }
+    }
+    else
+    {
+        // all fixed bodies (inf mass) get mapped to a single solver id
+        if ( m_fixedBodyId < 0 )
+        {
+            m_fixedBodyId = m_tmpSolverBodyPool.size();
+            btSolverBody& fixedBody = m_tmpSolverBodyPool.expand();
+            initSolverBody( &fixedBody, 0, timeStep );
+        }
+        solverBodyId = m_fixedBodyId;
     }
     btAssert( solverBodyId < m_tmpSolverBodyPool.size() );
 	return solverBodyId;


### PR DESCRIPTION
The first commit changes the MultiThreadedDemo example to work as a test case to replicate the bug. In the example, use the "Ground horiz amp" slider to add some horizontal shaking to the ground. The stacks of boxes should react when the ground moves and fall down pretty quickly. Because of the bug however, the stacks of boxes don't see any motion from the ground. Vertical shaking still affects the stacks because of penetration.

The second commit fixes the bug. Now the boxes will tumble when the ground moves horizontally.

Tested on Windows 10, Visual Studio 2013, win32, built with Cmake with BULLET2_USE_THREAD_LOCKS enabled, as well as BULLET2_MULTITHREADED_*_DEMO enabled.