### PR TITLE
add const to masses for calculatePrincipalAxisTransform

### DIFF
--- a/src/BulletCollision/CollisionShapes/btCompoundShape.cpp
+++ b/src/BulletCollision/CollisionShapes/btCompoundShape.cpp
@@ -213,7 +213,7 @@ void	btCompoundShape::calculateLocalInertia(btScalar mass,btVector3& inertia) co
 
 
 
-void btCompoundShape::calculatePrincipalAxisTransform(btScalar* masses, btTransform& principal, btVector3& inertia) const
+void btCompoundShape::calculatePrincipalAxisTransform(const btScalar* masses, btTransform& principal, btVector3& inertia) const
 {
 	int n = m_children.size();
 

--- a/src/BulletCollision/CollisionShapes/btCompoundShape.h
+++ b/src/BulletCollision/CollisionShapes/btCompoundShape.h
@@ -160,7 +160,7 @@ public:
 	///"principal" has to be applied inversely to all children transforms in order for the local coordinate system of the compound
 	///shape to be centered at the center of mass and to coincide with the principal axes. This also necessitates a correction of the world transform
 	///of the collision object by the principal transform.
-	void calculatePrincipalAxisTransform(btScalar* masses, btTransform& principal, btVector3& inertia) const;
+	void calculatePrincipalAxisTransform(const btScalar* masses, btTransform& principal, btVector3& inertia) const;
 
 	int	getUpdateRevision() const
 	{


### PR DESCRIPTION
`masses` is treated as read-only in `btCompoundShape::calculatePrincipalAxisTransform`, so it can be declared as a `const` parameter so that callers can also use read-only data to feed into this function.