### PR TITLE
Use kF_UseGjkConvexCastRaytest by default for raycast in PyBullet (it…

### DIFF
--- a/examples/SharedMemory/PhysicsServerCommandProcessor.cpp
+++ b/examples/SharedMemory/PhysicsServerCommandProcessor.cpp
@@ -43,6 +43,7 @@
 #include "../Utils/b3Clock.h"
 #include "b3PluginManager.h"
 #include "../Extras/Serialize/BulletFileLoader/btBulletFile.h"
+#include "BulletCollision/NarrowPhaseCollision/btRaycastCallback.h"
 
 
 #ifdef STATIC_LINK_VR_PLUGIN
@@ -4472,6 +4473,8 @@ bool PhysicsServerCommandProcessor::processRequestRaycastIntersectionsCommand(co
 			clientCmd.m_requestRaycastIntersections.m_rayToPositions[ray][2]);
 
 		btCollisionWorld::ClosestRayResultCallback rayResultCallback(rayFromWorld,rayToWorld);
+		rayResultCallback.m_flags |= btTriangleRaycastCallback::kF_UseGjkConvexCastRaytest;
+
 		m_data->m_dynamicsWorld->rayTest(rayFromWorld,rayToWorld,rayResultCallback);
 		int rayHits = serverStatusOut.m_raycastHits.m_numRaycastHits;
 

--- a/src/BulletCollision/NarrowPhaseCollision/btSubSimplexConvexCast.cpp
+++ b/src/BulletCollision/NarrowPhaseCollision/btSubSimplexConvexCast.cpp
@@ -72,11 +72,8 @@ bool	btSubsimplexConvexCast::calcTimeOfImpact(
 
 
 	btScalar dist2 = v.length2();
-#ifdef BT_USE_DOUBLE_PRECISION
-	btScalar epsilon = btScalar(0.0001);
-#else
-	btScalar epsilon = btScalar(0.0001);
-#endif //BT_USE_DOUBLE_PRECISION
+	btScalar epsilon = SIMD_EPSILON * 10;
+
 	btVector3	w,p;
 	btScalar VdotR;
 	


### PR DESCRIPTION
… is more robust/accurate, but a bit slower)

Use 10*EPSILON, as suggested in Gino's paper:
http://www.continuousphysics.com/ftp/pub/test/files/physics/papers/jgt04raycast.pdf