### PR TITLE
Conflict with x11 cpp 3 building

### DIFF
--- a/src/BulletSoftBody/btSoftBody.cpp
+++ b/src/BulletSoftBody/btSoftBody.cpp
@@ -503,7 +503,7 @@ void			btSoftBody::addAeroForceToNode(const btVector3& windVelocity,int nodeInde
 					fDrag = 0.5f * kDG * medium.m_density * rel_v2 * tri_area * n_dot_v * (-rel_v_nrm);
 							
 					// Check angle of attack
-					// cos(10บ) = 0.98480
+					// cos(10ยบ) = 0.98480
 					if ( 0 < n_dot_v && n_dot_v < 0.98480f)
 						fLift = 0.5f * kLF * medium.m_density * rel_v_len * tri_area * btSqrt(1.0f-n_dot_v*n_dot_v) * (nrm.cross(rel_v_nrm).cross(rel_v_nrm));
 
@@ -589,7 +589,7 @@ void			btSoftBody::addAeroForceToFace(const btVector3& windVelocity,int faceInde
 				fDrag = 0.5f * kDG * medium.m_density * rel_v2 * tri_area * n_dot_v * (-rel_v_nrm);
 
 				// Check angle of attack
-				// cos(10บ) = 0.98480
+				// cos(10ยบ) = 0.98480
 				if ( 0 < n_dot_v && n_dot_v < 0.98480f)
 					fLift = 0.5f * kLF * medium.m_density * rel_v_len * tri_area * btSqrt(1.0f-n_dot_v*n_dot_v) * (nrm.cross(rel_v_nrm).cross(rel_v_nrm));
 
@@ -1705,7 +1705,7 @@ bool			btSoftBody::rayTest(const btVector3& rayFrom,
 
 	results.body	=	this;
 	results.fraction = 1.f;
-	results.feature	=	eFeature::None;
+	results.feature	=	eFeature::Nothing;
 	results.index	=	-1;
 
 	return(rayTest(rayFrom,rayTo,results.fraction,results.feature,results.index,false)!=0);

--- a/src/BulletSoftBody/btSoftBody.h
+++ b/src/BulletSoftBody/btSoftBody.h
@@ -117,7 +117,7 @@ public:
 
 	///eFeature
 	struct	eFeature { enum _ {
-		None,
+		Nothing,
 		Node,
 		Link,
 		Face,


### PR DESCRIPTION
The compiler x11 insert a header that define the macro "None". Is better to use the word Nothing instead.