### PR TITLE
pybullet: Error message wrong when linkIndex < 0 in getLinkState

### DIFF
--- a/examples/pybullet/pybullet.c
+++ b/examples/pybullet/pybullet.c
@@ -2054,7 +2054,7 @@ b3PhysicsClientHandle sm = 0;
         return NULL;
       }
       if (linkIndex < 0) {
-        PyErr_SetString(SpamError, "getLinkState failed; invalid jointIndex");
+        PyErr_SetString(SpamError, "getLinkState failed; invalid linkIndex");
         return NULL;
       }
 


### PR DESCRIPTION
If the linkIndex is set to < 0, it says invalid jointIndex when it is actually about linkIndex.

This commit fixes it.