### PR TITLE
Fix wrong depth values returned by TinyRenderer

### DIFF
--- a/examples/SharedMemory/TinyRendererVisualShapeConverter.cpp
+++ b/examples/SharedMemory/TinyRendererVisualShapeConverter.cpp
@@ -772,12 +772,13 @@ void TinyRendererVisualShapeConverter::resetCamera(float camDist, float yaw, flo
 
 void TinyRendererVisualShapeConverter::clearBuffers(TGAColor& clearColor)
 {
+	float farPlane = m_data->m_camera.getCameraFrustumFar();
     for(int y=0;y<m_data->m_swHeight;++y)
     {
         for(int x=0;x<m_data->m_swWidth;++x)
         {
             m_data->m_rgbColorBuffer.set(x,y,clearColor);
-            m_data->m_depthBuffer[x+y*m_data->m_swWidth] = -1e30f;
+            m_data->m_depthBuffer[x+y*m_data->m_swWidth] = -farPlane;
             m_data->m_shadowBuffer[x+y*m_data->m_swWidth] = -1e30f;
             m_data->m_segmentationMaskBuffer[x+y*m_data->m_swWidth] = -1;
         }
@@ -806,13 +807,13 @@ void TinyRendererVisualShapeConverter::render(const float viewMat[16], const flo
     clearColor.bgra[2] = 255;
     clearColor.bgra[3] = 255;
     
-    clearBuffers(clearColor);
 	float near = projMat[14]/(projMat[10]-1);
 	float far = projMat[14]/(projMat[10]+1);
 
 	m_data->m_camera.setCameraFrustumNear( near);
 	m_data->m_camera.setCameraFrustumFar(far);
-		
+
+	clearBuffers(clearColor);	
     
     ATTRIBUTE_ALIGNED16(btScalar modelMat[16]);
     

--- a/examples/SharedMemory/TinyRendererVisualShapeConverter.cpp
+++ b/examples/SharedMemory/TinyRendererVisualShapeConverter.cpp
@@ -1025,12 +1025,13 @@ void TinyRendererVisualShapeConverter::copyCameraImageData(unsigned char* pixels
         {
 			if (depthBuffer)
 			{
-                float distance = -m_data->m_depthBuffer[i+startPixelIndex];
                 float farPlane = m_data->m_camera.getCameraFrustumFar();
                 float nearPlane = m_data->m_camera.getCameraFrustumNear();
-                
-                btClamp(distance,nearPlane,farPlane);
-                
+				
+				// TinyRenderer returns clip coordinates, transform to eye coordinates first
+				float z_c = -m_data->m_depthBuffer[i+startPixelIndex];
+				float distance = (farPlane - nearPlane) / (farPlane + nearPlane) * (z_c + 2. * farPlane * nearPlane / (farPlane - nearPlane));
+				                
                 // the depth buffer value is between 0 and 1
                 float a = farPlane / (farPlane - nearPlane);
                 float b = farPlane * nearPlane / (nearPlane - farPlane);

--- a/examples/SharedMemory/TinyRendererVisualShapeConverter.cpp
+++ b/examples/SharedMemory/TinyRendererVisualShapeConverter.cpp
@@ -1031,12 +1031,15 @@ void TinyRendererVisualShapeConverter::copyCameraImageData(unsigned char* pixels
 				
 				// TinyRenderer returns clip coordinates, transform to eye coordinates first
 				float z_c = -m_data->m_depthBuffer[i+startPixelIndex];
-				float distance = (farPlane - nearPlane) / (farPlane + nearPlane) * (z_c + 2. * farPlane * nearPlane / (farPlane - nearPlane));
+				// float distance = (farPlane - nearPlane) / (farPlane + nearPlane) * (z_c + 2. * farPlane * nearPlane / (farPlane - nearPlane));
 				                
-                // the depth buffer value is between 0 and 1
-                float a = farPlane / (farPlane - nearPlane);
-                float b = farPlane * nearPlane / (nearPlane - farPlane);
-                depthBuffer[i] = a + b / distance;
+                // The depth buffer value is between 0 and 1
+                // float a = farPlane / (farPlane - nearPlane);
+                // float b = farPlane * nearPlane / (nearPlane - farPlane);
+                // depthBuffer[i] = a + b / distance;
+
+				// Simply the above expressions
+				depthBuffer[i] = farPlane * (nearPlane + z_c) / (2. * farPlane * nearPlane + farPlane * z_c - nearPlane * z_c);
 			}
 			if (segmentationMaskBuffer)
             {

--- a/examples/TinyRenderer/our_gl.cpp
+++ b/examples/TinyRenderer/our_gl.cpp
@@ -182,7 +182,7 @@ void triangle(mat<4,3,float> &clipc, IShader &shader, TGAImage &image, float *zb
             bool discard = shader.fragment(bc_clip, color);
             if (frag_depth<-shader.m_farPlane)
                 discard=true;
-            if (frag_depth>-shader.m_nearPlane)
+            if (frag_depth>shader.m_nearPlane)
                 discard=true;
 
             if (!discard) {


### PR DESCRIPTION
This pull request addresses Issue #1197 in which I observed that TinyRenderer depth values are incorrect. This can be seen in the following image generated with this [script](https://gist.github.com/mbreyer/ba7db03a3a2834d6b9ca1285dfe102fd), where images in the first row were rendered with OpenGL and images in the second row were rendered with TinyRenderer.

![figure_1](https://user-images.githubusercontent.com/10465414/32952284-12545d84-cbad-11e7-8b74-4bd8409f4339.png)

The problem was not precision, but an error in the transformation pipeline. The part of the code that transforms depth values to OpenGL style depth buffer assumes that the input is the distance from camera eye to the object, see this [article](https://sjbaker.org/steve/omniv/love_your_z_buffer.html). However, the value stored in m_data->m_depthBuffer is actually given in clip coordinates. In my first commit, I transform these values to camera eye coordinates according to this [article](http://www.songho.ca/opengl/gl_projectionmatrix.html), before they are transformed to OpenGL style depth buffer.

Second, in our_gl, fragments were not discarded properly leading to objects disappearing, even though they were further away than the near_plane (also seen in the above figure). After addressing these issues, I get the same output with TinyRenderer and OpenGL

![figure_2](https://user-images.githubusercontent.com/10465414/32952455-ab20377c-cbad-11e7-9041-411504ae4ffc.png)

Lastly, if all triangles get discarded because they are too close or too far away, OpenGL’s depth buffer contains the maximum value of 1. My third commit mimics this behavior in TinyRenderer by appropriately initializing the buffer.

  