### PR TITLE
Expand aabb with CollisionObject getContactProcessingThreshold()

### DIFF
--- a/src/BulletCollision/CollisionDispatch/btCollisionWorld.cpp
+++ b/src/BulletCollision/CollisionDispatch/btCollisionWorld.cpp
@@ -128,6 +128,11 @@ void	btCollisionWorld::addCollisionObject(btCollisionObject* collisionObject, in
 	btVector3	maxAabb;
 	collisionObject->getCollisionShape()->getAabb(trans,minAabb,maxAabb);
 
+	//need to increase the aabb for contact thresholds
+	btVector3 contactThreshold(collisionObject->getContactProcessingThreshold(), collisionObject->getContactProcessingThreshold(), collisionObject->getContactProcessingThreshold());
+	minAabb -= contactThreshold;
+	maxAabb += contactThreshold;
+
 	int type = collisionObject->getCollisionShape()->getShapeType();
 	collisionObject->setBroadphaseHandle( getBroadphase()->createProxy(
 		minAabb,
@@ -151,7 +156,7 @@ void	btCollisionWorld::updateSingleAabb(btCollisionObject* colObj)
 	btVector3 minAabb,maxAabb;
 	colObj->getCollisionShape()->getAabb(colObj->getWorldTransform(), minAabb,maxAabb);
 	//need to increase the aabb for contact thresholds
-	btVector3 contactThreshold(gContactBreakingThreshold,gContactBreakingThreshold,gContactBreakingThreshold);
+  btVector3 contactThreshold(colObj->getContactProcessingThreshold(), colObj->getContactProcessingThreshold(), colObj->getContactProcessingThreshold());
 	minAabb -= contactThreshold;
 	maxAabb += contactThreshold;
 
@@ -1270,6 +1275,12 @@ void	btCollisionWorld::contactTest( btCollisionObject* colObj, ContactResultCall
 {
 	btVector3 aabbMin,aabbMax;
 	colObj->getCollisionShape()->getAabb(colObj->getWorldTransform(),aabbMin,aabbMax);
+
+	//need to increase the aabb for contact thresholds
+	btVector3 contactThreshold(colObj->getContactProcessingThreshold(), colObj->getContactProcessingThreshold(), colObj->getContactProcessingThreshold());
+	aabbMin -= contactThreshold;
+	aabbMax += contactThreshold;
+
 	btSingleContactCallback	contactCB(colObj,this,resultCallback);
 	
 	m_broadphasePairCache->aabbTest(aabbMin,aabbMax,contactCB);
@@ -1599,7 +1610,7 @@ void	btCollisionWorld::debugDrawWorld()
 						btVector3 minAabb,maxAabb;
 						btVector3 colorvec = defaultColors.m_aabb;
 						colObj->getCollisionShape()->getAabb(colObj->getWorldTransform(), minAabb,maxAabb);
-						btVector3 contactThreshold(gContactBreakingThreshold,gContactBreakingThreshold,gContactBreakingThreshold);
+						btVector3 contactThreshold(colObj->getContactProcessingThreshold(),colObj->getContactProcessingThreshold(),colObj->getContactProcessingThreshold());
 						minAabb -= contactThreshold;
 						maxAabb += contactThreshold;
 

--- a/src/BulletCollision/CollisionDispatch/btConvexConcaveCollisionAlgorithm.cpp
+++ b/src/BulletCollision/CollisionDispatch/btConvexConcaveCollisionAlgorithm.cpp
@@ -179,7 +179,7 @@ void	btConvexTriangleCallback::setTimeStepAndCounters(btScalar collisionMarginTr
 	const btCollisionShape* convexShape = static_cast<const btCollisionShape*>(m_convexBodyWrap->getCollisionShape());
 	//CollisionShape* triangleShape = static_cast<btCollisionShape*>(triBody->m_collisionShape);
 	convexShape->getAabb(convexInTriangleSpace,m_aabbMin,m_aabbMax);
-	btScalar extraMargin = collisionMarginTriangle+ resultOut->m_closestPointDistanceThreshold;
+	btScalar extraMargin = collisionMarginTriangle + resultOut->m_closestPointDistanceThreshold + m_convexBodyWrap->getCollisionObject()->getContactProcessingThreshold();
 	
 	btVector3 extra(extraMargin,extraMargin,extraMargin);
 


### PR DESCRIPTION
I was working on a way to get distance information using the broadphase collision checking. I noticed that even if you set the contactProcessingThreshold for the collision object to a positive distance it would not return contact information for objects within this distance. These are the changes that were the changes required to get contact information for objects within the contactProcesssingThreshold. I also had to make a change to the ConvexConcaveCollisionAlgorithm to get correct information and if this is the correct approach this change will most likely need to be made to some of the other algorithms.

I wanted to get this PR out early to get the maintainer engage early in case I am headed down the wrong path.