### PR TITLE
parallel solver: remove bad assert

### DIFF
--- a/src/BulletDynamics/ConstraintSolver/btBatchedConstraints.cpp
+++ b/src/BulletDynamics/ConstraintSolver/btBatchedConstraints.cpp
@@ -212,7 +212,6 @@ static int runLengthEncodeConstraintInfo(btBatchedConstraintInfo* outConInfos, i
             ++iSrc;
         }
         conInfo.numConstraintRows = iSrc - conInfo.constraintIndex;
-        btAssert( conInfo.numConstraintRows <= 6 );
         ++iDest;
     }
     return iDest;


### PR DESCRIPTION
This assert serves no useful purpose. It will cause an erroneous assert when there are more than 6 points of contact between a pair of bodies.
See issue #1673 