### PR TITLE
fix premake build instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ Depending on your system (Linux 32bit, 64bit or Mac OSX) use one of the followin
 Using premake:
 ```
 	cd build3
-	./premake4_linux gmake --double
-	./premake4_linux64 gmake --double
-	./premake4_osx gmake --double --enable_pybullet
+	./premake4_linux --double gmake
+	./premake4_linux64 --double gmake
+	./premake4_osx --double --enable_pybullet gmake
 ```
 Then
 ```


### PR DESCRIPTION
When testing the premake option I added in my other PR (--enable-multithreading) I discovered that the command line given in the bullet README doesn't work as expected.  When I tried

`./premake4_linux64 gmake --double`

It silently ignored the "--double", however putting the "gmake" after the options worked as expected.
I only tested this on linux64.