### PR TITLE
Cygwin build (and btlDebugDraw.h header warnings)

### DIFF
--- a/examples/ExampleBrowser/GwenGUISupport/GwenParameterInterface.cpp
+++ b/examples/ExampleBrowser/GwenGUISupport/GwenParameterInterface.cpp
@@ -1,3 +1,5 @@
+
+#include <cstdio>
 #include "GwenParameterInterface.h"
 #include "gwenInternalData.h"
 
@@ -237,7 +239,7 @@ void GwenParameterInterface::registerSliderFloatParameter(SliderParams& params)
     if (params.m_clampToIntegers)
     {
         pSlider->SetNotchCount( int( params.m_maxVal - params.m_minVal ) );
-        pSlider->SetClampToNotches( true );
+        pSlider->SetClampToNotches( params.m_clampToNotches );
     }
     else
     {

--- a/examples/OpenGLWindow/X11OpenGLWindow.cpp
+++ b/examples/OpenGLWindow/X11OpenGLWindow.cpp
@@ -97,7 +97,11 @@ typedef int (*PFNXPEEKEVENT) (Display* a,XEvent* b);
 typedef KeySym (*PFNXLOOKUPKEYSYM) (XKeyEvent* a,int b);
 typedef Status (*PFNXGETWINDOWATTRIBUTES) (Display* a,Window b,XWindowAttributes* c);
 
+#ifdef __CYGWIN__
+#define X11_LIBRARY "cygX11-6.dll"
+#else
 #define X11_LIBRARY "libX11.so.6"
+#endif
 
 #define MyXSync m_data->m_x11_XSync
 #define MyXGetKeyboardMapping m_data->m_x11_XGetKeyboardMapping
@@ -496,9 +500,10 @@ void X11OpenGLWindow::enableOpenGL()
 
 //Access pthreads as a workaround for a bug in Linux/Ubuntu
 //See https://bugs.launchpad.net/ubuntu/+source/nvidia-graphics-drivers-319/+bug/1248642
-
+#ifndef __CYGWIN__ 
 	int i=pthread_getconcurrency();
         printf("pthread_getconcurrency()=%d\n",i);
+#endif
 
 //    const GLubyte* ext = glGetString(GL_EXTENSIONS);
 //    printf("GL_EXTENSIONS=%s\n", ext);

--- a/examples/ThirdPartyLibs/Glew/glew.c
+++ b/examples/ThirdPartyLibs/Glew/glew.c
@@ -49,7 +49,11 @@ void* dlglXGetProcAddressARB(const GLubyte* name)
 
   if (h == NULL)
   {
+	#ifdef __CYGWIN__
+	if ((h = dlopen("cygGL-1.dll", RTLD_LAZY | RTLD_LOCAL)) == NULL)
+	#else
     if ((h = dlopen("libGL.so.1", RTLD_LAZY | RTLD_LOCAL)) == NULL)
+	#endif
     {
     		return NULL;
     }

--- a/examples/ThirdPartyLibs/Gwen/Gwen.cpp
+++ b/examples/ThirdPartyLibs/Gwen/Gwen.cpp
@@ -4,7 +4,7 @@
 	See license in Gwen.h
 */
 
-
+#include <cstdio>
 #include "Gwen/Gwen.h"
 
 

--- a/examples/ThirdPartyLibs/Gwen/Macros.h
+++ b/examples/ThirdPartyLibs/Gwen/Macros.h
@@ -38,7 +38,7 @@
 	#define GwenUtil_OutputDebugWideString( lpOutputString ) //wprintf( lpOutputString  )
 	#define GwenUtil_WideStringToFloat( _Str ) wcstof(_Str, NULL)
 
-#elif defined(__linux__) || defined(__OpenBSD__)
+#elif defined(__linux__) || defined(__OpenBSD__) || defined(__CYGWIN__)
 
 	#define GwenUtil_VSNPrintFSafe( _DstBuf, _DstSize, _MaxCount, _Format, _ArgList ) vsnprintf( _DstBuf, _DstSize, _Format, _ArgList )
 	#define GwenUtil_VSWPrintFSafe( _DstBuf, _SizeInWords, _Format, _ArgList ) vswprintf( _DstBuf, _SizeInWords, _Format, _ArgList )

--- a/examples/ThirdPartyLibs/clsocket/src/Host.h
+++ b/examples/ThirdPartyLibs/clsocket/src/Host.h
@@ -61,7 +61,7 @@ extern "C"
   #define __WORDSIZE 32
 #endif
 
-#if defined(_LINUX) || defined(_DARWIN) || defined(_BSD)
+#if defined(_LINUX) || defined(_DARWIN) || defined(_BSD) || defined(__CYGWIN__)
     typedef unsigned char  uint8;
     typedef char           int8;
     typedef unsigned short uint16;
@@ -176,7 +176,7 @@ extern "C"
 #define GETHOSTBYNAME(a)       gethostbyname(a)
 #endif
 
-#if defined(_LINUX) || defined(_DARWIN) || defined(_BSD)
+#if defined(_LINUX) || defined(_DARWIN) || defined(_BSD) || defined(__CYGWIN__)
 #define ACCEPT(a,b,c)          accept(a,b,c)
 #define CONNECT(a,b,c)         connect(a,b,c)
 #define CLOSE(a)               close(a)

--- a/examples/ThirdPartyLibs/clsocket/src/SimpleSocket.h
+++ b/examples/ThirdPartyLibs/clsocket/src/SimpleSocket.h
@@ -49,7 +49,7 @@
 #include <stdarg.h>
 #include <errno.h>
 
-#if defined(_LINUX) || defined (_DARWIN) || defined(_BSD)
+#if defined(_LINUX) || defined (_DARWIN) || defined(_BSD) || defined(__CYGWIN__)
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
@@ -66,7 +66,7 @@
 #ifdef _DARWIN
 #include <net/if.h>
 #endif
-#if defined(_LINUX) || defined (_DARWIN) || defined(_BSD)
+#if defined(_LINUX) || defined (_DARWIN) || defined(_BSD) || defined(__CYGWIN__)
 #include <sys/time.h>
 #include <sys/uio.h>
 #include <unistd.h>

--- a/src/LinearMath/btIDebugDraw.h
+++ b/src/LinearMath/btIDebugDraw.h
@@ -166,9 +166,9 @@ class	btIDebugDraw
 	virtual void drawTransform(const btTransform& transform, btScalar orthoLen)
 	{
 		btVector3 start = transform.getOrigin();
-		drawLine(start, start+transform.getBasis() * btVector3(orthoLen, 0, 0), btVector3(1.f,0.3,0.3));
-		drawLine(start, start+transform.getBasis() * btVector3(0, orthoLen, 0), btVector3(0.3,1.f, 0.3));
-		drawLine(start, start+transform.getBasis() * btVector3(0, 0, orthoLen), btVector3(0.3, 0.3,1.f));
+		drawLine(start, start+transform.getBasis() * btVector3(orthoLen, 0, 0), btVector3(1.f,0.3f,0.3f));
+		drawLine(start, start+transform.getBasis() * btVector3(0, orthoLen, 0), btVector3(0.3f,1.f, 0.3f));
+		drawLine(start, start+transform.getBasis() * btVector3(0, 0, orthoLen), btVector3(0.3f, 0.3f,1.f));
 	}
 
 	virtual void drawArc(const btVector3& center, const btVector3& normal, const btVector3& axis, btScalar radiusA, btScalar radiusB, btScalar minAngle, btScalar maxAngle, 


### PR DESCRIPTION
These are changes I made to build for Cygwin. A number seem to be in borrowed code. Maybe they should be addressed at the source.

The following is a change introduced today that was not mine. That this merge would undo. I tried to edit it back with GitHub, but couldn't. I'm new to GitHub. Please resolve this for me.

-        pSlider->SetClampToNotches( true );
+        pSlider->SetClampToNotches( params.m_clampToNotches );