### PR TITLE
Cmake pybullet fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -301,8 +301,25 @@ IF (APPLE)
 ENDIF()
 
 OPTION(BUILD_BULLET3 "Set when you want to build Bullet 3" ON)
-
-OPTION(BUILD_PYBULLET "Set when you want to build pybullet (Python bindings for Bullet)" OFF)
+# Optional Python configuration
+# builds pybullet automatically if all the requirements are met
+SET(PYTHON_VERSION_PYBULLET "2.7" CACHE STRING "Python version pybullet will use.")
+SET(Python_ADDITIONAL_VERSIONS 2.7 2.7.3 2.7.12 3 3.0 3.1 3.2 3.3 3.4 3.5 3.6)
+SET_PROPERTY(CACHE PYTHON_VERSION_PYBULLET PROPERTY STRINGS ${Python_ADDITIONAL_VERSIONS})
+SET(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/build3/cmake ${CMAKE_MODULE_PATH})
+OPTION(EXACT_PYTHON_VERSION "Require Python and match PYTHON_VERSION_PYBULLET exactly, e.g. 2.7.12" OFF)
+IF(EXACT_PYTHON_VERSION)
+  set(EXACT_PYTHON_VERSION_FLAG EXACT REQUIRED)
+ENDIF(EXACT_PYTHON_VERSION)
+# first find the python interpreter
+FIND_PACKAGE(PythonInterp ${PYTHON_VERSION_PYBULLET} ${EXACT_PYTHON_VERSION_FLAG})
+# python library should exactly match that of the interpreter
+FIND_PACKAGE(PythonLibs ${PYTHON_VERSION_STRING} EXACT)
+SET(DEFAULT_BUILD_PYBULLET OFF)
+IF(PYTHONLIBS_FOUND)
+	SET(DEFAULT_BUILD_PYBULLET ON)
+ENDIF(PYTHONLIBS_FOUND)
+OPTION(BUILD_PYBULLET "Set when you want to build pybullet (Python bindings for Bullet)" ${DEFAULT_BUILD_PYBULLET})
 
 OPTION(BUILD_ENET "Set when you want to build apps with enet UDP networking support" ON)
 OPTION(BUILD_CLSOCKET "Set when you want to build apps with enet TCP networking support" ON)
@@ -310,7 +327,7 @@ OPTION(BUILD_CLSOCKET "Set when you want to build apps with enet TCP networking 
 
 IF(BUILD_PYBULLET)
 	FIND_PACKAGE(PythonLibs)
-	
+
 	OPTION(BUILD_PYBULLET_NUMPY "Set when you want to build pybullet with NumPy support" OFF)
 	OPTION(BUILD_PYBULLET_ENET "Set when you want to build pybullet with enet UDP networking support" ON)
 	OPTION(BUILD_PYBULLET_CLSOCKET "Set when you want to build pybullet with enet TCP networking support" ON)

--- a/build3/cmake/FindPythonLibs.cmake
+++ b/build3/cmake/FindPythonLibs.cmake
@@ -64,7 +64,7 @@ if(EXISTS "${PYTHON_INCLUDE_DIR}" AND EXISTS "${PYTHON_LIBRARY}")
 else()
   set(_PYTHON1_VERSIONS 1.6 1.5)
   set(_PYTHON2_VERSIONS 2.7 2.6 2.5 2.4 2.3 2.2 2.1 2.0)
-  set(_PYTHON3_VERSIONS 3.4 3.3 3.2 3.1 3.0)
+  set(_PYTHON3_VERSIONS 3.6 3.5 3.4 3.3 3.2 3.1 3.0)
 
   unset(_PYTHON_FIND_OTHER_VERSIONS)
   if(PythonLibs_FIND_VERSION)
@@ -176,14 +176,15 @@ else()
               FIND_LIBRARY(PYTHON_LIBRARY
                 NAMES ${_PYTHON_LIBRARY_NAMES}
                 PATH_SUFFIXES
-                python${_PYTHON_SHORT_VERSION}/config
-                python${_PYTHON_SHORT_VERSION_NO_DOT}/config
+                "python${_PYTHON_SHORT_VERSION}/config"
+                "python${_PYTHON_SHORT_VERSION_NO_DOT}/config"
                 PATHS
                 ${_PYTHON_LIBRARY_DIR}
-                ${_PYTHON_PREFIX}/lib $
-                {_PYTHON_PREFIX}/libs
+                ${_PYTHON_PREFIX}/lib
+                ${_PYTHON_PREFIX}/libs
+                ${_PYTHON_LIBRARY_DIR}/x86_64-linux-gnu/
                 NO_DEFAULT_PATH)
-
+              message(STATUS "PYTHON_LIBRARY:${PYTHON_LIBRARY}")
               if(WIN32)
                 find_library(PYTHON_DEBUG_LIBRARY
                   NAMES python${_PYTHON_SHORT_VERSION_NO_DOT}_d python
@@ -254,6 +255,10 @@ set(PYTHON_LIBRARY_DEBUG "${PYTHON_DEBUG_LIBRARY}")
 set(PYTHON_LIBRARY_RELEASE "${PYTHON_LIBRARY}")
 include(${CMAKE_CURRENT_LIST_DIR}/SelectLibraryConfigurations.cmake)
 SELECT_LIBRARY_CONFIGURATIONS(PYTHON)
+message(STATUS "${PYTHON_LIBRARY}")
+if(PYTHON_LIBRARY)
+  set(PYTHON_LIBRARIES "${PYTHON_LIBRARY}")
+endif()
 # SELECT_LIBRARY_CONFIGURATIONS() sets ${PREFIX}_FOUND if it has a library.
 # Unset this, this prefix doesn't match the module prefix, they are different
 # for historical reasons.

--- a/build3/cmake/FindPythonLibs.cmake
+++ b/build3/cmake/FindPythonLibs.cmake
@@ -184,7 +184,7 @@ else()
                 ${_PYTHON_PREFIX}/libs
                 ${_PYTHON_LIBRARY_DIR}/x86_64-linux-gnu/
                 NO_DEFAULT_PATH)
-              message(STATUS "PYTHON_LIBRARY:${PYTHON_LIBRARY}")
+
               if(WIN32)
                 find_library(PYTHON_DEBUG_LIBRARY
                   NAMES python${_PYTHON_SHORT_VERSION_NO_DOT}_d python
@@ -255,8 +255,8 @@ set(PYTHON_LIBRARY_DEBUG "${PYTHON_DEBUG_LIBRARY}")
 set(PYTHON_LIBRARY_RELEASE "${PYTHON_LIBRARY}")
 include(${CMAKE_CURRENT_LIST_DIR}/SelectLibraryConfigurations.cmake)
 SELECT_LIBRARY_CONFIGURATIONS(PYTHON)
-message(STATUS "${PYTHON_LIBRARY}")
-if(PYTHON_LIBRARY)
+
+if(PYTHON_LIBRARY AND NOT PYTHON_LIBRARIES)
   set(PYTHON_LIBRARIES "${PYTHON_LIBRARY}")
 endif()
 # SELECT_LIBRARY_CONFIGURATIONS() sets ${PREFIX}_FOUND if it has a library.


### PR DESCRIPTION
fix #1322, the problem is that python itself declares its own lib file to be in the wrong location in certain linux versions. Here I primarily add the extra missing path component to the set of search paths. I also restore changes from previous fix attempts that were incorrect.

https://github.com/bulletphysics/bullet3/pull/1131 is a past change of interest to this one