### PR TITLE
added collision-shape parameter to ray test callback

### DIFF
--- a/src/BulletCollision/CollisionDispatch/btCollisionWorld.h
+++ b/src/BulletCollision/CollisionDispatch/btCollisionWorld.h
@@ -186,10 +186,12 @@ public:
 	struct	LocalRayResult
 	{
 		LocalRayResult(const btCollisionObject*	collisionObject, 
+			const btCollisionShape* collisionShape,
 			LocalShapeInfo*	localShapeInfo,
 			const btVector3&		hitNormalLocal,
 			btScalar hitFraction)
 		:m_collisionObject(collisionObject),
+		m_collisionShape(collisionShape),
 		m_localShapeInfo(localShapeInfo),
 		m_hitNormalLocal(hitNormalLocal),
 		m_hitFraction(hitFraction)
@@ -197,6 +199,7 @@ public:
 		}
 
 		const btCollisionObject*		m_collisionObject;
+		const btCollisionShape* m_collisionShape;
 		LocalShapeInfo*			m_localShapeInfo;
 		btVector3				m_hitNormalLocal;
 		btScalar				m_hitFraction;
@@ -208,6 +211,7 @@ public:
 	{
 		btScalar	m_closestHitFraction;
 		const btCollisionObject*		m_collisionObject;
+		const btCollisionShape* m_collisionShape;
 		int	m_collisionFilterGroup;
 		int	m_collisionFilterMask;
 		//@BP Mod - Custom flags, currently used to enable backface culling on tri-meshes, see btRaycastCallback.h. Apply any of the EFlags defined there on m_flags here to invoke.
@@ -224,6 +228,7 @@ public:
 		RayResultCallback()
 			:m_closestHitFraction(btScalar(1.)),
 			m_collisionObject(0),
+			m_collisionShape(0),
 			m_collisionFilterGroup(btBroadphaseProxy::DefaultFilter),
 			m_collisionFilterMask(btBroadphaseProxy::AllFilter),
 			//@BP Mod
@@ -263,6 +268,7 @@ public:
 			
 			m_closestHitFraction = rayResult.m_hitFraction;
 			m_collisionObject = rayResult.m_collisionObject;
+			m_collisionShape = rayResult.m_collisionShape;
 			if (normalInWorldSpace)
 			{
 				m_hitNormalWorld = rayResult.m_hitNormalLocal;
@@ -296,6 +302,7 @@ public:
 		virtual	btScalar	addSingleResult(LocalRayResult& rayResult,bool normalInWorldSpace)
 		{
 			m_collisionObject = rayResult.m_collisionObject;
+			m_collisionShape = rayResult.m_collisionShape;
 			m_collisionObjects.push_back(rayResult.m_collisionObject);
 			btVector3 hitNormalWorld;
 			if (normalInWorldSpace)
@@ -319,12 +326,14 @@ public:
 	struct LocalConvexResult
 	{
 		LocalConvexResult(const btCollisionObject*	hitCollisionObject, 
+			const btCollisionShape* hitCollisionShape,
 			LocalShapeInfo*	localShapeInfo,
 			const btVector3&		hitNormalLocal,
 			const btVector3&		hitPointLocal,
 			btScalar hitFraction
 			)
 		:m_hitCollisionObject(hitCollisionObject),
+		m_hitCollisionShape(hitCollisionShape),
 		m_localShapeInfo(localShapeInfo),
 		m_hitNormalLocal(hitNormalLocal),
 		m_hitPointLocal(hitPointLocal),
@@ -333,6 +342,7 @@ public:
 		}
 
 		const btCollisionObject*		m_hitCollisionObject;
+		const btCollisionShape* m_hitCollisionShape;
 		LocalShapeInfo*			m_localShapeInfo;
 		btVector3				m_hitNormalLocal;
 		btVector3				m_hitPointLocal;

--- a/src/BulletCollision/CollisionShapes/btConcaveShape.cpp
+++ b/src/BulletCollision/CollisionShapes/btConcaveShape.cpp
@@ -25,3 +25,27 @@ btConcaveShape::~btConcaveShape()
 {
 
 }
+
+void btConcaveShape::processRaycastAllTriangles( btTriangleRaycastCallback *callback,
+const btVector3 &raySource, const btVector3 &rayTarget ){
+	btVector3 rayAabbMinLocal = raySource;
+	rayAabbMinLocal.setMin( rayTarget );
+	
+	btVector3 rayAabbMaxLocal = raySource;
+	rayAabbMaxLocal.setMax( rayTarget );
+	
+	processAllTriangles( callback, rayAabbMinLocal, rayAabbMaxLocal );
+}
+
+void btConcaveShape::processConvexcastAllTriangles( btTriangleConvexcastCallback *callback,
+const btVector3 &boxSource, const btVector3 &boxTarget, const btVector3 &boxMin, const btVector3 &boxMax ){
+	btVector3 rayAabbMinLocal = boxSource;
+	rayAabbMinLocal.setMin( boxTarget );
+	rayAabbMinLocal += boxMin;
+	
+	btVector3 rayAabbMaxLocal = boxSource;
+	rayAabbMaxLocal.setMax( boxTarget );
+	rayAabbMaxLocal += boxMax;
+	
+	processAllTriangles( callback, rayAabbMinLocal, rayAabbMaxLocal );
+}

--- a/src/BulletCollision/CollisionShapes/btConcaveShape.h
+++ b/src/BulletCollision/CollisionShapes/btConcaveShape.h
@@ -19,6 +19,7 @@ subject to the following restrictions:
 #include "btCollisionShape.h"
 #include "BulletCollision/BroadphaseCollision/btBroadphaseProxy.h" // for the types
 #include "btTriangleCallback.h"
+#include "BulletCollision/NarrowPhaseCollision/btRaycastCallback.h"
 
 /// PHY_ScalarType enumerates possible scalar types.
 /// See the btStridingMeshInterface or btHeightfieldTerrainShape for its use
@@ -46,6 +47,22 @@ public:
 	virtual ~btConcaveShape();
 
 	virtual void	processAllTriangles(btTriangleCallback* callback,const btVector3& aabbMin,const btVector3& aabbMax) const = 0;
+	
+	/**
+	 * \brief Process all triangles for ray casting.
+	 * \details This is a fix for bad code design in bullet. The default implementation
+	 *          forwards to processAllTriangles and can be overloaded.
+	 */
+	virtual void processRaycastAllTriangles( btTriangleRaycastCallback *callback,
+	const btVector3 &raySource, const btVector3 &rayTarget );
+	/**
+	 * \brief Process all triangles for convex shape casting.
+	 * \details This is a fix for bad code design in bullet. The default implementation
+	 *          forwards to processAllTriangles and can be overloaded.
+	 */
+	virtual void processConvexcastAllTriangles( btTriangleConvexcastCallback *callback,
+	const btVector3 &boxSource, const btVector3 &boxTarget,
+	const btVector3 &boxMin, const btVector3 &boxMax );
 
 	virtual btScalar getMargin() const {
 		return m_collisionMargin;

--- a/src/BulletSoftBody/btSoftMultiBodyDynamicsWorld.cpp
+++ b/src/BulletSoftBody/btSoftMultiBodyDynamicsWorld.cpp
@@ -315,6 +315,7 @@ void	btSoftMultiBodyDynamicsWorld::rayTestSingle(const btTransform& rayFromTrans
 	
 					btCollisionWorld::LocalRayResult rayResult
 						(collisionObject,
+						 collisionShape,
 						 &shapeInfo,
 						 normal,
 						 softResult.fraction);

--- a/src/BulletSoftBody/btSoftRigidDynamicsWorld.cpp
+++ b/src/BulletSoftBody/btSoftRigidDynamicsWorld.cpp
@@ -315,6 +315,7 @@ void	btSoftRigidDynamicsWorld::rayTestSingle(const btTransform& rayFromTrans,con
 	
 					btCollisionWorld::LocalRayResult rayResult
 						(collisionObject,
+						 collisionShape,
 						 &shapeInfo,
 						 normal,
 						 softResult.fraction);


### PR DESCRIPTION
- added collision-shape parameter to ray test callback to figure out  which shape caused the collision (per shape parameter support)
- added triangles test to concave shape aware of the above modification

Basically this addition allows to figure out what collision shape inside a compound shape has been hit by a collision test. This information can be used for example to apply different game script handling depending on what child shape is hit. Avoids the need to split collision objects into smaller collision objects just to track what part of them is hit.