### PR TITLE
Ignore 'xcode4' build files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /bin
 /build3/gmake
+/build3/xcode4
 /build_cmake/


### PR DESCRIPTION
At the moment xcode 4 build files aren't ignored, it would be great if they were :). Unless there's some reason I'm missing as to why they aren't?