### PR TITLE
ThreadSupportInterface: add platform independent create function

### DIFF
--- a/examples/ExampleBrowser/InProcessExampleBrowser.cpp
+++ b/examples/ExampleBrowser/InProcessExampleBrowser.cpp
@@ -31,39 +31,15 @@ void*	ExampleBrowserMemoryFunc();
 #include "../SharedMemory/PhysicsServerExampleBullet2.h"
 
 #include "../SharedMemory/PhysicsClientExample.h"
+#include "../MultiThreading/b3ThreadSupportInterface.h"
 
-#ifndef _WIN32
-#include "../MultiThreading/b3PosixThreadSupport.h"
-
-
-
-static b3ThreadSupportInterface* createExampleBrowserThreadSupport(int numThreads)
-{
-	b3PosixThreadSupport::ThreadConstructionInfo constructionInfo("testThreads",
-                                                                ExampleBrowserThreadFunc,
-                                                                ExampleBrowserMemoryFunc,
-                                                                numThreads);
-    b3ThreadSupportInterface* threadSupport = new b3PosixThreadSupport(constructionInfo);
-
-	return threadSupport;
-
-}
-
-
-
-#elif defined( _WIN32)
-#include "../MultiThreading/b3Win32ThreadSupport.h"
 
 b3ThreadSupportInterface* createExampleBrowserThreadSupport(int numThreads)
 {
-	b3Win32ThreadSupport::Win32ThreadConstructionInfo threadConstructionInfo("testThreads",ExampleBrowserThreadFunc,ExampleBrowserMemoryFunc,numThreads);
-	b3Win32ThreadSupport* threadSupport = new b3Win32ThreadSupport(threadConstructionInfo);
+	b3ThreadSupportInterface::ConstructionInfo threadConstructionInfo("testThreads",ExampleBrowserThreadFunc,ExampleBrowserMemoryFunc,numThreads);
+	b3ThreadSupportInterface* threadSupport = b3ThreadSupportInterface::create(threadConstructionInfo);
 	return threadSupport;
-
 }
-#endif
-
-
 
 
 

--- a/examples/MultiThreading/MultiThreadingExample.cpp
+++ b/examples/MultiThreading/MultiThreadingExample.cpp
@@ -13,6 +13,7 @@
 #include "Bullet3Common/b3Matrix3x3.h"
 #include "../Utils/b3Clock.h"
 #include "../CommonInterfaces/CommonParameterInterface.h"
+#include "b3ThreadSupportInterface.h"
 
 #include "LinearMath/btAlignedObjectArray.h"
 #define  stdvector btAlignedObjectArray
@@ -26,33 +27,13 @@ void*	SamplelsMemoryFunc();
 #include <stdio.h>
 //#include "BulletMultiThreaded/PlatformDefinitions.h"
 
-#ifndef _WIN32
-#include "b3PosixThreadSupport.h"
 
 b3ThreadSupportInterface* createThreadSupport(int numThreads)
 {
-	b3PosixThreadSupport::ThreadConstructionInfo constructionInfo("testThreads",
-                                                                SampleThreadFunc,
-                                                                SamplelsMemoryFunc,
-                                                                numThreads);
-    b3ThreadSupportInterface* threadSupport = new b3PosixThreadSupport(constructionInfo);
-
+	b3ThreadSupportInterface::ConstructionInfo threadConstructionInfo("testThreads",SampleThreadFunc,SamplelsMemoryFunc,numThreads);
+	b3ThreadSupportInterface* threadSupport = b3ThreadSupportInterface::create(threadConstructionInfo);
 	return threadSupport;
-
 }
