### PR TITLE
Fixed setting of m_userConstraintResultArgs.

### DIFF
--- a/examples/SharedMemory/PhysicsServerCommandProcessor.cpp
+++ b/examples/SharedMemory/PhysicsServerCommandProcessor.cpp
@@ -7209,6 +7209,7 @@ bool PhysicsServerCommandProcessor::processCommand(const struct SharedMemoryComm
 												InteralUserConstraintData userConstraintData;
 												userConstraintData.m_mbConstraint = multibodyGear;
 												int uid = m_data->m_userConstraintUIDGenerator++;
+                                                serverCmd.m_userConstraintResultArgs = clientCmd.m_userConstraintArguments;
 												serverCmd.m_userConstraintResultArgs.m_userConstraintUniqueId = uid;
 												serverCmd.m_userConstraintResultArgs.m_maxAppliedForce = defaultMaxForce;
 												userConstraintData.m_userConstraintData = serverCmd.m_userConstraintResultArgs;
@@ -7230,6 +7231,7 @@ bool PhysicsServerCommandProcessor::processCommand(const struct SharedMemoryComm
 												InteralUserConstraintData userConstraintData;
 												userConstraintData.m_mbConstraint = multibodyFixed;
 												int uid = m_data->m_userConstraintUIDGenerator++;
+                                                serverCmd.m_userConstraintResultArgs = clientCmd.m_userConstraintArguments;
 												serverCmd.m_userConstraintResultArgs.m_userConstraintUniqueId = uid;
 												serverCmd.m_userConstraintResultArgs.m_maxAppliedForce = defaultMaxForce;
 												userConstraintData.m_userConstraintData = serverCmd.m_userConstraintResultArgs;


### PR DESCRIPTION
I'm not sure how it ever worked for anyone. It was filling up the userConstraintData with stale memory because serverCmd.m_userConstraintResultArgs wasn't ever initialized.

Please check the change though, because I'm not entirely familiar with the PhysicsServerCommandProcessor.cpp codebase (8589 lines of code! It's a monster ;-) ).