### PR TITLE
example browser: restore on-screen text

### DIFF
--- a/examples/MultiThreadedDemo/CommonRigidBodyMTBase.cpp
+++ b/examples/MultiThreadedDemo/CommonRigidBodyMTBase.cpp
@@ -774,13 +774,9 @@ void CommonRigidBodyMTBase::createDefaultParameters()
     }
 }
 
-void CommonRigidBodyMTBase::physicsDebugDraw(int debugFlags)
+
+void CommonRigidBodyMTBase::drawScreenText()
 {
-	if (m_dynamicsWorld && m_dynamicsWorld->getDebugDrawer())
-	{
-		m_dynamicsWorld->getDebugDrawer()->setDebugMode(debugFlags);
-		m_dynamicsWorld->debugDrawWorld();
-	}
     char msg[ 1024 ];
     int xCoord = 400;
     int yCoord = 30;
@@ -866,3 +862,21 @@ void CommonRigidBodyMTBase::physicsDebugDraw(int debugFlags)
     }
 }
 
+
+void CommonRigidBodyMTBase::physicsDebugDraw(int debugFlags)
+{
+	if (m_dynamicsWorld && m_dynamicsWorld->getDebugDrawer())
+	{
+		m_dynamicsWorld->getDebugDrawer()->setDebugMode(debugFlags);
+		m_dynamicsWorld->debugDrawWorld();
+	}
+	drawScreenText();
+}
+
+
+void CommonRigidBodyMTBase::renderScene()
+{
+    m_guiHelper->syncPhysicsToGraphics(m_dynamicsWorld);
+    m_guiHelper->render(m_dynamicsWorld);
+    drawScreenText();
+}

--- a/examples/MultiThreadedDemo/CommonRigidBodyMTBase.h
+++ b/examples/MultiThreadedDemo/CommonRigidBodyMTBase.h
@@ -52,6 +52,8 @@ struct CommonRigidBodyMTBase : public CommonExampleInterface
 		}
 	}
 
+    virtual void drawScreenText();
+    virtual void renderScene();
 	virtual void physicsDebugDraw(int debugFlags);
 
 	virtual void exitPhysics()
@@ -418,19 +420,7 @@ struct CommonRigidBodyMTBase : public CommonExampleInterface
         return body;
     }
 
-	
-	virtual void renderScene()
-	{
-		{
-			
-			m_guiHelper->syncPhysicsToGraphics(m_dynamicsWorld);
-		}
-		
-		{
-			
-			m_guiHelper->render(m_dynamicsWorld);
-		}
-	}
+
 };
 
 #endif //#define COMMON_RIGID_BODY_MT_BASE_H


### PR DESCRIPTION
The examples in the example browser which are based on CommonRigidBodyMTBase are supposed to be displaying on-screen text to display various information such as profiling stats (but only when the "display profile timings" button is on). Currently this is only drawn when in 'wireframe' display mode which is odd.

This PR fixes that so the text appears consistently.