### PR TITLE
Tidy up cmake build script

### DIFF
--- a/build_cmake_pybullet_double.sh
+++ b/build_cmake_pybullet_double.sh
@@ -6,7 +6,7 @@ fi
 mkdir -p build_cmake
 cd build_cmake
 cmake -DBUILD_PYBULLET=ON -DBUILD_PYBULLET_NUMPY=OFF -DUSE_DOUBLE_PRECISION=ON -DCMAKE_BUILD_TYPE=Release ..
-make -j $(command nproc || echo 12)
+make -j $(command nproc 2>/dev/null || echo 12)
 cd examples
 cd pybullet
 if [ -e pybullet.dylib ]; then

--- a/build_cmake_pybullet_double.sh
+++ b/build_cmake_pybullet_double.sh
@@ -5,11 +5,11 @@ if [ -e CMakeCache.txt ]; then
 fi
 mkdir -p build_cmake
 cd build_cmake
-cmake -DBUILD_PYBULLET=ON -DBUILD_PYBULLET_NUMPY=OFF -DUSE_DOUBLE_PRECISION=ON -DCMAKE_BUILD_TYPE=Release ..
-make -j $(command nproc 2>/dev/null || echo 12)
+cmake -DBUILD_PYBULLET=ON -DBUILD_PYBULLET_NUMPY=OFF -DUSE_DOUBLE_PRECISION=ON -DCMAKE_BUILD_TYPE=Release .. || exit 1
+make -j $(command nproc 2>/dev/null || echo 12) || exit 1
 cd examples
 cd pybullet
 if [ -e pybullet.dylib ]; then
   ln -f -s pybullet.dylib pybullet.so
 fi
-
+echo "Completed build of Bullet."

--- a/build_cmake_pybullet_double.sh
+++ b/build_cmake_pybullet_double.sh
@@ -10,7 +10,6 @@ make -j $(command nproc 2>/dev/null || echo 12)
 cd examples
 cd pybullet
 if [ -e pybullet.dylib ]; then
-  rm pybullet.so
-  ln -s pybullet.dylib pybullet.so
+  ln -f -s pybullet.dylib pybullet.so
 fi
 

--- a/build_cmake_pybullet_double.sh
+++ b/build_cmake_pybullet_double.sh
@@ -1,10 +1,16 @@
 #!/bin/sh
-rm CMakeCache.txt
-mkdir build_cmake
+
+if [ -e CMakeCache.txt ]; then
+  rm CMakeCache.txt
+fi
+mkdir -p build_cmake
 cd build_cmake
 cmake -DBUILD_PYBULLET=ON -DBUILD_PYBULLET_NUMPY=OFF -DUSE_DOUBLE_PRECISION=ON -DCMAKE_BUILD_TYPE=Release ..
-make -j12
+make -j $(command nproc || echo 12)
 cd examples
 cd pybullet
-ln -s pybullet.dylib pybullet.so
+if [ -e pybullet.dylib ]; then
+  rm pybullet.so
+  ln -s pybullet.dylib pybullet.so
+fi
 


### PR DESCRIPTION
Minor improvements to tidy up build_cmake_pybullet_double.sh

Existing version:
-started with an rm of the CMakeCache.txt, which won't exist on first build, printing an error
-did a mkdir build_cmake which already exists on teh second build, printing an error.
-make command used a hardcoded "-j12" to always try to use 12 processes regardless of the number of CPU's on the machine.  
-The symlink for pybullet.so would error after the first build because pybullet.so already exists.


This PR will
-Check for the existence of CMakeCache.txt before trying to delete it.
-Add a -p flag to mkdir so it won't error when repeatedly making the build_cmake directory.
-Use the nproc command if available to run as many build processes as there are CPU's in the system. (Or preserve old behavior and use -j12 if it isn't available)
- Tidy up the pybullet.so symlink so it is only attempted if a .dylib exists, and ln is set to force mode so it won't complain if pybullet.so already exists.
- Add a friendly message saying "Completed build of Bullet." to increase the joy of the user.  Message is displayed only if script didn't bail early because cmake or make failed.

Result is fewer distracting warning messages will be printed in a normal build, and build may be faster on machines with many cores and fast storage.