### PR TITLE
expose width/height as ExampleBrowser options etc.

### DIFF
--- a/examples/ExampleBrowser/OpenGLExampleBrowser.cpp
+++ b/examples/ExampleBrowser/OpenGLExampleBrowser.cpp
@@ -871,6 +871,16 @@ bool OpenGLExampleBrowser::init(int argc, char* argv[])
 	
 	int width = 1024;
     int height=768;
+
+	if (args.CheckCmdLineFlag("width"))
+	{
+		args.GetCmdLineArgument("width",width );
+	}
+	if (args.CheckCmdLineFlag("height"))
+	{
+		args.GetCmdLineArgument("height",height);
+	}
+
 #ifndef NO_OPENGL3
     SimpleOpenGL3App* simpleApp=0;
 	sUseOpenGL2 =args.CheckCmdLineFlag("opengl2");

--- a/examples/Importers/ImportMJCFDemo/BulletMJCFImporter.cpp
+++ b/examples/Importers/ImportMJCFDemo/BulletMJCFImporter.cpp
@@ -1026,6 +1026,11 @@ struct BulletMJCFImporterInternalData
 			{
 				handled = true;
 			}
+			if (n=="site")
+			{
+				handled = true;
+			}
+
 			if (!handled)
 			{
 				logger->reportWarning( (sourceFileLocation(xml) + ": unknown field '" + n + "'").c_str() );

--- a/examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp
+++ b/examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp
@@ -961,9 +961,15 @@ static void convertURDFToVisualShapeInternal(const UrdfVisual* visual, const cha
 			}
 			break;
 		}
-
+		case URDF_GEOM_PLANE:
+		{
+			b3Warning("No default visual for URDF_GEOM_PLANE");
+			break;
+		}
 		default:
+		{
 			b3Warning("Error: unknown visual geometry type %i\n", visual->m_geometry.m_type);
+		}
 	}
 
 	//if we have a convex, tesselate into localVertices/localIndices

--- a/examples/Importers/ImportURDFDemo/URDFImporterInterface.h
+++ b/examples/Importers/ImportURDFDemo/URDFImporterInterface.h
@@ -15,7 +15,6 @@ public:
 
 	virtual ~URDFImporterInterface() {}
 	
- 
     virtual bool loadURDF(const char* fileName, bool forceFixedBase = false)=0;
 
     virtual bool loadSDF(const char* fileName, bool forceFixedBase = false) { return false;}
@@ -27,8 +26,12 @@ public:
     
     ///pure virtual interfaces, precondition is a valid linkIndex (you can assert/terminate if the linkIndex is out of range)
     virtual std::string getLinkName(int linkIndex) const =0;
-    
-	virtual std::string getBodyName() const = 0;
+
+	//various derived class in internal source code break with new pure virtual methods, so provide some default implementation
+	virtual std::string getBodyName() const
+	{
+		return "";
+	}
     
 	/// optional method to provide the link color. return true if the color is available and copied into colorRGBA, return false otherwise
 	virtual bool getLinkColor(int linkIndex, btVector4& colorRGBA) const { return false;}

