### PR TITLE
Update btOverlappingPairCache.h

### DIFF
--- a/src/BulletCollision/BroadphaseCollision/btOverlappingPairCache.h
+++ b/src/BulletCollision/BroadphaseCollision/btOverlappingPairCache.h
@@ -80,7 +80,7 @@ public:
 
 	virtual void    processAllOverlappingPairs(btOverlapCallback* callback,btDispatcher* dispatcher, const struct btDispatcherInfo& dispatchInfo)
 	{
-		processAllOverlappingPairs(callback, dispatcher, dispatchInfo);
+		processAllOverlappingPairs(callback, dispatcher);
 	}
 	virtual btBroadphasePair* findPair(btBroadphaseProxy* proxy0, btBroadphaseProxy* proxy1) = 0;
 


### PR DESCRIPTION
processAllOverlappingPairs : don't call own method, call the default one without dispatchInfo. Thanks James Dolan, fixes Issue #1750