### PR TITLE
Zeroed axis in setupTorsionalFrictionConstraint

### DIFF
--- a/src/BulletDynamics/ConstraintSolver/btSequentialImpulseConstraintSolver.cpp
+++ b/src/BulletDynamics/ConstraintSolver/btSequentialImpulseConstraintSolver.cpp
@@ -652,8 +652,8 @@ void btSequentialImpulseConstraintSolver::setupTorsionalFrictionConstraint(	btSo
 
 {
 
-	solverConstraint.m_contactNormal1 = normalAxis;
-	solverConstraint.m_contactNormal2 = -normalAxis;
+	solverConstraint.m_contactNormal1 = normalAxis1;
+	solverConstraint.m_contactNormal2 = -normalAxis1;
 	btSolverBody& solverBodyA = m_tmpSolverBodyPool[solverBodyIdA];
 	btSolverBody& solverBodyB = m_tmpSolverBodyPool[solverBodyIdB];
 

--- a/src/BulletDynamics/ConstraintSolver/btSequentialImpulseConstraintSolver.cpp
+++ b/src/BulletDynamics/ConstraintSolver/btSequentialImpulseConstraintSolver.cpp
@@ -651,8 +651,6 @@ void btSequentialImpulseConstraintSolver::setupTorsionalFrictionConstraint(	btSo
 									btScalar desiredVelocity, btScalar cfmSlip)
 
 {
-	btVector3 normalAxis(0,0,0);
-
 
 	solverConstraint.m_contactNormal1 = normalAxis;
 	solverConstraint.m_contactNormal2 = -normalAxis;


### PR DESCRIPTION
Not sure if this was the desired behavior. The zeroing of normalAxis1 seems to be the cause of spheres spinning in place while stopped. Also the two dot products for contactNormal1 and contactNormal2 would always be zero as well.