### PR TITLE
remove `using namespace ConvexDecomposition` from library header file

### DIFF
--- a/Extras/ConvexDecomposition/ConvexBuilder.cpp
+++ b/Extras/ConvexDecomposition/ConvexBuilder.cpp
@@ -12,9 +12,9 @@ unsigned int MAXDEPTH = 8 ;
 float CONCAVE_PERCENT = 1.0f ;
 float MERGE_PERCENT   = 2.0f ;
 
-CHull::CHull(const ConvexResult &result)
+CHull::CHull(const ConvexDecomposition::ConvexResult &result)
 {
-	mResult = new ConvexResult(result);
+	mResult = new ConvexDecomposition::ConvexResult(result);
 	mVolume = computeMeshVolume( result.mHullVertices, result.mHullTcount, result.mHullIndices );
 
 	mDiagonal = getBoundingRegion( result.mHullVcount, result.mHullVertices, sizeof(float)*3, mMin, mMax );
@@ -81,7 +81,7 @@ bool ConvexBuilder::isDuplicate(unsigned int i1,unsigned int i2,unsigned int i3,
 	return dcount == 3;
 }
 
-void ConvexBuilder::getMesh(const ConvexResult &cr,VertexLookup vc,UintVector &indices)
+void ConvexBuilder::getMesh(const ConvexDecomposition::ConvexResult &cr,VertexLookup vc,UintVector &indices)
 {
 	unsigned int *src = cr.mHullIndices;
 
@@ -154,19 +154,19 @@ CHull * ConvexBuilder::canMerge(CHull *a,CHull *b)
 		return 0;
 	}
 
-	HullResult hresult;
-	HullLibrary hl;
-	HullDesc   desc;
+	ConvexDecomposition::HullResult hresult;
+	ConvexDecomposition::HullLibrary hl;
+	ConvexDecomposition::HullDesc   desc;
 
-	desc.SetHullFlag(QF_TRIANGLES);
+	desc.SetHullFlag(ConvexDecomposition::QF_TRIANGLES);
 
 	desc.mVcount       = vcount;
 	desc.mVertices     = vertices;
 	desc.mVertexStride = sizeof(float)*3;
 
-	HullError hret = hl.CreateConvexHull(desc,hresult);
+	ConvexDecomposition::HullError hret = hl.CreateConvexHull(desc,hresult);
 
-	if ( hret == QE_OK )
+	if ( hret == ConvexDecomposition::QE_OK )
 	{
 
 		float combineVolume  = computeMeshVolume( hresult.mOutputVertices, hresult.mNumFaces, hresult.mIndices );
@@ -175,7 +175,7 @@ CHull * ConvexBuilder::canMerge(CHull *a,CHull *b)
 		float percent = (sumVolume*100) / combineVolume;
 		if ( percent >= (100.0f-MERGE_PERCENT) )
 		{
-			ConvexResult cr(hresult.mNumOutputVertices, hresult.mOutputVertices, hresult.mNumFaces, hresult.mIndices);
+			ConvexDecomposition::ConvexResult cr(hresult.mNumOutputVertices, hresult.mOutputVertices, hresult.mNumFaces, hresult.mIndices);
 			ret = new CHull(cr);
 		}
 	}
@@ -259,7 +259,7 @@ bool ConvexBuilder::combineHulls(void)
 	return combine;
 }
 
