### PR TITLE
Removed warnings of unused variable in btThreads header

### DIFF
--- a/src/BulletCollision/CollisionShapes/btCapsuleShape.h
+++ b/src/BulletCollision/CollisionShapes/btCapsuleShape.h
@@ -49,6 +49,7 @@ public:
 	virtual void setMargin(btScalar collisionMargin)
 	{
 		//don't override the margin for capsules, their entire radius == margin
+		(void)collisionMargin;
 	}
 
 	virtual void getAabb (const btTransform& t, btVector3& aabbMin, btVector3& aabbMax) const

--- a/src/LinearMath/btThreads.h
+++ b/src/LinearMath/btThreads.h
@@ -72,6 +72,8 @@ SIMD_FORCE_INLINE void btMutexLock( btSpinMutex* mutex )
 {
 #if BT_THREADSAFE
     mutex->lock();
+#else
+    (void)mutex;
 #endif // #if BT_THREADSAFE
 }
 
@@ -79,6 +81,8 @@ SIMD_FORCE_INLINE void btMutexUnlock( btSpinMutex* mutex )
 {
 #if BT_THREADSAFE
     mutex->unlock();
+#else
+    (void)mutex;
 #endif // #if BT_THREADSAFE
 }
 
@@ -87,6 +91,7 @@ SIMD_FORCE_INLINE bool btMutexTryLock( btSpinMutex* mutex )
 #if BT_THREADSAFE
     return mutex->tryLock();
 #else
+    (void)mutex;
     return true;
 #endif // #if BT_THREADSAFE
 }


### PR DESCRIPTION
I don't care too much about warnings when building the library,
but these where generated using it (it's in a, header file).