### PR TITLE
people are actually using this internal API, add a new one and keep o…

### DIFF
--- a/examples/SharedMemory/SharedMemoryInProcessPhysicsC_API.cpp
+++ b/examples/SharedMemory/SharedMemoryInProcessPhysicsC_API.cpp
@@ -273,7 +273,7 @@ B3_SHARED_API	b3PhysicsClientHandle b3CreateInProcessPhysicsServerFromExistingEx
 
 extern int gSharedMemoryKey;
 
-B3_SHARED_API    b3PhysicsClientHandle b3CreateInProcessPhysicsServerFromExistingExampleBrowserAndConnect2(void* guiHelperPtr, int sharedMemoryKey)
+B3_SHARED_API    b3PhysicsClientHandle b3CreateInProcessPhysicsServerFromExistingExampleBrowserAndConnect3(void* guiHelperPtr, int sharedMemoryKey)
 {
     static DummyGUIHelper noGfx;
     
@@ -289,6 +289,13 @@ B3_SHARED_API    b3PhysicsClientHandle b3CreateInProcessPhysicsServerFromExistin
 
 	cl->setSharedMemoryKey(sharedMemoryKey+1);
     cl->connect();
+	//backward compatiblity
+	gSharedMemoryKey = SHARED_MEMORY_KEY;
     return (b3PhysicsClientHandle ) cl;
 }
 
+//backward compatiblity
+B3_SHARED_API    b3PhysicsClientHandle b3CreateInProcessPhysicsServerFromExistingExampleBrowserAndConnect2(void* guiHelperPtr)
+{
+	return b3CreateInProcessPhysicsServerFromExistingExampleBrowserAndConnect3(guiHelperPtr, SHARED_MEMORY_KEY);
+}

--- a/examples/SharedMemory/SharedMemoryInProcessPhysicsC_API.h
+++ b/examples/SharedMemory/SharedMemoryInProcessPhysicsC_API.h
@@ -18,7 +18,9 @@ B3_SHARED_API	b3PhysicsClientHandle b3CreateInProcessPhysicsServerAndConnectMain
 
 B3_SHARED_API	b3PhysicsClientHandle b3CreateInProcessPhysicsServerFromExistingExampleBrowserAndConnect(void* guiHelperPtr);
 //create a shared memory physics server, with a DummyGUIHelper (no graphics)
-B3_SHARED_API    b3PhysicsClientHandle b3CreateInProcessPhysicsServerFromExistingExampleBrowserAndConnect2(void* guiHelperPtr, int sharedMemoryKey);
+B3_SHARED_API    b3PhysicsClientHandle b3CreateInProcessPhysicsServerFromExistingExampleBrowserAndConnect2(void* guiHelperPtr);
+//create a shared memory physics server, with a DummyGUIHelper (no graphics) and allow to set shared memory key
+B3_SHARED_API    b3PhysicsClientHandle b3CreateInProcessPhysicsServerFromExistingExampleBrowserAndConnect3(void* guiHelperPtr, int sharedMemoryKey);
 
 ///ignore the following APIs, they are for internal use for example browser
 void b3InProcessRenderSceneInternal(b3PhysicsClientHandle clientHandle);


### PR DESCRIPTION
…ld one backward compatible

b3CreateInProcessPhysicsServerFromExistingExampleBrowserAndConnect3 is the new one,
b3CreateInProcessPhysicsServerFromExistingExampleBrowserAndConnect2 old