### PR TITLE
Fix jump(without argument)

### DIFF
--- a/src/BulletDynamics/Character/btCharacterControllerInterface.h
+++ b/src/BulletDynamics/Character/btCharacterControllerInterface.h
@@ -37,7 +37,7 @@ public:
 	virtual void	preStep ( btCollisionWorld* collisionWorld) = 0;
 	virtual void	playerStep (btCollisionWorld* collisionWorld, btScalar dt) = 0;
 	virtual bool	canJump () const = 0;
-	virtual void	jump(const btVector3& dir = btVector3()) = 0;
+	virtual void	jump(const btVector3& dir = btVector3(0, 0, 0)) = 0;
 
 	virtual bool	onGround () const = 0;
 	virtual void	setUpInterpolate (bool value) = 0;

--- a/src/BulletDynamics/Character/btKinematicCharacterController.h
+++ b/src/BulletDynamics/Character/btKinematicCharacterController.h
@@ -176,7 +176,7 @@ public:
 	void setMaxJumpHeight (btScalar maxJumpHeight);
 	bool canJump () const;
 
-	void jump(const btVector3& v = btVector3());
+	void jump(const btVector3& v = btVector3(0, 0, 0));
 
 	void applyImpulse(const btVector3& v) { jump(v); }
 


### PR DESCRIPTION
While searching the reason of not working jump(when using Z as vertical axis). Lihis found that jump requires btVector3 filled with zeros. But actually default argument is empty.
Fix for openrw:
https://github.com/rwengine/openrw/commit/4bf1d3795b226c46ffd9c6873669b547047e453d
Issue to close:
https://github.com/bulletphysics/bullet3/issues/1366