### PR TITLE
PyBullet: soft bodies are rendered, so we don't need to also render w…

### DIFF
--- a/examples/ExampleBrowser/OpenGLExampleBrowser.cpp
+++ b/examples/ExampleBrowser/OpenGLExampleBrowser.cpp
@@ -1303,7 +1303,7 @@ void OpenGLExampleBrowser::update(float deltaTime)
                 BT_PROFILE("Render Scene");
                 sCurrentDemo->renderScene();
             }
-			//else
+			else
             {
 				B3_PROFILE("physicsDebugDraw");
 				glPolygonMode( GL_FRONT_AND_BACK, GL_FILL );

--- a/examples/OpenGLWindow/GLInstancingRenderer.cpp
+++ b/examples/OpenGLWindow/GLInstancingRenderer.cpp
@@ -1047,11 +1047,17 @@ void GLInstancingRenderer::updateShape(int shapeIndex, const float* vertices)
 	int numvertices = gfxObj->m_numVertices;
 
 	glBindBuffer(GL_ARRAY_BUFFER, m_data->m_vbo);
-	char* dest=  (char*)glMapBuffer( GL_ARRAY_BUFFER,GL_WRITE_ONLY);//GL_WRITE_ONLY
 	int vertexStrideInBytes = 9*sizeof(float);
 	int sz = numvertices*vertexStrideInBytes;
+#if 0
+	char* dest=  (char*)glMapBuffer( GL_ARRAY_BUFFER,GL_WRITE_ONLY);//GL_WRITE_ONLY
 	memcpy(dest+vertexStrideInBytes*gfxObj->m_vertexArrayOffset,vertices,sz);
 	glUnmapBuffer( GL_ARRAY_BUFFER);
+#else
+	glBufferSubData(	GL_ARRAY_BUFFER,vertexStrideInBytes*gfxObj->m_vertexArrayOffset,sz,
+ 						vertices);
+#endif
+	
 }
 
 int GLInstancingRenderer::registerShape(const float* vertices, int numvertices, const int* indices, int numIndices,int primitiveType, int textureId)

--- a/examples/SharedMemory/PhysicsServerCommandProcessor.cpp
+++ b/examples/SharedMemory/PhysicsServerCommandProcessor.cpp
@@ -1538,7 +1538,6 @@ struct PhysicsServerCommandProcessorInternalData
 #ifndef SKIP_SOFT_BODY_MULTI_BODY_DYNAMICS_WORLD
 	btSoftMultiBodyDynamicsWorld* m_dynamicsWorld;
     btSoftBodySolver* m_softbodySolver;
-    btSoftBodyWorldInfo	m_softBodyWorldInfo;
 #else
     btMultiBodyDynamicsWorld* m_dynamicsWorld;
 #endif
@@ -5833,13 +5832,6 @@ bool PhysicsServerCommandProcessor::processLoadSoftBodyCommand(const struct Shar
         collisionMargin = clientCmd.m_loadSoftBodyArguments.m_collisionMargin;
     }
 	
-    m_data->m_softBodyWorldInfo.air_density		=	(btScalar)1.2;
-    m_data->m_softBodyWorldInfo.water_density	=	0;
-    m_data->m_softBodyWorldInfo.water_offset	=	0;
-    m_data->m_softBodyWorldInfo.water_normal	=	btVector3(0,0,0);
-    m_data->m_softBodyWorldInfo.m_gravity.setValue(0,0,-10);
-    m_data->m_softBodyWorldInfo.m_broadphase = m_data->m_broadphase;
-    m_data->m_softBodyWorldInfo.m_sparsesdf.Initialize();
 	
 	{
 		char relativeFileName[1024];
@@ -5871,7 +5863,7 @@ bool PhysicsServerCommandProcessor::processLoadSoftBodyCommand(const struct Shar
 			int numTris = indices.size()/3;
 			if (numTris>0)
 			{
-				btSoftBody*	psb=btSoftBodyHelpers::CreateFromTriMesh(m_data->m_softBodyWorldInfo,&vertices[0],&indices[0],numTris);
+				btSoftBody*	psb=btSoftBodyHelpers::CreateFromTriMesh(m_data->m_dynamicsWorld->getWorldInfo(),&vertices[0],&indices[0],numTris);
 				btSoftBody::Material*	pm=psb->appendMaterial();
 				pm->m_kLST				=	0.5;
 				pm->m_flags				-=	btSoftBody::fMaterial::DebugDraw;
@@ -5882,6 +5874,7 @@ bool PhysicsServerCommandProcessor::processLoadSoftBodyCommand(const struct Shar
 				psb->rotate(btQuaternion(0.70711,0,0,0.70711));
 				psb->translate(btVector3(-0.05,0,1.0));
 				psb->scale(btVector3(scale,scale,scale));
+				
 				psb->setTotalMass(mass,true);
 				psb->getCollisionShape()->setMargin(collisionMargin);
 				psb->getCollisionShape()->setUserPointer(psb);
@@ -6594,6 +6587,7 @@ bool PhysicsServerCommandProcessor::processSendPhysicsParametersCommand(const st
 						clientCmd.m_physSimParamArgs.m_gravityAcceleration[1],
 						clientCmd.m_physSimParamArgs.m_gravityAcceleration[2]);
 		this->m_data->m_dynamicsWorld->setGravity(grav);
+		m_data->m_dynamicsWorld->getWorldInfo().m_gravity=grav;
 		if (m_data->m_verboseOutput)
 		{
 			b3Printf("Updated Gravity: %f,%f,%f",grav[0],grav[1],grav[2]);

--- a/examples/pybullet/examples/load_soft_body.py
+++ b/examples/pybullet/examples/load_soft_body.py
@@ -6,15 +6,17 @@ physicsClient = p.connect(p.GUI)
 p.setGravity(0,0,-10)
 planeId = p.loadURDF("plane.urdf")
 bunnyId = p.loadSoftBody("bunny.obj")
-
+p.loadURDF("cube_small.urdf",[1,0,1])
 useRealTimeSimulation = 1
 
 if (useRealTimeSimulation):
 	p.setRealTimeSimulation(1)
 
-while 1:
+while p.isConnected():
+	p.setGravity(0,0,-10)
 	if (useRealTimeSimulation):
-		p.setGravity(0,0,-10)
+
 		sleep(0.01) # Time in seconds.
+		#p.getCameraImage(320,200,renderer=p.ER_BULLET_HARDWARE_OPENGL )
 	else:
 		p.stepSimulation()


### PR DESCRIPTION
…ireframes in regular mode.

Use glBufferSubData instead of glMapBuffer/glUnmapBuffer, much faster soft body vertex sync.
Don't use a separate btSoftBodyWorldInfo, use the existing one in btSoftMultiBodyDynamicsWorld.