### PR TITLE
Forced Exploration

### DIFF
--- a/examples/pybullet/gym/pybullet_envs/gym_locomotion_envs.py
+++ b/examples/pybullet/gym/pybullet_envs/gym_locomotion_envs.py
@@ -61,7 +61,7 @@ class WalkerBaseBulletEnv(MJCFBaseBulletEnv):
 		state = self.robot.calc_state()  # also calculates self.joints_at_limit
 
 		alive = float(self.robot.alive_bonus(state[0]+self.robot.initial_z, self.robot.body_rpy[1]))   # state[0] is body height above ground, body_rpy[1] is pitch
-		done = alive < 0
+		done = False
 		if not np.isfinite(state).all():
 			print("~INF~", state)
 			done = True


### PR DESCRIPTION
We force the exploration by setting done to False during the whole episode.

Forced exploration allows to give more information to the AI, which leads to finding the best muscle impulsions / actions even after it fails within one same full episode.