### PR TITLE
disable keyboard toggle in Linux/X11, revert num solver iterations to 50 (from 150)

### DIFF
--- a/examples/ExampleBrowser/OpenGLExampleBrowser.cpp
+++ b/examples/ExampleBrowser/OpenGLExampleBrowser.cpp
@@ -257,7 +257,6 @@ void MyKeyboardCallback(int key, int state)
 
 		} else
 		{
-
 			b3ChromeUtilsStopTimingsAndWriteJsonFile();
 		}
 #endif //BT_NO_PROFILE

--- a/examples/OpenGLWindow/X11OpenGLWindow.cpp
+++ b/examples/OpenGLWindow/X11OpenGLWindow.cpp
@@ -839,7 +839,7 @@ void X11OpenGLWindow::pumpMessage()
 
                 if (m_data->m_keyboardCallback)
                 {
-#if 0
+#if 1
                      unsigned short is_retriggered = 0;
 ///filter out keyboard repeat
 //see http://stackoverflow.com/questions/2100654/ignore-auto-repeat-in-x11-applications
@@ -851,8 +851,8 @@ void X11OpenGLWindow::pumpMessage()
                          if (nev.type == KeyPress && nev.xkey.time ==  m_data->m_xev.xkey.time &&
                              nev.xkey.keycode ==  m_data->m_xev.xkey.keycode)
                            {
-                             fprintf (stdout, "key #%ld was retriggered.\n",
-                               (long) MyXLookupKeysym(&nev.xkey, 0));
+                             //fprintf (stdout, "key #%ld was retriggered.\n",
+                              // (long) MyXLookupKeysym(&nev.xkey, 0));
 
                              // delete retriggered KeyPress event
                              MyXNextEvent(m_data->m_dpy, & m_data->m_xev);
@@ -861,6 +861,7 @@ void X11OpenGLWindow::pumpMessage()
                        }
 #endif
                     int state = 0;
+		    if (!is_retriggered)
                     (*m_data->m_keyboardCallback)(keycode,state);
                     }
 

--- a/examples/RoboticsLearning/GripperGraspExample.cpp
+++ b/examples/RoboticsLearning/GripperGraspExample.cpp
@@ -209,6 +209,7 @@ public:
         
         if ((m_options & eONE_MOTOR_GRASP)!=0)
         {
+	    m_robotSim.setNumSolverIterations(150);
             {
                 SliderParams slider("Vertical velocity",&sGripperVerticalVelocity);
                 slider.m_minVal=-2;

--- a/examples/RoboticsLearning/b3RobotSimAPI.cpp
+++ b/examples/RoboticsLearning/b3RobotSimAPI.cpp
@@ -478,6 +478,16 @@ void b3RobotSimAPI::setGravity(const b3Vector3& gravityAcceleration)
 
 }
 
+void b3RobotSimAPI::setNumSolverIterations(int numIterations)
+{
+    b3SharedMemoryCommandHandle command = b3InitPhysicsParamCommand(m_data->m_physicsClient);
+    b3SharedMemoryStatusHandle statusHandle;
+    b3PhysicsParamSetNumSolverIterations(command, numIterations);
+    statusHandle = b3SubmitClientCommandAndWaitStatus(m_data->m_physicsClient, command);
+    b3Assert(b3GetStatusType(statusHandle)==CMD_CLIENT_COMMAND_COMPLETED);
+
+}
+
 void b3RobotSimAPI::setNumSimulationSubSteps(int numSubSteps)
 {
     b3SharedMemoryCommandHandle command = b3InitPhysicsParamCommand(m_data->m_physicsClient);

--- a/examples/RoboticsLearning/b3RobotSimAPI.h
+++ b/examples/RoboticsLearning/b3RobotSimAPI.h
@@ -157,6 +157,7 @@ public:
 	void setGravity(const b3Vector3& gravityAcceleration);
     
     void setNumSimulationSubSteps(int numSubSteps);
+	void setNumSolverIterations(int numIterations);
 
 	bool calculateInverseKinematics(const struct b3RobotSimInverseKinematicArgs& args, struct b3RobotSimInverseKinematicsResults& results);
 

--- a/examples/SharedMemory/PhysicsServerCommandProcessor.cpp
+++ b/examples/SharedMemory/PhysicsServerCommandProcessor.cpp
@@ -799,7 +799,7 @@ void PhysicsServerCommandProcessor::createEmptyDynamicsWorld()
     m_data->m_dynamicsWorld->getSolverInfo().m_erp2 = 0.08;
     
 	m_data->m_dynamicsWorld->getSolverInfo().m_linearSlop = 0.00001;
-	m_data->m_dynamicsWorld->getSolverInfo().m_numIterations = 150;
+	m_data->m_dynamicsWorld->getSolverInfo().m_numIterations = 50;
 	m_data->m_dynamicsWorld->getSolverInfo().m_leastSquaresResidualThreshold = 1e-7;
 //	m_data->m_dynamicsWorld->getSolverInfo().m_minimumSolverBatchSize = 2;
 	//todo: islands/constraints are buggy in btMultiBodyDynamicsWorld! (performance + see slipping grasp)


### PR DESCRIPTION
revert num solver iterations to 50 (from 150)
set solver iterations for one gripper grasp to 150