### PR TITLE
Fixed uninitialized default argument

### DIFF
--- a/src/BulletDynamics/Character/btKinematicCharacterController.h
+++ b/src/BulletDynamics/Character/btKinematicCharacterController.h
@@ -176,7 +176,7 @@ public:
 	void setMaxJumpHeight (btScalar maxJumpHeight);
 	bool canJump () const;
 
-	void jump(const btVector3& v = btVector3());
+	void jump(const btVector3& v = btVector3(btScalar(0.0), btScalar(0.0), btScalar(0.0)));
 
 	void applyImpulse(const btVector3& v) { jump(v); }
 


### PR DESCRIPTION
The default value for the argument to btKinematicCharacterController::jump leaves it uninitialized and causes strange behavior.