### PR TITLE
minor bugfix in image reshaping in kukaGymEnv.py

### DIFF
--- a/examples/pybullet/gym/pybullet_envs/bullet/kukaGymEnv.py
+++ b/examples/pybullet/gym/pybullet_envs/bullet/kukaGymEnv.py
@@ -205,7 +205,7 @@ class KukaGymEnv(gym.Env):
 
         
     rgb_array = np.array(px, dtype=np.uint8)
-    rgb_array = np.reshape(rgb_array, (RENDER_WIDTH, RENDER_HEIGHT, 4))
+    rgb_array = np.reshape(rgb_array, (RENDER_HEIGHT, RENDER_WIDTH, 4))
 		
     rgb_array = rgb_array[:, :, :3]
     return rgb_array


### PR DESCRIPTION
Reshaped image array should be of size (RENDER_HEIGHT, RENDER_WIDTH, 4) instead of (RENDER_WIDTH, RENDER_HEIGHT, 4).