-unsigned int ConvexBuilder::process(const DecompDesc &desc)
+unsigned int ConvexBuilder::process(const ConvexDecomposition::DecompDesc &desc)
 {
 
 	unsigned int ret = 0;
@@ -282,13 +282,13 @@ unsigned int ConvexBuilder::process(const DecompDesc &desc)
 		// before we hand it back to the application, we need to regenerate the hull based on the
 		// limits given by the user.
 
-		const ConvexResult &c = *cr->mResult; // the high resolution hull...
+		const ConvexDecomposition::ConvexResult &c = *cr->mResult; // the high resolution hull...
 
-		HullResult result;
-		HullLibrary hl;
-		HullDesc   hdesc;
+		ConvexDecomposition::HullResult result;
+		ConvexDecomposition::HullLibrary hl;
+		ConvexDecomposition::HullDesc   hdesc;
 
-		hdesc.SetHullFlag(QF_TRIANGLES);
+		hdesc.SetHullFlag(ConvexDecomposition::QF_TRIANGLES);
 
 		hdesc.mVcount       = c.mHullVcount;
 		hdesc.mVertices     = c.mHullVertices;
@@ -298,14 +298,14 @@ unsigned int ConvexBuilder::process(const DecompDesc &desc)
 		if ( desc.mSkinWidth  )
 		{
 			hdesc.mSkinWidth = desc.mSkinWidth;
-			hdesc.SetHullFlag(QF_SKIN_WIDTH); // do skin width computation.
+			hdesc.SetHullFlag(ConvexDecomposition::QF_SKIN_WIDTH); // do skin width computation.
 		}
 
-		HullError ret = hl.CreateConvexHull(hdesc,result);
+		ConvexDecomposition::HullError ret = hl.CreateConvexHull(hdesc,result);
 
-		if ( ret == QE_OK )
+		if ( ret == ConvexDecomposition::QE_OK )
 		{
-			ConvexResult r(result.mNumOutputVertices, result.mOutputVertices, result.mNumFaces, result.mIndices);
+			ConvexDecomposition::ConvexResult r(result.mNumOutputVertices, result.mOutputVertices, result.mNumFaces, result.mIndices);
 
 			r.mHullVolume = computeMeshVolume( result.mOutputVertices, result.mNumFaces, result.mIndices ); // the volume of the hull.
 
@@ -358,7 +358,7 @@ void ConvexBuilder::ConvexDebugBound(const float *bmin,const float *bmax,unsigne
 	mCallback->ConvexDebugBound(bmin,bmax,color);
 }
 
-void ConvexBuilder::ConvexDecompResult(ConvexResult &result)
+void ConvexBuilder::ConvexDecompResult(ConvexDecomposition::ConvexResult &result)
 {
 	CHull *ch = new CHull(result);
 	mChulls.push_back(ch);

--- a/Extras/ConvexDecomposition/ConvexBuilder.h
+++ b/Extras/ConvexDecomposition/ConvexBuilder.h
@@ -40,13 +40,11 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "vlookup.h"
 #include "LinearMath/btAlignedObjectArray.h"
 
-using namespace ConvexDecomposition;
-
 
 class CHull
 {
 public:
-	CHull(const ConvexResult &result);
+	CHull(const ConvexDecomposition::ConvexResult &result);
 
 	~CHull(void);
 
@@ -56,7 +54,7 @@ public:
 	float          mMax[3];
 	float          mVolume;
 	float          mDiagonal; // long edge..
-	ConvexResult  *mResult;
+	ConvexDecomposition::ConvexResult  *mResult;
 };
 
 // Usage: std::sort( list.begin(), list.end(), StringSortRef() );
@@ -75,23 +73,23 @@ typedef btAlignedObjectArray< CHull * > CHullVector;
 
 
 
-class ConvexBuilder : public ConvexDecompInterface
+class ConvexBuilder : public ConvexDecomposition::ConvexDecompInterface
 {
 public:
-	ConvexBuilder(ConvexDecompInterface *callback);
+	ConvexBuilder(ConvexDecomposition::ConvexDecompInterface *callback);
 
 	virtual ~ConvexBuilder(void);
 
 	bool isDuplicate(unsigned int i1,unsigned int i2,unsigned int i3,
 		unsigned int ci1,unsigned int ci2,unsigned int ci3);
 
-	void getMesh(const ConvexResult &cr,VertexLookup vc,UintVector &indices);
+	void getMesh(const ConvexDecomposition::ConvexResult &cr,VertexLookup vc,UintVector &indices);
 
 	CHull * canMerge(CHull *a,CHull *b);
 
 	bool combineHulls(void);
 
-	unsigned int process(const DecompDesc &desc);
+	unsigned int process(const ConvexDecomposition::DecompDesc &desc);
 
 	virtual void ConvexDebugTri(const float *p1,const float *p2,const float *p3,unsigned int color);
 
@@ -100,7 +98,7 @@ public:
 
 	virtual void ConvexDebugBound(const float *bmin,const float *bmax,unsigned int color);
 
-	virtual void ConvexDecompResult(ConvexResult &result);
+	virtual void ConvexDecompResult(ConvexDecomposition::ConvexResult &result);
 
 	void sortChulls(CHullVector &hulls);
 

--- a/src/Bullet3Common/b3CommandLineArgs.h
+++ b/src/Bullet3Common/b3CommandLineArgs.h
@@ -25,8 +25,6 @@ public:
 
 	void addArgs(int argc, char**argv)
 	{
-		using namespace std;
-
 	    for (int i = 1; i < argc; i++)
 	    {
 	        std::string arg = argv[i];
@@ -55,8 +53,7 @@ public:
 
 	bool CheckCmdLineFlag(const char* arg_name)
 	{
-		using namespace std;
-		map<std::string, std::string>::iterator itr;
+		std::map<std::string, std::string>::iterator itr;
 		if ((itr = pairs.find(arg_name)) != pairs.end()) {
 			return true;
 	    }
@@ -75,10 +72,9 @@ public:
 template <typename T>
 inline bool b3CommandLineArgs::GetCmdLineArgument(const char *arg_name, T &val)
 {
-	using namespace std;
-	map<std::string, std::string>::iterator itr;
+	std::map<std::string, std::string>::iterator itr;
 	if ((itr = pairs.find(arg_name)) != pairs.end()) {
-		istringstream strstream(itr->second);
+		std::istringstream strstream(itr->second);
 		strstream >> val;
 		return true;
     }
@@ -88,8 +84,7 @@ inline bool b3CommandLineArgs::GetCmdLineArgument(const char *arg_name, T &val)
 template <>
 inline bool b3CommandLineArgs::GetCmdLineArgument<char*>(const char* arg_name, char* &val)
 {
-	using namespace std;
-	map<std::string, std::string>::iterator itr;
+	std::map<std::string, std::string>::iterator itr;
 	if ((itr = pairs.find(arg_name)) != pairs.end()) {
 
 		std::string s = itr->second;


### PR DESCRIPTION
commit message I guess is self explanatory. There are a few very similar classes with identical names and if you include these files:
ConvexDecomposition/cd_hull.h
ConvexDecomposition/ConvexBuilder.h 
LinearMath/btConvexHull.h
you'll get compilation error.