### PR TITLE
Provide sane default GwenUtil_* implementation

### DIFF
--- a/examples/ThirdPartyLibs/Gwen/Macros.h
+++ b/examples/ThirdPartyLibs/Gwen/Macros.h
@@ -28,27 +28,18 @@
 	#define GwenUtil_OutputDebugWideString( lpOutputString ) OutputDebugStringW( lpOutputString )
 	#define GwenUtil_WideStringToFloat( _Str ) _wtof( _Str )
 
-#elif defined(__APPLE__)
-
-	#include <CoreFoundation/CoreFoundation.h>
-
-	#define GwenUtil_VSNPrintFSafe( _DstBuf, _DstSize, _MaxCount, _Format, _ArgList ) vsnprintf( _DstBuf, _DstSize, _Format, _ArgList )
-	#define GwenUtil_VSWPrintFSafe( _DstBuf, _SizeInWords, _Format, _ArgList ) vswprintf( _DstBuf, _SizeInWords, _Format, _ArgList )
-	#define GwenUtil_OutputDebugCharString( lpOutputString ) //printf( lpOutputString )
-	#define GwenUtil_OutputDebugWideString( lpOutputString ) //wprintf( lpOutputString  )
-	#define GwenUtil_WideStringToFloat( _Str ) wcstof(_Str, NULL)
-
-#elif defined(__linux__) || defined(__OpenBSD__)
-
-	#define GwenUtil_VSNPrintFSafe( _DstBuf, _DstSize, _MaxCount, _Format, _ArgList ) vsnprintf( _DstBuf, _DstSize, _Format, _ArgList )
-	#define GwenUtil_VSWPrintFSafe( _DstBuf, _SizeInWords, _Format, _ArgList ) vswprintf( _DstBuf, _SizeInWords, _Format, _ArgList )
-	#define GwenUtil_OutputDebugCharString( lpOutputString ) //printf( lpOutputString )
-	#define GwenUtil_OutputDebugWideString( lpOutputString ) //wprintf( lpOutputString  )
-	#define GwenUtil_WideStringToFloat( _Str ) wcstof(_Str, NULL)
-
 #else
+	#if defined(__APPLE__)
 
-	#error MUST_IMPLEMENT_PLATFORM
+		#include <CoreFoundation/CoreFoundation.h>
+
+	#endif
+
+	#define GwenUtil_VSNPrintFSafe( _DstBuf, _DstSize, _MaxCount, _Format, _ArgList ) vsnprintf( _DstBuf, _DstSize, _Format, _ArgList )
+	#define GwenUtil_VSWPrintFSafe( _DstBuf, _SizeInWords, _Format, _ArgList ) vswprintf( _DstBuf, _SizeInWords, _Format, _ArgList )
+	#define GwenUtil_OutputDebugCharString( lpOutputString ) //printf( lpOutputString )
+	#define GwenUtil_OutputDebugWideString( lpOutputString ) //wprintf( lpOutputString  )
+	#define GwenUtil_WideStringToFloat( _Str ) wcstof(_Str, NULL)
 
 #endif
 


### PR DESCRIPTION
The linux/openbsd preprocessor chunk also applies to FreeBSD and probably much more systems, so instead of adding another condition lets's use it as default. Also merge with Apple chunk to reduce duplication.