### PR TITLE
Remove pointless if

### DIFF
--- a/src/BulletDynamics/Dynamics/btRigidBody.h
+++ b/src/BulletDynamics/Dynamics/btRigidBody.h
@@ -336,7 +336,8 @@ public:
 		if (m_inverseMass != btScalar(0.))
 		{
 			applyCentralImpulse(impulse);
-			if (m_angularFactor)
+			// test evaluates m_angularFactor as (float*)operator()  which is always non-zero
+			//if (m_angularFactor)
 			{
 				applyTorqueImpulse(rel_pos.cross(impulse*m_linearFactor));
 			}


### PR DESCRIPTION
"if (m_angularFactor)" test evaluates m_angularFactor as (float*)operator() {return &m_floats[0]} which is always non-zero