### PR TITLE
Support for reading <inertial> elements from MJCF

### DIFF
--- a/examples/Importers/ImportURDFDemo/URDF2Bullet.cpp
+++ b/examples/Importers/ImportURDFDemo/URDF2Bullet.cpp
@@ -296,9 +296,7 @@ void ConvertURDF2BulletInternal(
          */
         if (mass)
         {
-            if (!(flags & CUF_USE_URDF_INERTIA) && (localInertiaDiagonal[0] == 0.0 ||
-													localInertiaDiagonal[1] == 0.0 ||
-													localInertiaDiagonal[2] == 0.0))
+            if (!(flags & CUF_USE_URDF_INERTIA))
             {
                 compoundShape->calculateLocalInertia(mass, localInertiaDiagonal);
                 btAssert(localInertiaDiagonal[0] < 1e10);

--- a/examples/Importers/ImportURDFDemo/URDF2Bullet.cpp
+++ b/examples/Importers/ImportURDFDemo/URDF2Bullet.cpp
@@ -296,7 +296,9 @@ void ConvertURDF2BulletInternal(
          */
         if (mass)
         {
-            if (!(flags & CUF_USE_URDF_INERTIA))
+            if (!(flags & CUF_USE_URDF_INERTIA) && (localInertiaDiagonal[0] == 0.0 ||
+													localInertiaDiagonal[1] == 0.0 ||
+													localInertiaDiagonal[2] == 0.0))
             {
                 compoundShape->calculateLocalInertia(mass, localInertiaDiagonal);
                 btAssert(localInertiaDiagonal[0] < 1e10);


### PR DESCRIPTION
I'm trying to replicate an analytic CartPole environment in Bullet, and to do that accurately I needed to specify the moments of inertia. This patch is part of the solution and adds support for that.

I'm not very sure about [this line](https://github.com/bulletphysics/bullet3/compare/master...rhaps0dy:MJCFImporter?expand=1#diff-3fcc3b2c48d9839736d2f098bc4ca97aR299), is it always the case that bodies without a set `localInertiaDiagonal` have it set to 0? Empirical observation suggests so but my tests haven't been very extense.

More information in the issue that I'm going to link.