### PR TITLE
example browser: fix 'clamp-to-integer' on GUI-sliders

### DIFF
--- a/examples/ExampleBrowser/GwenGUISupport/GwenParameterInterface.cpp
+++ b/examples/ExampleBrowser/GwenGUISupport/GwenParameterInterface.cpp
@@ -237,7 +237,7 @@ void GwenParameterInterface::registerSliderFloatParameter(SliderParams& params)
     if (params.m_clampToIntegers)
     {
         pSlider->SetNotchCount( int( params.m_maxVal - params.m_minVal ) );
-        pSlider->SetClampToNotches( params.m_clampToNotches );
+        pSlider->SetClampToNotches( true );
     }
     else
     {


### PR DESCRIPTION
Improves the feel on GUI sliders that are flagged with clamp-to-integer