### PR TITLE
pybullet: add support for Anaconda install on Mac OSX, for pip instal…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,7 +267,10 @@ IF(BUILD_PYBULLET)
 	OPTION(BUILD_PYBULLET_NUMPY "Set when you want to build pybullet with NumPy support" OFF)
 	OPTION(BUILD_PYBULLET_ENET "Set when you want to build pybullet with enet UDP networking support" ON)
 	OPTION(BUILD_PYBULLET_CLSOCKET "Set when you want to build pybullet with enet TCP networking support" ON)
-	
+
+	OPTION(BUILD_PYBULLET_MAC_USE_PYTHON_FRAMEWORK "Set when you want to use the Python Framework on Mac" ON)
++#if defined(__APPLE__) && (!defined(B3_NO_PYTHON_FRAMEWORK))
+
 	IF(BUILD_PYBULLET_NUMPY)	
 		set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_LIST_DIR}/build3/cmake)
 		#include(FindNumPy)
@@ -286,6 +289,19 @@ IF(BUILD_PYBULLET)
 	ELSE(WIN32)
 		SET(BUILD_SHARED_LIBS ON CACHE BOOL "Shared Libs" FORCE)
 	ENDIF(WIN32)
+
+	IF(APPLE)
+		OPTION(BUILD_PYBULLET_MAC_USE_PYTHON_FRAMEWORK "Set when you want to use the Python Framework on Mac" ON)
+		IF(NOT BUILD_PYBULLET_MAC_USE_PYTHON_FRAMEWORK)
+			add_definitions(-DB3_NO_PYTHON_FRAMEWORK)
+		ENDIF(NOT BUILD_PYBULLET_MAC_USE_PYTHON_FRAMEWORK)
+		OPTION(BUILD_PYBULLET_SHOW_PY_VERSION "Set when you want to show the PY_MAJOR_VERSION and PY_MAJOR_VERSION using #pragme message." OFF)
+		IF(BUILD_PYBULLET_SHOW_PY_VERSION)
+			add_definitions(-DB3_DUMP_PYTHON_VERSION)
+		ENDIF()
+
+	ENDIF(APPLE)
+
 ENDIF(BUILD_PYBULLET)
 
 IF(BUILD_BULLET3)

--- a/examples/pybullet/pybullet.c
+++ b/examples/pybullet/pybullet.c
@@ -11,15 +11,24 @@
 #include "../SharedMemory/PhysicsClientTCP_C_API.h"
 #endif  //BT_ENABLE_CLSOCKET
 
-#ifdef __APPLE__
+#if defined(__APPLE__) && (!defined(B3_NO_PYTHON_FRAMEWORK))
 #include <Python/Python.h>
 #else
 #include <Python.h>
 #endif
 
+#ifdef B3_DUMP_PYTHON_VERSION
+#define B3_VALUE_TO_STRING(x) #x
+#define B3_VALUE(x) B3_VALUE_TO_STRING(x)
+#define B3_VAR_NAME_VALUE(var) #var "="  B3_VALUE(var)
+#pragma message(B3_VAR_NAME_VALUE(PY_MAJOR_VERSION))
+#pragma message(B3_VAR_NAME_VALUE(PY_MINOR_VERSION))
+#endif
+
 #ifdef PYBULLET_USE_NUMPY
 #include <numpy/arrayobject.h>
 #endif
+
 
 #if PY_MAJOR_VERSION >= 3
 #define PyInt_FromLong PyLong_FromLong

--- a/setup.py
+++ b/setup.py
@@ -391,7 +391,7 @@ elif _platform == "darwin":
 
 setup(
 	name = 'pybullet',
-	version='0.1.6',
+	version='0.1.7',
 	description='Official Python Interface for the Bullet Physics SDK Robotics Simulator',
 	long_description='pybullet is an easy to use Python module for physics simulation, robotics and machine learning based on the Bullet Physics SDK. With pybullet you can load articulated bodies from URDF, SDF and other file formats. pybullet provides forward dynamics simulation, inverse dynamics computation, forward and inverse kinematics and collision detection and ray intersection queries. Aside from physics simulation, pybullet supports to rendering, with a CPU renderer and OpenGL visualization and support for virtual reality headsets.',
 	url='https://github.com/bulletphysics/bullet3',


### PR DESCRIPTION
…l pybullet, python setup.py install and cmake.

Usage:

Also updated pypi to latest, see https://pypi.python.org/pypi?:action=display&name=pybullet&version=0.1.7
Here are a few options for Mac OSX + Anaconda:

1) In the root of the Bullet Physics SDK source tree, run
CFLAGS="-DB3_NO_PYTHON_FRAMEWORK" python setup.py install

2) cmake, add the flag -DBUILD_PYBULLET_MAC_USE_PYTHON_FRAMEWORK=OFF

3) Globally, just use pip or pip3:
CFLAGS="-DB3_NO_PYTHON_FRAMEWORK" pip install pybullet

Option (3) may have an out-of-date pybullet/bullet version.