### PR TITLE
Removed default ON for USE_MSVC_SSE (warning on recent 64 bit windows)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,7 +108,7 @@ IF(MSVC)
 	IF (CMAKE_CL_64)
 	  ADD_DEFINITIONS(-D_WIN64)
 	ELSE()
-	  OPTION(USE_MSVC_SSE "Use MSVC /arch:sse option"	ON)
+	  OPTION(USE_MSVC_SSE "Use MSVC /arch:sse option"	OFF)
 	  option(USE_MSVC_SSE2 "Compile your program with SSE2 instructions" ON)
 
 	  IF (USE_MSVC_SSE)


### PR DESCRIPTION
This is related to https://github.com/bulletphysics/bullet3/issues/1450.

SSE and SSE2 conflict with this [command line warning D9025](https://docs.microsoft.com/en-us/cpp/error-messages/tool-errors/command-line-warning-d9025), and as [observed here](https://stackoverflow.com/questions/1067630/sse2-option-in-visual-c-x64) recent 64-bit windows versions support SSE2.

Just to simplify building on most recent versions of Windows and remove warnings, it may be preferable to have this default be off.

It doesn't affect other platforms.