### PR TITLE
Override of the reset() public funciton in child classes

### DIFF
--- a/examples/pybullet/gym/pybullet_envs/bullet/kukaGymEnv.py
+++ b/examples/pybullet/gym/pybullet_envs/bullet/kukaGymEnv.py
@@ -275,3 +275,11 @@ class KukaGymEnv(gym.Env):
      #print("reward")
     #print(reward)
     return reward
+
+    def reset(self):
+        """Resets the state of the environment and returns an initial observation.
+
+        Returns: observation (object): the initial observation of the
+            space.
+        """
+        return self._reset()


### PR DESCRIPTION
Hi Erviw,
I followed your instruction about the issue https://github.com/bulletphysics/bullet3/issues/1525 
Then I discovered that the classes KukaGymEnv and KukaDiverseObjectEnv call the function reset() that calls the _reset() function from the Env class.

In this PR i just added the override of the reset() funciton in the child classes.

Andrea