### PR TITLE
btsoftbody fix #1106, compiler error in App_PhysicsServer_SharedMemory

### DIFF
--- a/examples/SharedMemory/CMakeLists.txt
+++ b/examples/SharedMemory/CMakeLists.txt
@@ -62,7 +62,7 @@ SET(SharedMemory_SRCS
 	../Importers/ImportMJCFDemo/BulletMJCFImporter.cpp
 	../Importers/ImportMJCFDemo/BulletMJCFImporter.h
 	../Utils/b3ResourcePath.cpp
-	../Utils/b3Clock.cpp	
+	../Utils/b3Clock.cpp
 	../Utils/RobotLoggingUtil.cpp
 	../Utils/RobotLoggingUtil.h
 	../Utils/ChromeTraceUtil.cpp
@@ -75,13 +75,13 @@ SET(SharedMemory_SRCS
 	../Importers/ImportSTLDemo/LoadMeshFromSTL.h
 	../Importers/ImportColladaDemo/LoadMeshFromCollada.cpp
 	../Importers/ImportColladaDemo/ColladaGraphicsInstance.h
-	../ThirdPartyLibs/Wavefront/tiny_obj_loader.cpp	
+	../ThirdPartyLibs/Wavefront/tiny_obj_loader.cpp
 	../ThirdPartyLibs/tinyxml/tinystr.cpp
 	../ThirdPartyLibs/tinyxml/tinyxml.cpp
 	../ThirdPartyLibs/tinyxml/tinyxmlerror.cpp
 	../ThirdPartyLibs/tinyxml/tinyxmlparser.cpp
 	../Importers/ImportMeshUtility/b3ImportMeshUtility.cpp
-	../ThirdPartyLibs/stb_image/stb_image.cpp  
+	../ThirdPartyLibs/stb_image/stb_image.cpp
 	../MultiThreading/b3ThreadSupportInterface.cpp
 	../MultiThreading/b3ThreadSupportInterface.h
 )
@@ -94,6 +94,10 @@ INCLUDE_DIRECTORIES(
 LINK_LIBRARIES(
  Bullet3Common BulletWorldImporter BulletFileLoader BulletInverseDynamicsUtils BulletInverseDynamics BulletDynamics BulletCollision LinearMath BussIK
 )
+
+IF (USE_SOFT_BODY_MULTI_BODY_DYNAMICS_WORLD)
+	LINK_LIBRARIES(BulletSoftBody)
+ENDIF()
 
 IF (WIN32)
         ADD_EXECUTABLE(App_PhysicsServer_SharedMemory
@@ -112,7 +116,7 @@ ELSE(WIN32)
 	               			../MultiThreading/b3PosixThreadSupport.h
 			                main.cpp
 			        )
-							
+
         ELSE(APPLE)
                                 LINK_LIBRARIES(  pthread ${DL} )
 			        ADD_EXECUTABLE(App_PhysicsServer_SharedMemory
@@ -152,7 +156,7 @@ LINK_LIBRARIES(
 IF (WIN32)
  				ADD_DEFINITIONS(-DGLEW_STATIC)
 				LINK_LIBRARIES( ${OPENGL_gl_LIBRARY} ${OPENGL_glu_LIBRARY} )
-	
+
         ADD_EXECUTABLE(App_PhysicsServer_SharedMemory_GUI
                 ${SharedMemory_SRCS}
 								../StandaloneMain/main_opengl_single_example.cpp
@@ -169,23 +173,23 @@ ELSE(WIN32)
 			        FIND_LIBRARY(COCOA NAMES Cocoa)
               MESSAGE(${COCOA})
               LINK_LIBRARIES(${COCOA} ${OPENGL_gl_LIBRARY} ${OPENGL_glu_LIBRARY})
-                
+
 			        ADD_EXECUTABLE(App_PhysicsServer_SharedMemory_GUI
 			                ${SharedMemory_SRCS}
 	               			../StandaloneMain/main_opengl_single_example.cpp
 											../ExampleBrowser/OpenGLGuiHelper.cpp
 											../ExampleBrowser/GL_ShapeDrawer.cpp
-											../ExampleBrowser/CollisionShape2TriangleMesh.cpp					
+											../ExampleBrowser/CollisionShape2TriangleMesh.cpp
 			                ../MultiThreading/b3PosixThreadSupport.cpp
 	               			../MultiThreading/b3PosixThreadSupport.h
 			        )
-							
+
         ELSE(APPLE)
 				LINK_LIBRARIES(  pthread ${DL} )
          			ADD_DEFINITIONS("-DGLEW_INIT_OPENGL11_FUNCTIONS=1")
               ADD_DEFINITIONS("-DGLEW_STATIC")
               ADD_DEFINITIONS("-DGLEW_DYNAMIC_LOAD_ALL_GLX_FUNCTIONS=1")
-                
+
 			        ADD_EXECUTABLE(App_PhysicsServer_SharedMemory_GUI
 			                ${SharedMemory_SRCS}
 	              			../StandaloneMain/main_opengl_single_example.cpp
@@ -215,7 +219,7 @@ INCLUDE_DIRECTORIES(
 	${BULLET_PHYSICS_SOURCE_DIR}/examples/ThirdPartyLibs
 	${BULLET_PHYSICS_SOURCE_DIR}/examples/ThirdPartyLibs/Glew
 	${BULLET_PHYSICS_SOURCE_DIR}/examples/ThirdPartyLibs/openvr/headers
-	${BULLET_PHYSICS_SOURCE_DIR}/examples/ThirdPartyLibs/openvr/samples/shared		
+	${BULLET_PHYSICS_SOURCE_DIR}/examples/ThirdPartyLibs/openvr/samples/shared
 )
 
 
@@ -233,7 +237,7 @@ LINK_LIBRARIES(
 					LINK_DIRECTORIES(${BULLET_PHYSICS_SOURCE_DIR}/examples/ThirdPartyLibs/openvr/lib/win64)
 				ELSE(CMAKE_CL_64)
 					LINK_DIRECTORIES(${BULLET_PHYSICS_SOURCE_DIR}/examples/ThirdPartyLibs/openvr/lib/win32)
-				ENDIF(CMAKE_CL_64)			
+				ENDIF(CMAKE_CL_64)
         ADD_EXECUTABLE(App_PhysicsServer_SharedMemory_VR
                 ${SharedMemory_SRCS}
           ../StandaloneMain/hellovr_opengl_main.cpp
@@ -250,12 +254,12 @@ LINK_LIBRARIES(
 					../ThirdPartyLibs/openvr/samples/shared/pathtools.cpp
 					../ThirdPartyLibs/openvr/samples/shared/pathtools.h
 					../ThirdPartyLibs/openvr/samples/shared/strtools.cpp
-					../ThirdPartyLibs/openvr/samples/shared/strtools.h					
+					../ThirdPartyLibs/openvr/samples/shared/strtools.h
 					../ThirdPartyLibs/openvr/samples/shared/Vectors.h
 						../MultiThreading/b3Win32ThreadSupport.cpp
 						../MultiThreading/b3Win32ThreadSupport.h
 	          ${BULLET_PHYSICS_SOURCE_DIR}/build3/bullet.rc
-        )			
+        )
 
 
 IF (NOT INTERNAL_CREATE_DISTRIBUTABLE_MSVC_PROJECTFILES)
@@ -272,7 +276,7 @@ IF (NOT INTERNAL_CREATE_DISTRIBUTABLE_MSVC_PROJECTFILES)
 			COMMAND ${CMAKE_COMMAND} ARGS -E copy_if_different ${BULLET_PHYSICS_SOURCE_DIR}/examples/ThirdPartyLibs/openvr/bin/win32/openvr_api.dll  ${CMAKE_CURRENT_BINARY_DIR}/openvr_api.dll
 		)
 	ENDIF(CMAKE_CL_64)
-	
+
 	ADD_CUSTOM_COMMAND(
                 TARGET App_PhysicsServer_SharedMemory_VR
                 POST_BUILD


### PR DESCRIPTION
BulletSoftBody was not linking to App_PhysicsServer_SharedMemory when 
cmake flag USE_SOFT_BODY_MULTI_BODY_DYNAMICS_WORLD was ON.
fixes #1106 