### PR TITLE
fix conversion from getCameraImage output to rgb_array

### DIFF
--- a/examples/pybullet/gym/pybullet_envs/env_bases.py
+++ b/examples/pybullet/gym/pybullet_envs/env_bases.py
@@ -96,7 +96,8 @@ class MJCFBaseBulletEnv(gym.Env):
 			projectionMatrix=proj_matrix,
 			renderer=p.ER_BULLET_HARDWARE_OPENGL
 			)
-		rgb_array = np.array(px)
+		rgb_array = np.array(px, dtype=np.uint8)
+		rgb_array = np.reshape(rgb_array, (self._render_height, self._render_width, 4))
 		rgb_array = rgb_array[:, :, :3]
 		return rgb_array
 


### PR DESCRIPTION
This fixes a bug where `pybullet_envs.agents.visualize_ppo` fails with an error like:
```
  File "/Users/mwest/anaconda3/envs/DRL/lib/python3.6/site-packages/pybullet_envs/env_bases.py", line 101, in _render
    rgb_array = rgb_array[:, :, :3]
IndexError: too many indices for array
```
The array returned from `getCameraImage()` is flat and needs to be reshaped to `(height, width, 4)`.