### PR TITLE
Fix calculation of startPt for perturbed object A.

### DIFF
--- a/src/BulletCollision/CollisionDispatch/btConvexConvexAlgorithm.cpp
+++ b/src/BulletCollision/CollisionDispatch/btConvexConvexAlgorithm.cpp
@@ -259,7 +259,7 @@ struct btPerturbedContactResult : public btManifoldResult
 			btVector3 endPtOrg = pointInWorld + normalOnBInWorld*orgDepth;
 			endPt = (m_unPerturbedTransform*m_transformA.inverse())(endPtOrg);
 			newDepth = (endPt -  pointInWorld).dot(normalOnBInWorld);
-			startPt = endPt+normalOnBInWorld*newDepth;
+			startPt = endPt - normalOnBInWorld*newDepth;
 		} else
 		{
 			endPt = pointInWorld + normalOnBInWorld*orgDepth;


### PR DESCRIPTION
I believe this change in sign of the normal when calculating startPt will fix the calculation of contact points when object A is selected to be perturbed.  Indeed, in the object A case, first endPt (on object A surface) is calculated and then the startPt should be calculated following the normal **backwards** towards A surface, whereas currently the code moves along the normal forwards, into the B surface.

Since the contact point is then specified by the startPt location and normal, the result is a vector starting inside the B contour and pointing into it, instead of starting on the A surface and pointing to the B surface.

Regarding the test program mentioned in #1563, with this change, the following output is generated:

![image](https://user-images.githubusercontent.com/66805/36313185-93d7e980-130f-11e8-90e6-009a51e537e9.png)

Similarly if the objects are switched position so that the convex hull is on the bottom, previous to this change in sign it was:

![image](https://user-images.githubusercontent.com/66805/36313217-ac153b7e-130f-11e8-89c9-222a77eadb22.png)

but now is:

![image](https://user-images.githubusercontent.com/66805/36313207-a1632b28-130f-11e8-9e5e-517f1883ab95.png)

Similar results can be seen if the objects are rotated slightly.