### PR TITLE
Implemented support for softbodies in OpenGL renderer

### DIFF
--- a/examples/ExampleBrowser/OpenGLGuiHelper.cpp
+++ b/examples/ExampleBrowser/OpenGLGuiHelper.cpp
@@ -1291,8 +1291,8 @@ void OpenGLGuiHelper::computeSoftBodyVertices(btCollisionShape* collisionShape,
 											  btAlignedObjectArray<GLInstanceVertex>& gfxVertices,
 											  btAlignedObjectArray<int>& indices)
 {
-	b3Assert(collisionShape->getUserPointer());
-	btSoftBody* psb = (btSoftBody*)collisionShape->getUserPointer();
+	b3Assert(collisionShape->getBodyPointer());
+	btSoftBody* psb = (btSoftBody*)collisionShape->getBodyPointer();
 	gfxVertices.resize(psb->m_faces.size() * 3);
 	int i, j, k;
 	for (i = 0; i < psb->m_faces.size(); i++)  // Foreach face

--- a/examples/ExampleBrowser/OpenGLGuiHelper.cpp
+++ b/examples/ExampleBrowser/OpenGLGuiHelper.cpp
@@ -1291,8 +1291,8 @@ void OpenGLGuiHelper::computeSoftBodyVertices(btCollisionShape* collisionShape,
 											  btAlignedObjectArray<GLInstanceVertex>& gfxVertices,
 											  btAlignedObjectArray<int>& indices)
 {
-	b3Assert(collisionShape->getBodyPointer());
-	btSoftBody* psb = (btSoftBody*)collisionShape->getBodyPointer();
+	b3Assert(collisionShape->getUserPointer());
+	btSoftBody* psb = (btSoftBody*)collisionShape->getUserPointer();
 	gfxVertices.resize(psb->m_faces.size() * 3);
 	int i, j, k;
 	for (i = 0; i < psb->m_faces.size(); i++)  // Foreach face

--- a/examples/ExampleBrowser/OpenGLGuiHelper.h
+++ b/examples/ExampleBrowser/OpenGLGuiHelper.h
@@ -5,6 +5,7 @@
 class btCollisionShape;
 class btTransform;
 #include "LinearMath/btAlignedObjectArray.h"
+#include "../OpenGLWindow/GLInstanceGraphicsShape.h"
 
 struct OpenGLGuiHelper : public GUIHelperInterface
 {
@@ -99,6 +100,10 @@ struct OpenGLGuiHelper : public GUIHelperInterface
 	virtual void	dumpFramesToVideo(const char* mp4FileName);
 
 	int createCheckeredTexture(int r,int g, int b);
+
+	void computeSoftBodyVertices(btCollisionShape* collisionShape,
+											  btAlignedObjectArray<GLInstanceVertex>& gfxVertices,
+											  btAlignedObjectArray<int>& indices);
 };
 
 #endif //OPENGL_GUI_HELPER_H

--- a/examples/SharedMemory/PhysicsServerCommandProcessor.cpp
+++ b/examples/SharedMemory/PhysicsServerCommandProcessor.cpp
@@ -5862,7 +5862,7 @@ bool PhysicsServerCommandProcessor::processLoadSoftBodyCommand(const struct Shar
 				psb->scale(btVector3(scale,scale,scale));
 				psb->setTotalMass(mass,true);
 				psb->getCollisionShape()->setMargin(collisionMargin);
-				psb->getCollisionShape()->setBodyPointer(psb);
+				psb->getCollisionShape()->setUserPointer(psb);
 				m_data->m_dynamicsWorld->addSoftBody(psb);
 				m_data->m_guiHelper->createCollisionShapeGraphicsObject(psb->getCollisionShape());
 				m_data->m_guiHelper->autogenerateGraphicsObjects(this->m_data->m_dynamicsWorld);

--- a/examples/SharedMemory/PhysicsServerCommandProcessor.cpp
+++ b/examples/SharedMemory/PhysicsServerCommandProcessor.cpp
@@ -5862,7 +5862,7 @@ bool PhysicsServerCommandProcessor::processLoadSoftBodyCommand(const struct Shar
 				psb->scale(btVector3(scale,scale,scale));
 				psb->setTotalMass(mass,true);
 				psb->getCollisionShape()->setMargin(collisionMargin);
-				psb->getCollisionShape()->setUserPointer(psb);
+				psb->getCollisionShape()->setBodyPointer(psb);
 				m_data->m_dynamicsWorld->addSoftBody(psb);
 				m_data->m_guiHelper->createCollisionShapeGraphicsObject(psb->getCollisionShape());
 				m_data->m_guiHelper->autogenerateGraphicsObjects(this->m_data->m_dynamicsWorld);

--- a/examples/SharedMemory/PhysicsServerCommandProcessor.cpp
+++ b/examples/SharedMemory/PhysicsServerCommandProcessor.cpp
@@ -5862,7 +5862,10 @@ bool PhysicsServerCommandProcessor::processLoadSoftBodyCommand(const struct Shar
 				psb->scale(btVector3(scale,scale,scale));
 				psb->setTotalMass(mass,true);
 				psb->getCollisionShape()->setMargin(collisionMargin);
+				psb->getCollisionShape()->setUserPointer(psb);
 				m_data->m_dynamicsWorld->addSoftBody(psb);
+				m_data->m_guiHelper->createCollisionShapeGraphicsObject(psb->getCollisionShape());
+				m_data->m_guiHelper->autogenerateGraphicsObjects(this->m_data->m_dynamicsWorld);
 				int bodyUniqueId = m_data->m_bodyHandles.allocHandle();
 				InternalBodyHandle* bodyHandle = m_data->m_bodyHandles.getHandle(bodyUniqueId);
 				bodyHandle->m_softBody = psb;

--- a/src/BulletCollision/CollisionShapes/btCollisionShape.h
+++ b/src/BulletCollision/CollisionShapes/btCollisionShape.h
@@ -30,6 +30,7 @@ protected:
 	int m_shapeType;
 	void* m_userPointer;
 	int m_userIndex;
+	void* m_bodyPointer;
 
 public:
 
@@ -131,6 +132,18 @@ public:
 	{
 		return m_userPointer;
 	}
+
+	/// optional pointer to body the shape represents
+	void	setBodyPointer(void*  bodyPointer)
+	{
+		m_bodyPointer = bodyPointer;
+	}
+
+	void*	getBodyPointer() const
+	{
+		return m_bodyPointer;
+	}
+
 	void setUserIndex(int index)
 	{
 		m_userIndex = index;

--- a/src/BulletCollision/CollisionShapes/btCollisionShape.h
+++ b/src/BulletCollision/CollisionShapes/btCollisionShape.h
@@ -30,7 +30,6 @@ protected:
 	int m_shapeType;
 	void* m_userPointer;
 	int m_userIndex;
-	void* m_bodyPointer;
 
 public:
 
@@ -132,18 +131,6 @@ public:
 	{
 		return m_userPointer;
 	}
-
-	/// optional pointer to body the shape represents
-	void	setBodyPointer(void*  bodyPointer)
-	{
-		m_bodyPointer = bodyPointer;
-	}
-
-	void*	getBodyPointer() const
-	{
-		return m_bodyPointer;
-	}
-
 	void setUserIndex(int index)
 	{
 		m_userIndex = index;


### PR DESCRIPTION
Hi,

I implemented the support for softbodies in OpenGL  renderer. The main use cases are:
- softbodies are now visible in p.getCameraImage images
- softbodies now get textures and shadows in example browser

Known issues:
- I believe this could be problematic with 2D softBodies (as cloth in PR https://github.com/bulletphysics/bullet3/pull/1553) because of Face Culling. I will address this in separate PR is this one gets accepted.

Performance considerations:
- I am a bit worried that we need to write each vertex position on each syncPhysicsToGraphics call, but I do not currently see a better option. 

Screen from load_soft_body example:
<img width="522" alt="screen shot 2018-02-08 at 13 46 50" src="https://user-images.githubusercontent.com/9294723/35976024-a13c8002-0cd6-11e8-9b22-f1a009998744.png">


