### PR TITLE
Composite fixes for mingw64 and msvc.

### DIFF
--- a/examples/OpenGLWindow/Win32Window.cpp
+++ b/examples/OpenGLWindow/Win32Window.cpp
@@ -442,6 +442,7 @@ void Win32Window::setWindowTitle(const char* titleChar)
 #ifdef _WIN64
 		SetWindowText(m_data->m_hWnd, titleChar);
 #else
+		DWORD dwResult;
 		SendMessageTimeout(m_data->m_hWnd, WM_SETTEXT, 0,
 				reinterpret_cast<LPARAM>(titleChar),
 				SMTO_ABORTIFHUNG, 2000, &dwResult);

--- a/examples/OpenGLWindow/Win32Window.cpp
+++ b/examples/OpenGLWindow/Win32Window.cpp
@@ -439,15 +439,11 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 void Win32Window::setWindowTitle(const char* titleChar)
 {
 	
-	wchar_t  windowTitle[1024];
-	swprintf(windowTitle, 1024, L"%hs", titleChar);
-
 #ifdef _WIN64
-		SetWindowTextW(m_data->m_hWnd, windowTitle);
+		SetWindowText(m_data->m_hWnd, titleChar);
 #else
-		DWORD dwResult;
-		SendMessageTimeoutW(m_data->m_hWnd, WM_SETTEXT, 0,
-				reinterpret_cast<LPARAM>(windowTitle),
+		SendMessageTimeout(m_data->m_hWnd, WM_SETTEXT, 0,
+				reinterpret_cast<LPARAM>(titleChar),
 				SMTO_ABORTIFHUNG, 2000, &dwResult);
 #endif
 }

--- a/examples/ThirdPartyLibs/Gwen/CMakeLists.txt
+++ b/examples/ThirdPartyLibs/Gwen/CMakeLists.txt
@@ -15,7 +15,7 @@ IF(NOT WIN32 AND NOT APPLE)
         ADD_DEFINITIONS("-DDYNAMIC_LOAD_X11_FUNCTIONS=1")
 ENDIF()
 
-ADD_DEFINITIONS( -DGLEW_STATIC -DGWEN_COMPILE_STATIC -D_HAS_EXCEPTIONS=0 -D_STATIC_CPPLIB )
+ADD_DEFINITIONS( -DGLEW_STATIC -DGWEN_COMPILE_STATIC -D_HAS_EXCEPTIONS=0 )
 
 FILE(GLOB gwen_SRCS "*.cpp" "Controls/*.cpp" "Controls/Dialog/*.cpp" "Controls/Dialogs/*.cpp" "Controls/Layout/*.cpp" "Controls/Property/*.cpp" "Input/*.cpp" "Platforms/*.cpp" "Renderers/*.cpp" "Skins/*.cpp")
 FILE(GLOB gwen_HDRS "*.h" "Controls/*.h" "Controls/Dialog/*.h" "Controls/Dialogs/*.h" "Controls/Layout/*.h" "Controls/Property/*.h" "Input/*.h" "Platforms/*.h" "Renderers/*.h" "Skins/*.h")

--- a/examples/ThirdPartyLibs/Gwen/Macros.h
+++ b/examples/ThirdPartyLibs/Gwen/Macros.h
@@ -4,6 +4,7 @@
 #define GWEN_MACROS_H
 #include <stdlib.h>
 #include <stdarg.h>
+#include <stdio.h> // vsnprintf
 #if !defined(__APPLE__) && !defined(__OpenBSD__) && !defined(__FreeBSD__)
 	#include <malloc.h>
 #else
@@ -17,7 +18,7 @@
 #define GwenUtil_Max( a, b ) ( ( (a) > (b) ) ? (a) : (b) )
 #define GwenUtil_VSWPrintFSafeSized( _DstBuf_ARRAY_, _Format, _ArgList ) GwenUtil_VSWPrintFSafe( _DstBuf_ARRAY_, sizeof( _DstBuf_ARRAY_ ) / sizeof( wchar_t ), _Format, _ArgList )
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 
 	#ifndef NOMINMAX
         #define NOMINMAX
@@ -40,10 +41,15 @@
 	#define GwenUtil_OutputDebugWideString( lpOutputString ) //wprintf( lpOutputString  )
 	#define GwenUtil_WideStringToFloat( _Str ) wcstof(_Str, NULL)
 
-#elif defined(__linux__) || defined(__OpenBSD__)
+
+#elif defined(__linux__) || defined( __GNUC__ )
 
 	#define GwenUtil_VSNPrintFSafe( _DstBuf, _DstSize, _MaxCount, _Format, _ArgList ) vsnprintf( _DstBuf, _DstSize, _Format, _ArgList )
-	#define GwenUtil_VSWPrintFSafe( _DstBuf, _SizeInWords, _Format, _ArgList ) vswprintf( _DstBuf, _SizeInWords, _Format, _ArgList )
+	#ifdef _WIN32
+		#define GwenUtil_VSWPrintFSafe( _DstBuf, _SizeInWords, _Format, _ArgList ) vsnwprintf( _DstBuf, _SizeInWords, _Format, _ArgList )
+	#else
+		#define GwenUtil_VSWPrintFSafe( _DstBuf, _SizeInWords, _Format, _ArgList ) vswprintf( _DstBuf, _SizeInWords, _Format, _ArgList )
+	#endif
 	#define GwenUtil_OutputDebugCharString( lpOutputString ) //printf( lpOutputString )
 	#define GwenUtil_OutputDebugWideString( lpOutputString ) //wprintf( lpOutputString  )
 	#define GwenUtil_WideStringToFloat( _Str ) wcstof(_Str, NULL)

--- a/src/Bullet3Common/b3FileUtils.h
+++ b/src/Bullet3Common/b3FileUtils.h
@@ -36,7 +36,7 @@ struct b3FileUtils
 
 			for (int i=0;!f && i<numPrefixes;i++)
 			{
-#ifdef _WIN32
+#ifdef _MSC_VER
 				sprintf_s(relativeFileName,maxRelativeFileNameMaxLen,"%s%s",prefix[i],orgFileName);
 #else
 				sprintf(relativeFileName,"%s%s",prefix[i],orgFileName);

--- a/src/Bullet3OpenCL/Initialize/b3OpenCLUtils.cpp
+++ b/src/Bullet3OpenCL/Initialize/b3OpenCLUtils.cpp
@@ -619,7 +619,7 @@ cl_program b3OpenCLUtils_compileCLProgramFromString(cl_context clContext, cl_dev
 		strippedName = strip2(clFileNameForCaching,"\\");
 		strippedName = strip2(strippedName,"/");
 	
-#ifdef _MSVC_VER
+#ifdef _MSC_VER
 		sprintf_s(binaryFileName,B3_MAX_STRING_LENGTH,"%s/%s.%s.%s.bin",sCachedBinaryPath,strippedName, deviceName,driverVersion );
 #else
 		sprintf(binaryFileName,"%s/%s.%s.%s.bin",sCachedBinaryPath,strippedName, deviceName,driverVersion );

--- a/src/BulletCollision/CollisionDispatch/btCompoundCompoundCollisionAlgorithm.cpp
+++ b/src/BulletCollision/CollisionDispatch/btCompoundCompoundCollisionAlgorithm.cpp
@@ -396,32 +396,24 @@ void btCompoundCompoundCollisionAlgorithm::processCollision (const btCollisionOb
 				btCollisionAlgorithm* algo = (btCollisionAlgorithm*)pairs[i].m_userPointer;
 
 				{
-					btTransform	orgTrans0;
 					const btCollisionShape* childShape0 = 0;
 					
 					btTransform	newChildWorldTrans0;
-					btTransform	orgInterpolationTrans0;
 					childShape0 = compoundShape0->getChildShape(pairs[i].m_indexA);
-					orgTrans0 = col0ObjWrap->getWorldTransform();
-					orgInterpolationTrans0 = col0ObjWrap->getWorldTransform();
 					const btTransform& childTrans0 = compoundShape0->getChildTransform(pairs[i].m_indexA);
-					newChildWorldTrans0 = orgTrans0*childTrans0 ;
+					newChildWorldTrans0 = col0ObjWrap->getWorldTransform()*childTrans0 ;
 					childShape0->getAabb(newChildWorldTrans0,aabbMin0,aabbMax0);
 				}
 				btVector3 thresholdVec(resultOut->m_closestPointDistanceThreshold, resultOut->m_closestPointDistanceThreshold, resultOut->m_closestPointDistanceThreshold);
 				aabbMin0 -= thresholdVec;
 				aabbMax0 += thresholdVec;
 				{
-					btTransform	orgInterpolationTrans1;
 					const btCollisionShape* childShape1 = 0;
-					btTransform	orgTrans1;
 					btTransform	newChildWorldTrans1;
 
 					childShape1 = compoundShape1->getChildShape(pairs[i].m_indexB);
-					orgTrans1 = col1ObjWrap->getWorldTransform();
-					orgInterpolationTrans1 = col1ObjWrap->getWorldTransform();
 					const btTransform& childTrans1 = compoundShape1->getChildTransform(pairs[i].m_indexB);
-					newChildWorldTrans1 = orgTrans1*childTrans1 ;
+					newChildWorldTrans1 = col1ObjWrap->getWorldTransform()*childTrans1 ;
 					childShape1->getAabb(newChildWorldTrans1,aabbMin1,aabbMax1);
 				}
 				

--- a/src/BulletDynamics/ConstraintSolver/btSequentialImpulseConstraintSolver.cpp
+++ b/src/BulletDynamics/ConstraintSolver/btSequentialImpulseConstraintSolver.cpp
@@ -1427,9 +1427,6 @@ btScalar btSequentialImpulseConstraintSolver::solveGroupCacheFriendlySetup(btCol
 
 				if (constraints[i]->isEnabled())
 				{
-				}
-				if (constraints[i]->isEnabled())
-				{
 					constraints[i]->getInfo1(&info1);
 				} else
 				{


### PR DESCRIPTION
Composite of fixed code for mingw64(on windows) and general fixes for msvc.

1) (win32window) don't convert char to wide, use char direct to window.
2) (CMakeLists) Don't link one library as static CPPLIB and no others (mismatched allocations)
3) (macros) Fix Gwen macros for mingw64 on windows build.  (changes are by compiler(msc_ver) not platform)
4) (FileUtils) sprintf_s reference by platform, not compiler (mingw64 support)
5) (b3OpenCLUtils) fix bad define name _MSVC_VER->_MSC_VER
6) (compoundCollision) remove unused variables, simplify operation.
7) (impulseconstraint) remove duplicated code block