### PR TITLE
Unknown character causing syntax error

### DIFF
--- a/examples/pybullet/gym/pybullet_envs/__init__.py
+++ b/examples/pybullet/gym/pybullet_envs/__init__.py
@@ -1,7 +1,7 @@
 import gym
 from gym.envs.registration import registry, make, spec
 def register(id,*args,**kvargs):
-	if id in  registry.env_specs:
+	if id in registry.env_specs:
 		return
 	else:
 		return gym.envs.registration.register(id,*args,**kvargs)


### PR DESCRIPTION
After downloading, install and then running an example training file from the latest master, I got this message:
`
Traceback (most recent call last):
  File "enjoy_kuka_grasping.py", line 8, in <module>
    from pybullet_envs.bullet.kukaGymEnv import KukaGymEnv
  File "/Users/ishaanvarshney/bvn/bullet3/examples/pybullet/gym/pybullet_envs/__init__.py", line 4
    if id in  registry.env_specs:
            ^
SyntaxError: invalid character in identifier
`

This PR removes this addition unnecessary character.