### PR TITLE
Fix Large memory leak in bullet Softbody

### DIFF
--- a/examples/SharedMemory/PhysicsServerCommandProcessor.cpp
+++ b/examples/SharedMemory/PhysicsServerCommandProcessor.cpp
@@ -9693,7 +9693,7 @@ void PhysicsServerCommandProcessor::stepSimulationRealTime(double dtInSec,const 
 void PhysicsServerCommandProcessor::resetSimulation()
 {
 	//clean up all data
-
+	m_data->m_dynamicsWorld->getWorldInfo().m_sparsesdf.Reset();
 	if (m_data && m_data->m_guiHelper)
 	{
 		m_data->m_guiHelper->removeAllGraphicsInstances();

--- a/examples/SharedMemory/PhysicsServerCommandProcessor.cpp
+++ b/examples/SharedMemory/PhysicsServerCommandProcessor.cpp
@@ -9693,7 +9693,10 @@ void PhysicsServerCommandProcessor::stepSimulationRealTime(double dtInSec,const 
 void PhysicsServerCommandProcessor::resetSimulation()
 {
 	//clean up all data
-	m_data->m_dynamicsWorld->getWorldInfo().m_sparsesdf.Reset();
+	if (m_data && m_data->m_dynamicsWorld)
+	{
+		m_data->m_dynamicsWorld->getWorldInfo().m_sparsesdf.Reset();
+	}
 	if (m_data && m_data->m_guiHelper)
 	{
 		m_data->m_guiHelper->removeAllGraphicsInstances();


### PR DESCRIPTION
Hi,

I have noticed a fairly large memory leak when using bullet softbody. When the softbody collides with rigidbody, btSparseSDF is allocating memory (btSparseSdf.h:197). This is fine in long running simulations because the number of allocated cells has upper bound. However, if I call resetSimulation, it seems like this memory does not get freed (or at least I was not able to find a code path that would do so). In RL task, one often resets simulation after each episode, leading to massive leaks (5GB+ in my case).

A solution that worked for me is to add  Reset() that frees memory at the start of the resetSimulation code. There might be better solution (eg. maybe free memory in destructor of btSoftMultiBodyDynamicsWorld), but I did not explore other option further. Any comments are appreciated.