### PR TITLE
Fix a shadow warning by renaming a parameter in btInfMaskConverter

### DIFF
--- a/src/LinearMath/btScalar.h
+++ b/src/LinearMath/btScalar.h
@@ -374,8 +374,8 @@ inline int btGetVersion()
 			float mask;
 			int intmask;
 		};
-		btInfMaskConverter(int mask = 0x7F800000)
-			: intmask(mask)
+		btInfMaskConverter(int _mask = 0x7F800000)
+			: intmask(_mask)
 		{
 		}
 	};


### PR DESCRIPTION
This warning has been annoying me for a couple months so I finally decided to send a pull request. The warning can be seen when compiling with `-Wshadow` in GCC.

I'm not very experienced with contributing to open source so please let me know if I need to change anything.