### PR TITLE
pybullet: fix zed_racecar replay

### DIFF
--- a/examples/pybullet/gym/pybullet_envs/baselines/enjoy_pybullet_zed_racecar.py
+++ b/examples/pybullet/gym/pybullet_envs/baselines/enjoy_pybullet_zed_racecar.py
@@ -12,7 +12,7 @@ from baselines import deepq
 
 def main():
     
-    env = RacecarZEDGymEnv(renders=True)
+    env = RacecarZEDGymEnv(renders=True,isDiscrete=True)
     act = deepq.load("racecar_zed_model.pkl")
     print(act)
     while True:


### PR DESCRIPTION
This fixes the zed_racecar replay in pybullet.

enjoy_pybullet_zed_racecar would otherwise fail with the following traceback:

```
Traceback (most recent call last):
  File "enjoy_pybullet_zed_racecar.py", line 32, in <module>
    main()
  File "enjoy_pybullet_zed_racecar.py", line 26, in main
    obs, rew, done, _ = env.step(act(obs[None])[0])
  File "/usr/lib/python3.6/site-packages/pybullet_envs/bullet/racecarZEDGymEnv.py", line 141, in _step
    self._racecar.applyAction(realaction)
  File "/usr/lib/python3.6/site-packages/pybullet_envs/bullet/racecar.py", line 70, in applyAction
    targetVelocity=motorCommands[0]*self.speedMultiplier
IndexError: invalid index to scalar variable.
```
because action (in racecarZedGymEnv._step(action)) only contained an integer (in this case "3") instead of an array (forward, steer).