### PR TITLE
fix memcpy of depth and segmentation images to numpy arrays

### DIFF
--- a/examples/pybullet/pybullet.c
+++ b/examples/pybullet/pybullet.c
@@ -5178,9 +5178,9 @@ static PyObject* pybullet_getCameraImage(PyObject* self, PyObject* args, PyObjec
 			memcpy(PyArray_DATA(pyRGB), imageData.m_rgbColorData,
 				   imageData.m_pixelHeight * imageData.m_pixelWidth * bytesPerPixel);
 			memcpy(PyArray_DATA(pyDep), imageData.m_depthValues,
-				   imageData.m_pixelHeight * imageData.m_pixelWidth);
+				   imageData.m_pixelHeight * imageData.m_pixelWidth * sizeof(float));
 			memcpy(PyArray_DATA(pySeg), imageData.m_segmentationMaskValues,
-				   imageData.m_pixelHeight * imageData.m_pixelWidth);
+				   imageData.m_pixelHeight * imageData.m_pixelWidth * sizeof(int));
 
 			PyTuple_SetItem(pyResultList, 2, pyRGB);
 			PyTuple_SetItem(pyResultList, 3, pyDep);


### PR DESCRIPTION
When the image data is copied to NumPy arrays, the wrong byte count was used for the depth and segmentation values.