### PR TITLE
Request nvidia discrete GPU if available (no effect if NVidia GPU is …

### DIFF
--- a/examples/OpenGLWindow/Win32OpenGLWindow.cpp
+++ b/examples/OpenGLWindow/Win32OpenGLWindow.cpp
@@ -30,6 +30,11 @@ static void printGLString(const char *name, GLenum s) {
   printf("%s = %s\n",name, v);
 }
 
+// Request NVidia discrete GPU if both are available
+extern "C" {
+__declspec(dllexport) DWORD NvOptimusEnablement = 0x00000001;
+}
+
 bool sOpenGLVerbose = true;
 
 void Win32OpenGLWindow::enableOpenGL()


### PR DESCRIPTION
This is related to #1480 

The NVidia drivers check for this global variable and request the discrete GPU if available. I tested with the GPU connected and not, and it runs fine in both cases (just uses the integrated if the nvidia GPU is not available). 

EDIT: more information: https://docs.nvidia.com/gameworks/content/technologies/desktop/optimus.htm