### PR TITLE
Optimize rayTest with btScaledBvhTriangleMeshShape

### DIFF
--- a/src/BulletCollision/CollisionDispatch/btCollisionWorld.cpp
+++ b/src/BulletCollision/CollisionDispatch/btCollisionWorld.cpp
@@ -21,6 +21,7 @@ subject to the following restrictions:
 #include "BulletCollision/NarrowPhaseCollision/btGjkEpaPenetrationDepthSolver.h"
 #include "BulletCollision/CollisionShapes/btSphereShape.h" //for raycasting
 #include "BulletCollision/CollisionShapes/btBvhTriangleMeshShape.h" //for raycasting
+#include "BulletCollision/CollisionShapes/btScaledBvhTriangleMeshShape.h" //for raycasting
 #include "BulletCollision/NarrowPhaseCollision/btRaycastCallback.h"
 #include "BulletCollision/CollisionShapes/btCompoundShape.h"
 #include "BulletCollision/NarrowPhaseCollision/btSubSimplexConvexCast.h"
@@ -406,6 +407,21 @@ void	btCollisionWorld::rayTestSingleInternal(const btTransform& rayFromTrans,con
 				BridgeTriangleRaycastCallback rcb(rayFromLocal,rayToLocal,&resultCallback,collisionObjectWrap->getCollisionObject(),triangleMesh,colObjWorldTransform);
 				rcb.m_hitFraction = resultCallback.m_closestHitFraction;
 				triangleMesh->performRaycast(&rcb,rayFromLocal,rayToLocal);
+			}
+			else if (collisionShape->getShapeType() == SCALED_TRIANGLE_MESH_SHAPE_PROXYTYPE)
+			{
+				///optimized version for btScaledBvhTriangleMeshShape
+				btScaledBvhTriangleMeshShape* scaledTriangleMesh = (btScaledBvhTriangleMeshShape*)collisionShape;
+				btBvhTriangleMeshShape* triangleMesh = (btBvhTriangleMeshShape*)scaledTriangleMesh->getChildShape();
+
+				//scale the ray positions
+				btVector3 scale = scaledTriangleMesh->getLocalScaling();
+				btVector3 rayFromLocalScaled = rayFromLocal / scale;
+				btVector3 rayToLocalScaled = rayToLocal / scale;
+
+				BridgeTriangleRaycastCallback rcb(rayFromLocalScaled, rayToLocalScaled, &resultCallback, collisionObjectWrap->getCollisionObject(), triangleMesh, colObjWorldTransform);
+				rcb.m_hitFraction = resultCallback.m_closestHitFraction;
+				triangleMesh->performRaycast(&rcb, rayFromLocalScaled, rayToLocalScaled);
 			}
 			else
 			{

--- a/src/BulletCollision/CollisionDispatch/btCollisionWorld.cpp
+++ b/src/BulletCollision/CollisionDispatch/btCollisionWorld.cpp
@@ -418,7 +418,8 @@ void	btCollisionWorld::rayTestSingleInternal(const btTransform& rayFromTrans,con
 				btVector3 scale = scaledTriangleMesh->getLocalScaling();
 				btVector3 rayFromLocalScaled = rayFromLocal / scale;
 				btVector3 rayToLocalScaled = rayToLocal / scale;
-
+				
+				//perform raycast in the underlying btBvhTriangleMeshShape
 				BridgeTriangleRaycastCallback rcb(rayFromLocalScaled, rayToLocalScaled, &resultCallback, collisionObjectWrap->getCollisionObject(), triangleMesh, colObjWorldTransform);
 				rcb.m_hitFraction = resultCallback.m_closestHitFraction;
 				triangleMesh->performRaycast(&rcb, rayFromLocalScaled, rayToLocalScaled);


### PR DESCRIPTION
I've modified **btCollisionWorld::rayTestSingleInternal(...)** method to improve the performance in case that your collision object has a _btScaledBvhTriangleMeshShape_ shape.

The ray positions (from and to) are divided by the scale of the shape, and then I use this new ray positions to make a **performRay()** call with the underlying _btBvhTriangleMeshShape_.

That causes an incredible performance boost when using scaled meshes (10-20x in our project).

Best regards,
David Ávila, 
WaveEngine team member.