### PR TITLE
allow b3Clock to reset to time reference 0, by default reset will set…

### DIFF
--- a/examples/Utils/b3Clock.cpp
+++ b/examples/Utils/b3Clock.cpp
@@ -88,8 +88,23 @@ b3Clock& b3Clock::operator=(const b3Clock& other)
 
 
 	/// Resets the initial reference time.
-void b3Clock::reset()
+void b3Clock::reset(bool zeroReference)
 {
+	if (zeroReference)
+	{
+		m_data->mStartTick = 0;
+#ifdef B3_USE_WINDOWS_TIMERS
+		m_data->mStartTime.QuadPart = 0;
+#else
+	#ifdef __CELLOS_LV2__
+			m_data->mStartTime = 0;
+	#else
+			m_data->mStartTime = (struct timeval){0};
+	#endif
+#endif
+
+	} else
+	{
 #ifdef B3_USE_WINDOWS_TIMERS
 	QueryPerformanceCounter(&m_data->mStartTime);
 	m_data->mStartTick = GetTickCount();
@@ -105,6 +120,7 @@ void b3Clock::reset()
 	gettimeofday(&m_data->mStartTime, 0);
 #endif
 #endif
+	}
 }
 
 /// Returns the time in ms since the last call to reset or since 

--- a/examples/Utils/b3Clock.cpp
+++ b/examples/Utils/b3Clock.cpp
@@ -46,7 +46,6 @@ struct b3ClockData
 
 #ifdef B3_USE_WINDOWS_TIMERS
 	LARGE_INTEGER mClockFrequency;
-	DWORD mStartTick;
 	LARGE_INTEGER mStartTime;
 #else
 #ifdef __CELLOS_LV2__
@@ -92,7 +91,6 @@ void b3Clock::reset(bool zeroReference)
 {
 	if (zeroReference)
 	{
-		m_data->mStartTick = 0;
 #ifdef B3_USE_WINDOWS_TIMERS
 		m_data->mStartTime.QuadPart = 0;
 #else
@@ -107,7 +105,6 @@ void b3Clock::reset(bool zeroReference)
 	{
 #ifdef B3_USE_WINDOWS_TIMERS
 	QueryPerformanceCounter(&m_data->mStartTime);
-	m_data->mStartTick = GetTickCount();
 #else
 #ifdef __CELLOS_LV2__
 

--- a/examples/Utils/b3Clock.h
+++ b/examples/Utils/b3Clock.h
@@ -13,8 +13,8 @@ public:
 
 	~b3Clock();
 
-	/// Resets the initial reference time.
-	void reset();
+	/// Resets the initial reference time. If zeroReference is true, will set reference to absolute 0.
+	void reset(bool zeroReference=false);
 
 	/// Returns the time in ms since the last call to reset or since 
 	/// the b3Clock was created.


### PR DESCRIPTION
… the reference to 'now'.