### PR TITLE
fix using SSE on non x86 targets

### DIFF
--- a/src/Bullet3Common/b3Scalar.h
+++ b/src/Bullet3Common/b3Scalar.h
@@ -71,6 +71,7 @@ inline int	b3GetVersion()
 		#else
 
 #if (defined (_WIN32) && (_MSC_VER) && _MSC_VER >= 1400) && (!defined (B3_USE_DOUBLE_PRECISION))
+	#if (defined (_M_IX86) || defined (_M_X64))
 			#define B3_USE_SSE
 			#ifdef B3_USE_SSE
 			//B3_USE_SSE_IN_API is disabled under Windows by default, because 
@@ -82,6 +83,7 @@ inline int	b3GetVersion()
 			//#define B3_USE_SSE_IN_API
 			#endif //B3_USE_SSE
 			#include <emmintrin.h>
+	#endif
 #endif
 
 		#endif//_XBOX


### PR DESCRIPTION
Currently when building bullet for Windows on an ARM platform it will fail due to lack of SSE.