-
-
-#elif defined( _WIN32)
-#include "b3Win32ThreadSupport.h"
-
-b3ThreadSupportInterface* createThreadSupport(int numThreads)
-{
-	b3Win32ThreadSupport::Win32ThreadConstructionInfo threadConstructionInfo("testThreads",SampleThreadFunc,SamplelsMemoryFunc,numThreads);
-	b3Win32ThreadSupport* threadSupport = new b3Win32ThreadSupport(threadConstructionInfo);
-	return threadSupport;
-
-}
-#endif
 
 struct SampleJobInterface
 {

--- a/examples/MultiThreading/b3PosixThreadSupport.cpp
+++ b/examples/MultiThreading/b3PosixThreadSupport.cpp
@@ -447,4 +447,11 @@ void b3PosixThreadSupport::deleteCriticalSection(b3CriticalSection* cs)
 {
 	delete cs;
 }
+
+
+b3ThreadSupportInterface* b3ThreadSupportInterface::create(const ConstructionInfo& info)
+{
+    return new b3PosixThreadSupport(info);
+}
+
 #endif //_WIN32

--- a/examples/MultiThreading/b3PosixThreadSupport.cpp
+++ b/examples/MultiThreading/b3PosixThreadSupport.cpp
@@ -29,7 +29,7 @@ subject to the following restrictions:
 // Todo: each worker should be linked to a single core, using SetThreadIdealProcessor.
 
 
-b3PosixThreadSupport::b3PosixThreadSupport(ThreadConstructionInfo& threadConstructionInfo)
+b3PosixThreadSupport::b3PosixThreadSupport(const ConstructionInfo& threadConstructionInfo)
 {
 	startThreads(threadConstructionInfo);
 }
@@ -225,7 +225,7 @@ void b3PosixThreadSupport::waitForResponse( int *puiArgument0,  int *puiArgument
 
 
 
-void b3PosixThreadSupport::startThreads(ThreadConstructionInfo& threadConstructionInfo)
+void b3PosixThreadSupport::startThreads(const ConstructionInfo& threadConstructionInfo)
 {
         printf("%s creating %i threads.\n", __FUNCTION__, threadConstructionInfo.m_numThreads);
 	m_activeThreadStatus.resize(threadConstructionInfo.m_numThreads);

--- a/examples/MultiThreading/b3PosixThreadSupport.h
+++ b/examples/MultiThreading/b3PosixThreadSupport.h
@@ -75,12 +75,12 @@ public:
 
     typedef ConstructionInfo ThreadConstructionInfo;
 
-	b3PosixThreadSupport(ThreadConstructionInfo& threadConstructionInfo);
+	b3PosixThreadSupport(const ConstructionInfo& threadConstructionInfo);
 
 ///cleanup/shutdown Libspe2
 	virtual	~b3PosixThreadSupport();
 
-	void	startThreads(ThreadConstructionInfo&	threadInfo);
+	void	startThreads(const ConstructionInfo& threadInfo);
 
 
 	virtual	void runTask(int uiCommand, void* uiArgument0, int uiArgument1);

--- a/examples/MultiThreading/b3PosixThreadSupport.h
+++ b/examples/MultiThreading/b3PosixThreadSupport.h
@@ -33,9 +33,6 @@ subject to the following restrictions:
 #include "b3ThreadSupportInterface.h"
 
 
-typedef void (*b3PosixThreadFunc)(void* userPtr,void* lsMemory);
-typedef void* (*b3PosixlsMemorySetupFunc)();
-
 // b3PosixThreadSupport helps to initialize/shutdown libspe2, start/stop SPU tasks and communication
 class b3PosixThreadSupport : public b3ThreadSupportInterface
 {
@@ -53,7 +50,7 @@ public:
 		int	m_commandId;
 		int	m_status;
 
-		b3PosixThreadFunc	m_userThreadFunc;
+		ThreadFunc	m_userThreadFunc;
 		void*	m_userPtr; //for taskDesc etc
 		void*	m_lsMemory; //initialized using PosixLocalStoreMemorySetupFunc
 
@@ -76,32 +73,7 @@ private:
 public:
 	///Setup and initialize SPU/CELL/Libspe2
 
-
-
-	struct	ThreadConstructionInfo
-	{
-		ThreadConstructionInfo(const char* uniqueName,
-									b3PosixThreadFunc userThreadFunc,
-									b3PosixlsMemorySetupFunc	lsMemoryFunc,
-									int numThreads=1,
-									int threadStackSize=65535
-									)
-									:m_uniqueName(uniqueName),
-									m_userThreadFunc(userThreadFunc),
-									m_lsMemoryFunc(lsMemoryFunc),
-									m_numThreads(numThreads),
-									m_threadStackSize(threadStackSize)
-		{
-
-		}
-
-		const char*					m_uniqueName;
-		b3PosixThreadFunc			m_userThreadFunc;
-		b3PosixlsMemorySetupFunc	m_lsMemoryFunc;
-		int						m_numThreads;
-		int						m_threadStackSize;
-
-	};
+    typedef ConstructionInfo ThreadConstructionInfo;
 
 	b3PosixThreadSupport(ThreadConstructionInfo& threadConstructionInfo);
 

--- a/examples/MultiThreading/b3ThreadSupportInterface.h
+++ b/examples/MultiThreading/b3ThreadSupportInterface.h
@@ -84,6 +84,35 @@ public:
 
 	virtual void*	getThreadLocalMemory(int taskId) { return 0; }
 
+    typedef void( *ThreadFunc )( void* userPtr, void* lsMemory );
+    typedef void* ( *MemorySetupFunc )( );
+
+    struct ConstructionInfo
+    {
+        ConstructionInfo( const char* uniqueName,
+            ThreadFunc userThreadFunc,
+            MemorySetupFunc	lsMemoryFunc,
+            int numThreads = 1,
+            int threadStackSize = 65535
+        )
+            :m_uniqueName( uniqueName ),
+            m_userThreadFunc( userThreadFunc ),
+            m_lsMemoryFunc( lsMemoryFunc ),
+            m_numThreads( numThreads ),
+            m_threadStackSize( threadStackSize ),
+            m_priority( 0 )
+        {
+        }
+
+        const char*     m_uniqueName;
+        ThreadFunc      m_userThreadFunc;
+        MemorySetupFunc m_lsMemoryFunc;
+        int             m_numThreads;
+        int             m_threadStackSize;
+        int             m_priority;
+	};
+
+    static b3ThreadSupportInterface* create(const ConstructionInfo& info);
 };
 
 #endif //B3_THREAD_SUPPORT_INTERFACE_H

--- a/examples/MultiThreading/b3Win32ThreadSupport.cpp
+++ b/examples/MultiThreading/b3Win32ThreadSupport.cpp
@@ -477,6 +477,10 @@ void b3Win32ThreadSupport::deleteCriticalSection(b3CriticalSection* criticalSect
 
 
 
+b3ThreadSupportInterface* b3ThreadSupportInterface::create(const ConstructionInfo& info)
+{
+    return new b3Win32ThreadSupport(info);
+}
 
 
 #endif //_WIN32

--- a/examples/MultiThreading/b3Win32ThreadSupport.h
+++ b/examples/MultiThreading/b3Win32ThreadSupport.h
@@ -24,9 +24,6 @@ subject to the following restrictions:
 #include "b3ThreadSupportInterface.h"
 
 
-typedef void (*b3Win32ThreadFunc)(void* userPtr,void* lsMemory);
-typedef void* (*b3Win32lsMemorySetupFunc)();
-
 
 ///b3Win32ThreadSupport helps to initialize/shutdown libspe2, start/stop SPU tasks and communication
 class b3Win32ThreadSupport : public b3ThreadSupportInterface 
@@ -39,7 +36,7 @@ public:
 		int		m_commandId;
 		int		m_status;
 
-		b3Win32ThreadFunc	m_userThreadFunc;
+		ThreadFunc	m_userThreadFunc;
 		void*	m_userPtr; //for taskDesc etc
 		void*	m_lsMemory; //initialized using Win32LocalStoreMemorySetupFunc
 
@@ -62,34 +59,7 @@ private:
 public:
 	///Setup and initialize SPU/CELL/Libspe2
 
-	struct	Win32ThreadConstructionInfo
-	{
-		Win32ThreadConstructionInfo(const char* uniqueName,
-									b3Win32ThreadFunc userThreadFunc,
-									b3Win32lsMemorySetupFunc	lsMemoryFunc,
-									int numThreads=1,
-									int threadStackSize=65535
-									)
-									:m_uniqueName(uniqueName),
-									m_userThreadFunc(userThreadFunc),
-									m_lsMemoryFunc(lsMemoryFunc),
-									m_numThreads(numThreads),
-									m_threadStackSize(threadStackSize),
-									m_priority(0)
-		{
-
-		}
-
-		const char*				m_uniqueName;
-		b3Win32ThreadFunc			m_userThreadFunc;
-		b3Win32lsMemorySetupFunc	m_lsMemoryFunc;
-		int						m_numThreads;
-		int						m_threadStackSize;
-		int						m_priority;
-
-	};
-
-
+    typedef ConstructionInfo Win32ThreadConstructionInfo;
 
 	b3Win32ThreadSupport(const Win32ThreadConstructionInfo& threadConstructionInfo);
 

--- a/examples/MultiThreading/btTaskScheduler.cpp
+++ b/examples/MultiThreading/btTaskScheduler.cpp
@@ -13,33 +13,18 @@ typedef void* ( *btThreadLocalStorageFunc )();
 
 #if BT_THREADSAFE
 
-#if defined( _WIN32 )
-
-#include "b3Win32ThreadSupport.h"
+#include "b3ThreadSupportInterface.h"
 
 b3ThreadSupportInterface* createThreadSupport( int numThreads, btThreadFunc threadFunc, btThreadLocalStorageFunc localStoreFunc, const char* uniqueName )
 {
-    b3Win32ThreadSupport::Win32ThreadConstructionInfo constructionInfo( uniqueName, threadFunc, localStoreFunc, numThreads );
+    b3ThreadSupportInterface::ConstructionInfo constructionInfo( uniqueName, threadFunc, localStoreFunc, numThreads );
     //constructionInfo.m_priority = 0;  // highest priority (the default) -- can cause erratic performance when numThreads > numCores
     //                                     we don't want worker threads to be higher priority than the main thread or the main thread could get
     //                                     totally shut out and unable to tell the workers to stop
     constructionInfo.m_priority = -1;  // normal priority
-    b3Win32ThreadSupport* threadSupport = new b3Win32ThreadSupport( constructionInfo );
+    b3ThreadSupportInterface* threadSupport = b3ThreadSupportInterface::create( constructionInfo );
     return threadSupport;
 }
-
-#else // #if defined( _WIN32 )
-
-#include "b3PosixThreadSupport.h"
-
-b3ThreadSupportInterface* createThreadSupport( int numThreads, btThreadFunc threadFunc, btThreadLocalStorageFunc localStoreFunc, const char* uniqueName)
-{
-    b3PosixThreadSupport::ThreadConstructionInfo constructionInfo( uniqueName, threadFunc, localStoreFunc, numThreads );
-    b3ThreadSupportInterface* threadSupport = new b3PosixThreadSupport( constructionInfo );
-    return threadSupport;
-}
-
-#endif // #else // #if defined( _WIN32 )
 
 
 ///

--- a/examples/SharedMemory/PhysicsClientUDP.cpp
+++ b/examples/SharedMemory/PhysicsClientUDP.cpp
@@ -9,38 +9,19 @@
 #include <string>
 #include "Bullet3Common/b3Logging.h"
 #include "../MultiThreading/b3ThreadSupportInterface.h"
+#include "Bullet3Common/b3AlignedObjectArray.h"
+
 void	UDPThreadFunc(void* userPtr, void* lsMemory);
 void*	UDPlsMemoryFunc();
 bool gVerboseNetworkMessagesClient = false;
 
-#ifndef _WIN32
-#include "../MultiThreading/b3PosixThreadSupport.h"
 
 b3ThreadSupportInterface* createUDPThreadSupport(int numThreads)
 {
-	b3PosixThreadSupport::ThreadConstructionInfo constructionInfo("UDPThread",
-		UDPThreadFunc,
-		UDPlsMemoryFunc,
-		numThreads);
-	b3ThreadSupportInterface* threadSupport = new b3PosixThreadSupport(constructionInfo);
-
+	b3ThreadSupportInterface::ConstructionInfo constructionInfo("UDPThread", UDPThreadFunc, UDPlsMemoryFunc, numThreads);
+	b3ThreadSupportInterface* threadSupport = b3ThreadSupportInterface::create(constructionInfo);
 	return threadSupport;
-
 }
-
-
-#elif defined( _WIN32)
-#include "../MultiThreading/b3Win32ThreadSupport.h"
-
-b3ThreadSupportInterface* createUDPThreadSupport(int numThreads)
-{
-	b3Win32ThreadSupport::Win32ThreadConstructionInfo threadConstructionInfo("UDPThread", UDPThreadFunc, UDPlsMemoryFunc, numThreads);
-	b3Win32ThreadSupport* threadSupport = new b3Win32ThreadSupport(threadConstructionInfo);
-	return threadSupport;
-
-}
-#endif
-
 
 
 struct UDPThreadLocalStorage

--- a/examples/SharedMemory/PhysicsServerExample.cpp
+++ b/examples/SharedMemory/PhysicsServerExample.cpp
@@ -10,6 +10,7 @@
 #include "Bullet3Common/b3CommandLineArgs.h"
 #include "SharedMemoryCommon.h"
 #include "Bullet3Common/b3Matrix3x3.h"
+#include "Bullet3Common/b3AlignedObjectArray.h"
 #include "../Utils/b3Clock.h"
 #include "../MultiThreading/b3ThreadSupportInterface.h"
 #include "SharedMemoryPublic.h"
@@ -134,33 +135,13 @@ enum MultiThreadedGUIHelperCommunicationEnums
 #include <stdio.h>
 //#include "BulletMultiThreaded/PlatformDefinitions.h"
 
-#ifndef _WIN32
-#include "../MultiThreading/b3PosixThreadSupport.h"
 
 b3ThreadSupportInterface* createMotionThreadSupport(int numThreads)
 {
-	b3PosixThreadSupport::ThreadConstructionInfo constructionInfo("MotionThreads",
-                                                                MotionThreadFunc,
-                                                                MotionlsMemoryFunc,
-                                                                numThreads);
-    b3ThreadSupportInterface* threadSupport = new b3PosixThreadSupport(constructionInfo);
-
+	b3ThreadSupportInterface::ConstructionInfo threadConstructionInfo("MotionThreads",MotionThreadFunc,MotionlsMemoryFunc,numThreads);
+	b3ThreadSupportInterface* threadSupport = b3ThreadSupportInterface::create(threadConstructionInfo);
 	return threadSupport;
-
 }
-
-
-#elif defined( _WIN32)
-#include "../MultiThreading/b3Win32ThreadSupport.h"
-
-b3ThreadSupportInterface* createMotionThreadSupport(int numThreads)
-{
-	b3Win32ThreadSupport::Win32ThreadConstructionInfo threadConstructionInfo("MotionThreads",MotionThreadFunc,MotionlsMemoryFunc,numThreads);
-	b3Win32ThreadSupport* threadSupport = new b3Win32ThreadSupport(threadConstructionInfo);
-	return threadSupport;
-
-}
-#endif
 
 enum MyMouseCommandType
 {


### PR DESCRIPTION
This allows for creating a ThreadSupportInterface object without dealing with platform specific implementation details. Users can just call ThreadSupportInterface::create() and get the correct implementation for their platform.