### PR TITLE
only probe for python if PYBULLET explicitly specified

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -301,25 +301,26 @@ IF (APPLE)
 ENDIF()
 
 OPTION(BUILD_BULLET3 "Set when you want to build Bullet 3" ON)
+
 # Optional Python configuration
-# builds pybullet automatically if all the requirements are met
-SET(PYTHON_VERSION_PYBULLET "" CACHE STRING "Python version pybullet will use.")
-SET(Python_ADDITIONAL_VERSIONS 3 3.6 3.5 3.4 3.3 3.2 3.1 3.0 2.7 2.7.12 2.7.10 2.7.3 )
-SET_PROPERTY(CACHE PYTHON_VERSION_PYBULLET PROPERTY STRINGS ${Python_ADDITIONAL_VERSIONS})
-SET(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/build3/cmake ${CMAKE_MODULE_PATH})
-OPTION(EXACT_PYTHON_VERSION "Require Python and match PYTHON_VERSION_PYBULLET exactly, e.g. 2.7.12" OFF)
-IF(EXACT_PYTHON_VERSION)
-  set(EXACT_PYTHON_VERSION_FLAG EXACT REQUIRED)
-ENDIF(EXACT_PYTHON_VERSION)
-# first find the python interpreter
-FIND_PACKAGE(PythonInterp ${PYTHON_VERSION_PYBULLET} ${EXACT_PYTHON_VERSION_FLAG})
-# python library should exactly match that of the interpreter
-FIND_PACKAGE(PythonLibs ${PYTHON_VERSION_STRING} EXACT)
-SET(DEFAULT_BUILD_PYBULLET OFF)
-IF(PYTHONLIBS_FOUND)
-	SET(DEFAULT_BUILD_PYBULLET ON)
-ENDIF(PYTHONLIBS_FOUND)
-OPTION(BUILD_PYBULLET "Set when you want to build pybullet (Python bindings for Bullet)" ${DEFAULT_BUILD_PYBULLET})
+# Will not probe environment for Python configuration (which can abort the
+# build process) unless you explicitly turn on BUILD_PYBULLET.
+OPTION(BUILD_PYBULLET "Set when you want to build pybullet (Python bindings for Bullet)" OFF)
+IF(BUILD_PYBULLET)
+	SET(PYTHON_VERSION_PYBULLET "" CACHE STRING "Python version pybullet will use.")
+	SET(Python_ADDITIONAL_VERSIONS 3 3.6 3.5 3.4 3.3 3.2 3.1 3.0 2.7 2.7.12 2.7.10 2.7.3 )
+	SET_PROPERTY(CACHE PYTHON_VERSION_PYBULLET PROPERTY STRINGS ${Python_ADDITIONAL_VERSIONS})
+	SET(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/build3/cmake ${CMAKE_MODULE_PATH})
+	OPTION(EXACT_PYTHON_VERSION "Require Python and match PYTHON_VERSION_PYBULLET exactly, e.g. 2.7.12" OFF)
+	IF(EXACT_PYTHON_VERSION)
+	set(EXACT_PYTHON_VERSION_FLAG EXACT REQUIRED)
+	ENDIF(EXACT_PYTHON_VERSION)
+	# first find the python interpreter
+	FIND_PACKAGE(PythonInterp ${PYTHON_VERSION_PYBULLET} ${EXACT_PYTHON_VERSION_FLAG})
+	# python library should exactly match that of the interpreter
+	# the following can result in fatal error if you don't have the right python configuration
+	FIND_PACKAGE(PythonLibs ${PYTHON_VERSION_STRING} EXACT)
+ENDIF(BUILD_PYBULLET)
 
 OPTION(BUILD_ENET "Set when you want to build apps with enet UDP networking support" ON)
 OPTION(BUILD_CLSOCKET "Set when you want to build apps with enet TCP networking support" ON)


### PR DESCRIPTION
On Ubuntu 16.04, despite using `-DBUILD_PYBULLET=OFF`, the build fails with the following error:
```
CMake Error at build3/cmake/FindPythonLibs.cmake:118 (message):
  Could not find required file 'FindLibPython.py'
Call Stack (most recent call first):
  CMakeLists.txt:317 (FIND_PACKAGE)
```

If we look at the relevant code in CMakeLists.txt:
```
FIND_PACKAGE(PythonLibs ${PYTHON_VERSION_STRING} EXACT)
```
which FATAL_ERRORs out when it encounters this logic in [FindPythonLibs.cmake](https://github.com/bulletphysics/bullet3/blob/master/build3/cmake/FindPythonLibs.cmake)
```
if(NOT _FIND_LIB_PYTHON_PY)
    message(FATAL_ERROR "Could not find required file 'FindLibPython.py'")
endif()
```

This pull request changes the build behavior so that the environment is not probed at all for any Python libraries unless `BUILD_PYBULLET` is explicitly set to `ON`. The previous behavior was to always probe the environment, then set the default value of `BUILD_PYBULLET` based on whether the probe succeeds.

With this change, developers not interested in PYBULLET can isolate themselves from problems related to Python build going forward. The downside is folks that want PYBULLET and previously relied on the automagic probing behavior will now need to explicitly turn it ON.

Previous work: #1340 