### PR TITLE
Adds a simulation stepped notification

### DIFF
--- a/examples/SharedMemory/PhysicsServerCommandProcessor.cpp
+++ b/examples/SharedMemory/PhysicsServerCommandProcessor.cpp
@@ -10539,6 +10539,10 @@ b3Notification createTransformChangedNotification(int bodyUniqueId, int linkInde
 
 void PhysicsServerCommandProcessor::addTransformChangedNotifications()
 {
+	b3Notification notification;
+	notification.m_notificationType = SIMULATION_STEPPED;
+	m_data->m_pluginManager.addNotification(notification);
+
 	b3AlignedObjectArray<int> usedHandles;
 	m_data->m_bodyHandles.getUsedHandles(usedHandles);
 	for (int i=0;i<usedHandles.size();i++) {

--- a/examples/SharedMemory/SharedMemoryPublic.h
+++ b/examples/SharedMemory/SharedMemoryPublic.h
@@ -7,7 +7,8 @@
 //Please don't replace an existing magic number:
 //instead, only ADD a new one at the top, comment-out previous one
 
-#define SHARED_MEMORY_MAGIC_NUMBER 201807040
+#define SHARED_MEMORY_MAGIC_NUMBER 201809010
+//#define SHARED_MEMORY_MAGIC_NUMBER 201807040
 //#define SHARED_MEMORY_MAGIC_NUMBER 201806150
 //#define SHARED_MEMORY_MAGIC_NUMBER 201806020
 //#define SHARED_MEMORY_MAGIC_NUMBER 201801170
@@ -509,6 +510,7 @@ enum b3NotificationType {
 	LINK_DYNAMICS_CHANGED = 5,
 	VISUAL_SHAPE_CHANGED = 6,
 	TRANSFORM_CHANGED = 7,
+	SIMULATION_STEPPED = 8,
 };
 
 struct b3BodyNotificationArgs


### PR DESCRIPTION
This notification is called when the simulation is stepped, regardless
of whether any objects have moved.

Without this notification, there was no way for a plugin to tell when the simulation had been stepped but nothing had moved, since processNotifications would not be called in that case. The workaround would've been requesting the state and comparing with a previous snapshot after onPostTick, which would be undesirable.