### PR TITLE
getSolveSwingLimit() returns wrong value

### DIFF
--- a/src/BulletDynamics/ConstraintSolver/btConeTwistConstraint.h
+++ b/src/BulletDynamics/ConstraintSolver/btConeTwistConstraint.h
@@ -260,7 +260,7 @@ public:
 
 	inline int getSolveSwingLimit()
 	{
-		return m_solveTwistLimit;
+		return m_solveSwingLimit;
 	}
 
 	inline btScalar getTwistLimitSign()


### PR DESCRIPTION
Should return m_solveSwingLimit instead of m_solveTwistLimit