### PR TITLE
use Ansi version of LoadLibrary

### DIFF
--- a/examples/SharedMemory/b3PluginManager.cpp
+++ b/examples/SharedMemory/b3PluginManager.cpp
@@ -13,7 +13,7 @@
 
     typedef HMODULE             B3_DYNLIB_HANDLE;
 
-    #define B3_DYNLIB_OPEN    LoadLibrary
+    #define B3_DYNLIB_OPEN    LoadLibraryA
     #define B3_DYNLIB_CLOSE   FreeLibrary
     #define B3_DYNLIB_IMPORT  GetProcAddress
 #else


### PR DESCRIPTION
I got the error "C2664: 'HMODULE LoadLibraryW(LPCWSTR)': cannot convert argument 1 from 'const char *' to 'LPCWSTR'". 
Mapping B3_DYNLIB_OPEN to the Ansi version of LoadLibrary fixed the error for me.