--- a/examples/SharedMemory/PhysicsServerCommandProcessor.cpp
+++ b/examples/SharedMemory/PhysicsServerCommandProcessor.cpp
@@ -1580,6 +1580,7 @@ bool PhysicsServerCommandProcessor::processImportedObjects(const char* fileName,
         {
             btScalar mass = 0;
             bodyHandle->m_rootLocalInertialFrame.setIdentity();
+			bodyHandle->m_bodyName = u2b.getBodyName();
             btVector3 localInertiaDiagonal(0,0,0);
             int urdfLinkIndex = u2b.getRootLinkIndex();
             u2b.getMassAndInertia(urdfLinkIndex, mass,localInertiaDiagonal,bodyHandle->m_rootLocalInertialFrame);
@@ -2528,7 +2529,15 @@ bool PhysicsServerCommandProcessor::processCommand(const struct SharedMemoryComm
 
                         serverStatusOut.m_type = CMD_BODY_INFO_COMPLETED;
                         serverStatusOut.m_dataStreamArguments.m_bodyUniqueId = sdfInfoArgs.m_bodyUniqueId;
-                        serverStatusOut.m_numDataStreamBytes = streamSizeInBytes;
+                        serverStatusOut.m_dataStreamArguments.m_bodyName[0] = 0;
+						
+						InternalBodyHandle* bodyHandle = m_data->getHandle(clientCmd.m_calculateJacobianArguments.m_bodyUniqueId);
+						if (bodyHandle)
+						{
+							strcpy(serverStatusOut.m_dataStreamArguments.m_bodyName,bodyHandle->m_bodyName.c_str());
+						}
+
+						serverStatusOut.m_numDataStreamBytes = streamSizeInBytes;
 						
                         hasStatus = true;
                         break;

--- a/examples/pybullet/pybullet.c
+++ b/examples/pybullet/pybullet.c
@@ -221,6 +221,7 @@ static PyObject* pybullet_connectPhysicsServer(PyObject* self, PyObject* args, P
 	int freeIndex = -1;
 	int method = eCONNECT_GUI;
 	int i;
+	char* options="";
 	b3PhysicsClientHandle sm = 0;
 
 	if (sNumPhysicsClients >= MAX_PHYSICS_CLIENTS)
@@ -237,15 +238,24 @@ static PyObject* pybullet_connectPhysicsServer(PyObject* self, PyObject* args, P
 
 		const char* hostName = "localhost";
 
-		int size = PySequence_Size(args);
-		if (size == 1)
+
+		static char* kwlist1[] = {"method","key", "options", NULL};
+		static char* kwlist2[] = {"method","hostName", "port", "options", NULL};
+		
+		if (!PyArg_ParseTupleAndKeywords(args, keywds, "i|is", kwlist1, &method,&key,&options))
 		{
-			if (!PyArg_ParseTuple(args, "i", &method))
+			int port = -1;
+			if (!PyArg_ParseTupleAndKeywords(args, keywds, "i|sis", kwlist2, &method,&hostName, &port,&options))
 			{
-				PyErr_SetString(SpamError,
-								"connectPhysicsServer expected argument  GUI, "
-								"DIRECT, SHARED_MEMORY, UDP or TCP");
 				return NULL;
+			} else
+			{
+				PyErr_Clear();
+				if (port>=0)
+				{
+					udpPort = port;
+					tcpPort = port;
+				}
 			}
 		}
 
@@ -264,45 +274,12 @@ static PyObject* pybullet_connectPhysicsServer(PyObject* self, PyObject* args, P
 			}
 		}
 
-		if (size == 2)
-		{
-			if (!PyArg_ParseTuple(args, "ii", &method, &key))
-			{
-				if (!PyArg_ParseTuple(args, "is", &method, &hostName))
-				{
-					PyErr_SetString(SpamError,
-									"connectPhysicsServer cannot parse second argument (either integer or string)");
-					return NULL;
-				}
-				else
-				{
-					PyErr_Clear();
-				}
-			}
-		}
-
-		if (size == 3)
-		{
-			int port = -1;
-			if (!PyArg_ParseTuple(args, "isi", &method, &hostName, &port))
-			{
-				PyErr_SetString(SpamError,
-								"connectPhysicsServer 3 arguments: method, hostname, port");
-				return NULL;
-			}
-			if (port >= 0)
-			{
-				udpPort = port;
-				tcpPort = port;
-			}
-		}
-
 		switch (method)
 		{
 			case eCONNECT_GUI:
 			{
-				int argc = 0;
-				char* argv[1] = {0};
+				int argc = 2;
+				char* argv[2] = {"unused",options};
 
 #ifdef __APPLE__
 				sm = b3CreateInProcessPhysicsServerAndConnectMainThread(argc, argv);


### PR DESCRIPTION
suppress lack of 'site' support message in MJCF importer
suppress lack of 'plane' visual support in urdf/sdf import
getBodyName default to "" to avoid breaking cloudsim
expose bodyName when requesting body info (sdf/mjcf import)
pass optional "options" string to pybullet.connect method. this can be used for --opengl2 flag in GUI mode (or other flags)