### PR TITLE
Fix for memory leak at btCreateCompoundFromGimpactShape

### DIFF
--- a/src/BulletCollision/Gimpact/btCompoundFromGimpact.h
+++ b/src/BulletCollision/Gimpact/btCompoundFromGimpact.h
@@ -5,6 +5,22 @@
 #include "btGImpactShape.h"
 #include "BulletCollision/NarrowPhaseCollision/btRaycastCallback.h"
 
+ATTRIBUTE_ALIGNED16(class) btCompoundFromGimpactShape	: public btCompoundShape
+{
+public:
+	BT_DECLARE_ALIGNED_ALLOCATOR();
+
+	virtual ~btCompoundFromGimpactShape()
+	{
+		/*delete all the btBU_Simplex1to4 ChildShapes*/
+		for (int i = 0; i < m_children.size(); i++)
+		{
+			delete m_children[i].m_childShape;
+		}
+	}
+
+};
+
 struct MyCallback : public btTriangleRaycastCallback
 		{
 			int	m_ignorePart;
@@ -77,7 +93,7 @@ struct MyCallback : public btTriangleRaycastCallback
 		
 btCompoundShape*	btCreateCompoundFromGimpactShape(const btGImpactMeshShape* gimpactMesh, btScalar depth)
 {
-	btCompoundShape* colShape = new btCompoundShape();
+	btCompoundShape* colShape = new btCompoundFromGimpactShape();
 		
 		btTransform tr;
 		tr.setIdentity();


### PR DESCRIPTION
This is an fix for issue #1213 

The btBU_Simplex1to4 ChildShapes are created internally, and don't get cleaned up.

Fix contains:
btCompoundFromGimpactShape inherited from btCompoundShape, which automatically delete this childShapes