### PR TITLE
BulletInverseDynamics: Fix propagation of user_int and user_ptr when …

### DIFF
--- a/examples/MultiThreading/b3PosixThreadSupport.cpp
+++ b/examples/MultiThreading/b3PosixThreadSupport.cpp
@@ -268,7 +268,8 @@ void b3PosixThreadSupport::stopThreads()
 	for(size_t t=0; t < size_t(m_activeThreadStatus.size()); ++t)
 	{
             b3ThreadStatus&	spuStatus = m_activeThreadStatus[t];
-            printf("%s: Thread %i used: %ld\n", __FUNCTION__, int(t), spuStatus.threadUsed);
+           
+	   // printf("%s: Thread %i used: %ld\n", __FUNCTION__, int(t), spuStatus.threadUsed);
 
 	spuStatus.m_userPtr = 0;
  	checkPThreadFunction(sem_post(spuStatus.startSemaphore));

--- a/examples/SharedMemory/PhysicsServerExample.cpp
+++ b/examples/SharedMemory/PhysicsServerExample.cpp
@@ -260,6 +260,8 @@ void	MotionThreadFunc(void* userPtr,void* lsMemory)
 	if (init)
 	{
 
+		unsigned int cachedSharedParam = eMotionIsInitialized;
+
 		args->m_cs->lock();
 		args->m_cs->setSharedParam(0,eMotionIsInitialized);
 		args->m_cs->unlock();
@@ -269,6 +271,8 @@ void	MotionThreadFunc(void* userPtr,void* lsMemory)
 		int numCmdSinceSleep1ms = 0;
 		unsigned long long int prevTime = clock.getTimeMicroseconds();
 		
+		
+
 		do
 		{
 			{
@@ -468,7 +472,11 @@ void	MotionThreadFunc(void* userPtr,void* lsMemory)
 				numCmdSinceSleep1ms++;
 			}
 			
-		} while (args->m_cs->getSharedParam(0)!=eRequestTerminateMotion);
+			args->m_cs->lock();
+			cachedSharedParam = args->m_cs->getSharedParam(0);
+			args->m_cs->unlock();
+
+		} while (cachedSharedParam!=eRequestTerminateMotion);
 	} else
 	{
 		args->m_cs->lock();
@@ -1749,7 +1757,7 @@ void	PhysicsServerExample::initPhysics()
 		
 		
 		m_isConnected = m_physicsServer.connectSharedMemory( m_guiHelper);
-
+		
 
 		for (int i=0;i<m_threadSupport->getNumTasks();i++)
 		{

--- a/examples/SharedMemory/PhysicsServerExample.cpp
+++ b/examples/SharedMemory/PhysicsServerExample.cpp
@@ -201,7 +201,8 @@ struct	MotionArgs
 			{
 				m_vrControllerEvents[i].m_buttons[b]=0;
 			}
-
+			m_vrControllerPos[i].setValue(0,0,0);
+			m_vrControllerOrn[i].setValue(0,0,0,1);
 			m_isVrControllerPicking[i] = false;
 			m_isVrControllerDragging[i] = false;
 			m_isVrControllerReleasing[i] = false;
@@ -1747,6 +1748,8 @@ void	PhysicsServerExample::initPhysics()
 	m_threadSupport = createMotionThreadSupport(MAX_MOTION_NUM_THREADS);
 		
 		
+		m_isConnected = m_physicsServer.connectSharedMemory( m_guiHelper);
+
 
 		for (int i=0;i<m_threadSupport->getNumTasks();i++)
 		{
@@ -1765,18 +1768,25 @@ void	PhysicsServerExample::initPhysics()
 			m_args[w].m_cs2 = m_threadSupport->createCriticalSection();
 			m_args[w].m_cs3 = m_threadSupport->createCriticalSection();
 			m_args[w].m_csGUI = m_threadSupport->createCriticalSection();
-
+			m_args[w].m_cs->lock();
 			m_args[w].m_cs->setSharedParam(0,eMotionIsUnInitialized);
+			m_args[w].m_cs->unlock();
 			int numMoving = 0;
  			m_args[w].m_positions.resize(numMoving);
 			m_args[w].m_physicsServerPtr = &m_physicsServer;
 			//int index = 0;
 			
 			m_threadSupport->runTask(B3_THREAD_SCHEDULE_TASK, (void*) &this->m_args[w], w);
+			bool isUninitialized = true;	
 			
-			while (m_args[w].m_cs->getSharedParam(0)==eMotionIsUnInitialized)
+			while (isUninitialized)
 			{
+				m_args[w].m_cs->lock();
+				isUninitialized = (m_args[w].m_cs->getSharedParam(0)==eMotionIsUnInitialized);
+				m_args[w].m_cs->unlock();
+#ifdef _WIN32
 				b3Clock::usleep(1000);
+#endif
 			}
 		}
 
@@ -1788,8 +1798,6 @@ void	PhysicsServerExample::initPhysics()
 		
 		m_args[0].m_cs2->lock();
 
-
-		m_isConnected = m_physicsServer.connectSharedMemory( m_guiHelper);
 
 
 

--- a/src/BulletInverseDynamics/MultiBodyTree.cpp
+++ b/src/BulletInverseDynamics/MultiBodyTree.cpp
@@ -331,6 +331,22 @@ int MultiBodyTree::finalize() {
 		rigid_body.m_parent_pos_parent_body_ref = joint.m_parent_pos_parent_child_ref;
 		rigid_body.m_joint_type = joint.m_type;
 
+		int user_int;
+		if (-1 == m_init_cache->getUserInt(index, &user_int)) {
+			return -1;
+		}
+		if (-1 == m_impl->setUserInt(index, user_int)) {
+			return -1;
+		}
+
+		void* user_ptr;
+		if (-1 == m_init_cache->getUserPtr(index, &user_ptr)) {
+			return -1;
+		}
+		if (-1 == m_impl->setUserPtr(index, user_ptr)) {
+			return -1;
+		}
+
 		// Set joint Jacobians. Note that the dimension is always 3x1 here to avoid variable sized
 		// matrices.
 		switch (rigid_body.m_joint_type) {


### PR DESCRIPTION
…creating MultiBodyTree.

The user_ptr and user_int arguments passed to addBody were stored in the cache, but not propagated to the MultiBodyTree when finalizing it.

Thanks to Thomas Buschmann for the fix.