### PR TITLE
Fix alignment macro (mingw)

### DIFF
--- a/src/LinearMath/btScalar.h
+++ b/src/LinearMath/btScalar.h
@@ -61,7 +61,7 @@ inline int btGetVersion()
 #endif
 
 #ifdef _WIN32
-	#if defined(__GNC__)
+	#if defined(__GNUC__)
 		#define SIMD_FORCE_INLINE __inline__ __attribute__((always_inline))
 		#define ATTRIBUTE_ALIGNED16(a)  a __attribute__((aligned(16)))
 		#define ATTRIBUTE_ALIGNED64(a)  a __attribute__((aligned(64)))

--- a/src/LinearMath/btScalar.h
+++ b/src/LinearMath/btScalar.h
@@ -61,16 +61,16 @@ inline int btGetVersion()
 #endif
 
 #ifdef _WIN32
-	#if defined(__MINGW32__) || defined(__CYGWIN__) || (defined (_MSC_VER) && _MSC_VER < 1300)
+	#if defined(__GNC__)
+		#define SIMD_FORCE_INLINE __inline__ __attribute__((always_inline))
+		#define ATTRIBUTE_ALIGNED16(a)  a __attribute__((aligned(16)))
+		#define ATTRIBUTE_ALIGNED64(a)  a __attribute__((aligned(64)))
+		#define ATTRIBUTE_ALIGNED128(a) a __attribute__((aligned(128)))
+	#elif ( defined(_MSC_VER) && _MSC_VER < 1300 )
 		#define SIMD_FORCE_INLINE inline
 		#define ATTRIBUTE_ALIGNED16(a) a
 		#define ATTRIBUTE_ALIGNED64(a) a
 		#define ATTRIBUTE_ALIGNED128(a) a
-	#elif defined(_M_ARM)
-		#define SIMD_FORCE_INLINE __forceinline
-		#define ATTRIBUTE_ALIGNED16(a) __declspec() a
-		#define ATTRIBUTE_ALIGNED64(a) __declspec() a
-		#define ATTRIBUTE_ALIGNED128(a) __declspec () a
 	#else//__MINGW32__
 		//#define BT_HAS_ALIGNED_ALLOCATOR
 		#pragma warning(disable : 4324) // disable padding warning


### PR DESCRIPTION
For ATTRIBUTE_ALIGNED16 macro etc.. 
__attribute__((aligned(16))) is used with gcc on windows