### PR TITLE
added additional parameter to btConcaveShape::processAllTriangles()

### DIFF
--- a/Extras/GIMPACTUtils/btGImpactConvexDecompositionShape.cpp
+++ b/Extras/GIMPACTUtils/btGImpactConvexDecompositionShape.cpp
@@ -210,7 +210,7 @@ btGImpactConvexDecompositionShape::~btGImpactConvexDecompositionShape()
 {
 	delete m_decomposition;
 }
-void btGImpactConvexDecompositionShape::processAllTriangles(btTriangleCallback* callback,const btVector3& aabbMin,const btVector3& aabbMax) const
+void btGImpactConvexDecompositionShape::processAllTriangles(btTriangleCallback* callback,const btVector3& aabbMin,const btVector3& aabbMax,const btCollisionObject* otherObject) const
 {
 
 	int part_count = m_trimeshInterfaces.size();

--- a/Extras/GIMPACTUtils/btGImpactConvexDecompositionShape.h
+++ b/Extras/GIMPACTUtils/btGImpactConvexDecompositionShape.h
@@ -77,7 +77,7 @@ public:
 		return &m_trimeshInterfaces[part];
 	}
 
-	virtual void processAllTriangles(btTriangleCallback* callback,const btVector3& aabbMin,const btVector3& aabbMax) const;
+	virtual void processAllTriangles(btTriangleCallback* callback,const btVector3& aabbMin,const btVector3& aabbMax,const btCollisionObject* otherObject) const;
 
 };
 

--- a/examples/ExampleBrowser/GL_ShapeDrawer.cpp
+++ b/examples/ExampleBrowser/GL_ShapeDrawer.cpp
@@ -752,7 +752,7 @@ void		GL_ShapeDrawer::drawShadow(btScalar* m,const btVector3& extrusion,const bt
 		GlDrawcallback drawCallback;
 		drawCallback.m_wireframe = false;
 
-		concaveMesh->processAllTriangles(&drawCallback,worldBoundsMin,worldBoundsMax);
+		concaveMesh->processAllTriangles(&drawCallback,worldBoundsMin,worldBoundsMax,NULL);
 
 	}
 	glPopMatrix();

--- a/src/BulletCollision/CollisionDispatch/btCollisionWorld.cpp
+++ b/src/BulletCollision/CollisionDispatch/btCollisionWorld.cpp
@@ -485,7 +485,7 @@ void	btCollisionWorld::rayTestSingleInternal(const btTransform& rayFromTrans,con
 				btVector3 rayAabbMaxLocal = rayFromLocal;
 				rayAabbMaxLocal.setMax(rayToLocal);
 
-				concaveShape->processAllTriangles(&rcb,rayAabbMinLocal,rayAabbMaxLocal);
+				concaveShape->processAllTriangles(&rcb,rayAabbMinLocal,rayAabbMaxLocal,NULL);
 			}
 		} else {
 			//			BT_PROFILE("rayTestCompound");
@@ -821,7 +821,7 @@ void	btCollisionWorld::objectQuerySingleInternal(const btConvexShape* castShape,
 					rayAabbMaxLocal.setMax(convexToLocal);
 					rayAabbMinLocal += boxMinLocal;
 					rayAabbMaxLocal += boxMaxLocal;
-					concaveShape->processAllTriangles(&tccb,rayAabbMinLocal,rayAabbMaxLocal);
+					concaveShape->processAllTriangles(&tccb,rayAabbMinLocal,rayAabbMaxLocal,colObjWrap->getCollisionObject());
 				}
 			}
 		} else {
@@ -1503,7 +1503,7 @@ void btCollisionWorld::debugDrawObject(const btTransform& worldTransform, const 
                     btVector3 aabbMin(btScalar(-BT_LARGE_FLOAT),btScalar(-BT_LARGE_FLOAT),btScalar(-BT_LARGE_FLOAT));
 
                     DebugDrawcallback drawCallback(getDebugDrawer(),worldTransform,color);
-                    concaveMesh->processAllTriangles(&drawCallback,aabbMin,aabbMax);
+                    concaveMesh->processAllTriangles(&drawCallback,aabbMin,aabbMax,NULL);
 
                 }
 

--- a/src/BulletCollision/CollisionDispatch/btConvexConcaveCollisionAlgorithm.cpp
+++ b/src/BulletCollision/CollisionDispatch/btConvexConcaveCollisionAlgorithm.cpp
@@ -280,7 +280,7 @@ void btConvexConcaveCollisionAlgorithm::processCollision (const btCollisionObjec
 
 				m_btConvexTriangleCallback.m_manifoldPtr->setBodies(convexBodyWrap->getCollisionObject(),triBodyWrap->getCollisionObject());
 
-				concaveShape->processAllTriangles( &m_btConvexTriangleCallback,m_btConvexTriangleCallback.getAabbMin(),m_btConvexTriangleCallback.getAabbMax());
+				concaveShape->processAllTriangles( &m_btConvexTriangleCallback,m_btConvexTriangleCallback.getAabbMin(),m_btConvexTriangleCallback.getAabbMax(),convexBodyWrap->getCollisionObject());
 			
 				resultOut->refreshContactPoints();
 
@@ -394,7 +394,7 @@ btScalar btConvexConcaveCollisionAlgorithm::calculateTimeOfImpact(btCollisionObj
 		
 		if (triangleMesh)
 		{
-			triangleMesh->processAllTriangles(&raycastCallback,rayAabbMin,rayAabbMax);
+			triangleMesh->processAllTriangles(&raycastCallback,rayAabbMin,rayAabbMax,convexbody);
 		}
 	
 

--- a/src/BulletCollision/CollisionDispatch/btInternalEdgeUtility.cpp
+++ b/src/BulletCollision/CollisionDispatch/btInternalEdgeUtility.cpp
@@ -372,7 +372,7 @@ void btGenerateInternalEdgeInfo (btBvhTriangleMeshShape*trimeshShape, btTriangle
 			connectivityProcessor.m_triangleVerticesA = &triangleVerts[0];
 			connectivityProcessor.m_triangleInfoMap  = triangleInfoMap;
 
-			trimeshShape->processAllTriangles(&connectivityProcessor,aabbMin,aabbMax);
+			trimeshShape->processAllTriangles(&connectivityProcessor,aabbMin,aabbMax,NULL);
 		}
 
 	}

--- a/src/BulletCollision/CollisionShapes/btBvhTriangleMeshShape.cpp
+++ b/src/BulletCollision/CollisionShapes/btBvhTriangleMeshShape.cpp
@@ -229,12 +229,12 @@ void	btBvhTriangleMeshShape::performConvexcast (btTriangleCallback* callback, co
 }
 
 //perform bvh tree traversal and report overlapping triangles to 'callback'
-void	btBvhTriangleMeshShape::processAllTriangles(btTriangleCallback* callback,const btVector3& aabbMin,const btVector3& aabbMax) const
+void	btBvhTriangleMeshShape::processAllTriangles(btTriangleCallback* callback,const btVector3& aabbMin,const btVector3& aabbMax,const btCollisionObject* otherObject) const
 {
 
 #ifdef DISABLE_BVH
 	//brute force traverse all triangles
-	btTriangleMeshShape::processAllTriangles(callback,aabbMin,aabbMax);
+	btTriangleMeshShape::processAllTriangles(callback,aabbMin,aabbMax,otherObject);
 #else
 
 	//first get all the nodes

--- a/src/BulletCollision/CollisionShapes/btBvhTriangleMeshShape.h
+++ b/src/BulletCollision/CollisionShapes/btBvhTriangleMeshShape.h
@@ -67,7 +67,7 @@ public:
 	void performRaycast (btTriangleCallback* callback, const btVector3& raySource, const btVector3& rayTarget);
 	void performConvexcast (btTriangleCallback* callback, const btVector3& boxSource, const btVector3& boxTarget, const btVector3& boxMin, const btVector3& boxMax);
 
-	virtual void	processAllTriangles(btTriangleCallback* callback,const btVector3& aabbMin,const btVector3& aabbMax) const;
+	virtual void	processAllTriangles(btTriangleCallback* callback,const btVector3& aabbMin,const btVector3& aabbMax,const btCollisionObject* otherObject) const;
 
 	void	refitTree(const btVector3& aabbMin,const btVector3& aabbMax);
 

--- a/src/BulletCollision/CollisionShapes/btConcaveShape.h
+++ b/src/BulletCollision/CollisionShapes/btConcaveShape.h
@@ -31,6 +31,7 @@ typedef enum PHY_ScalarType {
 	PHY_UCHAR
 } PHY_ScalarType;
 
+ATTRIBUTE_ALIGNED16(class)	btCollisionObject;
 ///The btConcaveShape class provides an interface for non-moving (static) concave shapes.
 ///It has been implemented by the btStaticPlaneShape, btBvhTriangleMeshShape and btHeightfieldTerrainShape.
 ATTRIBUTE_ALIGNED16(class) btConcaveShape : public btCollisionShape
@@ -45,7 +46,7 @@ public:
 
 	virtual ~btConcaveShape();
 
-	virtual void	processAllTriangles(btTriangleCallback* callback,const btVector3& aabbMin,const btVector3& aabbMax) const = 0;
+	virtual void	processAllTriangles(btTriangleCallback* callback,const btVector3& aabbMin,const btVector3& aabbMax,const btCollisionObject* otherObject) const = 0;
 
 	virtual btScalar getMargin() const {
 		return m_collisionMargin;

--- a/src/BulletCollision/CollisionShapes/btEmptyShape.h
+++ b/src/BulletCollision/CollisionShapes/btEmptyShape.h
@@ -58,7 +58,7 @@ public:
 		return "Empty";
 	}
 
-	virtual void processAllTriangles(btTriangleCallback* ,const btVector3& ,const btVector3& ) const
+	virtual void processAllTriangles(btTriangleCallback* ,const btVector3& ,const btVector3& ,const btCollisionObject* otherObject ) const
 	{
 	}
 

--- a/src/BulletCollision/CollisionShapes/btHeightfieldTerrainShape.cpp
+++ b/src/BulletCollision/CollisionShapes/btHeightfieldTerrainShape.cpp
@@ -278,7 +278,7 @@ void btHeightfieldTerrainShape::quantizeWithClamp(int* out, const btVector3& poi
     - convert input aabb to a range of heightfield grid points (quantize)
     - iterate over all triangles in that subset of the grid
  */
-void	btHeightfieldTerrainShape::processAllTriangles(btTriangleCallback* callback,const btVector3& aabbMin,const btVector3& aabbMax) const
+void	btHeightfieldTerrainShape::processAllTriangles(btTriangleCallback* callback,const btVector3& aabbMin,const btVector3& aabbMax,const btCollisionObject* otherObject) const
 {
 	// scale down the input aabb's so they are in local (non-scaled) coordinates
 	btVector3	localAabbMin = aabbMin*btVector3(1.f/m_localScaling[0],1.f/m_localScaling[1],1.f/m_localScaling[2]);

--- a/src/BulletCollision/CollisionShapes/btHeightfieldTerrainShape.h
+++ b/src/BulletCollision/CollisionShapes/btHeightfieldTerrainShape.h
@@ -151,7 +151,7 @@ public:
 
 	virtual void getAabb(const btTransform& t,btVector3& aabbMin,btVector3& aabbMax) const;
 
-	virtual void	processAllTriangles(btTriangleCallback* callback,const btVector3& aabbMin,const btVector3& aabbMax) const;
+	virtual void	processAllTriangles(btTriangleCallback* callback,const btVector3& aabbMin,const btVector3& aabbMax,const btCollisionObject* otherObject) const;
 
 	virtual void	calculateLocalInertia(btScalar mass,btVector3& inertia) const;
 

--- a/src/BulletCollision/CollisionShapes/btScaledBvhTriangleMeshShape.cpp
+++ b/src/BulletCollision/CollisionShapes/btScaledBvhTriangleMeshShape.cpp
@@ -51,7 +51,7 @@ public:
 	}
 };
 
-void	btScaledBvhTriangleMeshShape::processAllTriangles(btTriangleCallback* callback,const btVector3& aabbMin,const btVector3& aabbMax) const
+void	btScaledBvhTriangleMeshShape::processAllTriangles(btTriangleCallback* callback,const btVector3& aabbMin,const btVector3& aabbMax,const btCollisionObject* otherObject) const
 {
 	btScaledTriangleCallback scaledCallback(callback,m_localScaling);
 	
@@ -70,7 +70,7 @@ void	btScaledBvhTriangleMeshShape::processAllTriangles(btTriangleCallback* callb
 	scaledAabbMax[3] = 0.f;
 	
 	
-	m_bvhTriMeshShape->processAllTriangles(&scaledCallback,scaledAabbMin,scaledAabbMax);
+	m_bvhTriMeshShape->processAllTriangles(&scaledCallback,scaledAabbMin,scaledAabbMax,otherObject);
 }
 
 

--- a/src/BulletCollision/CollisionShapes/btScaledBvhTriangleMeshShape.h
+++ b/src/BulletCollision/CollisionShapes/btScaledBvhTriangleMeshShape.h
@@ -44,7 +44,7 @@ public:
 	virtual const btVector3& getLocalScaling() const;
 	virtual void	calculateLocalInertia(btScalar mass,btVector3& inertia) const;
 
-	virtual void	processAllTriangles(btTriangleCallback* callback,const btVector3& aabbMin,const btVector3& aabbMax) const;
+	virtual void	processAllTriangles(btTriangleCallback* callback,const btVector3& aabbMin,const btVector3& aabbMax,const btCollisionObject* otherObject) const;
 
 	btBvhTriangleMeshShape*	getChildShape()
 	{

--- a/src/BulletCollision/CollisionShapes/btSdfCollisionShape.cpp
+++ b/src/BulletCollision/CollisionShapes/btSdfCollisionShape.cpp
@@ -78,7 +78,7 @@ btScalar	btSdfCollisionShape::getMargin() const
 	return m_data->m_margin;
 }
 
-void	btSdfCollisionShape::processAllTriangles(btTriangleCallback* callback,const btVector3& aabbMin,const btVector3& aabbMax) const
+void	btSdfCollisionShape::processAllTriangles(btTriangleCallback* callback,const btVector3& aabbMin,const btVector3& aabbMax,const btCollisionObject* otherObject) const
 {
 	//not yet
 }

--- a/src/BulletCollision/CollisionShapes/btSdfCollisionShape.h
+++ b/src/BulletCollision/CollisionShapes/btSdfCollisionShape.h
@@ -22,7 +22,7 @@ public:
 	virtual void	setMargin(btScalar margin);
 	virtual btScalar	getMargin() const;
 
-	virtual void	processAllTriangles(btTriangleCallback* callback,const btVector3& aabbMin,const btVector3& aabbMax) const;
+	virtual void	processAllTriangles(btTriangleCallback* callback,const btVector3& aabbMin,const btVector3& aabbMax,const btCollisionObject* otherObject) const;
 
 	bool queryPoint(const btVector3& ptInSDF, btScalar& distOut, btVector3& normal);
 };

--- a/src/BulletCollision/CollisionShapes/btStaticPlaneShape.cpp
+++ b/src/BulletCollision/CollisionShapes/btStaticPlaneShape.cpp
@@ -55,7 +55,7 @@ void btStaticPlaneShape::getAabb(const btTransform& t,btVector3& aabbMin,btVecto
 
 
 
-void	btStaticPlaneShape::processAllTriangles(btTriangleCallback* callback,const btVector3& aabbMin,const btVector3& aabbMax) const
+void	btStaticPlaneShape::processAllTriangles(btTriangleCallback* callback,const btVector3& aabbMin,const btVector3& aabbMax,const btCollisionObject* otherObject) const
 {
 
 	btVector3 halfExtents = (aabbMax - aabbMin) * btScalar(0.5);

--- a/src/BulletCollision/CollisionShapes/btStaticPlaneShape.h
+++ b/src/BulletCollision/CollisionShapes/btStaticPlaneShape.h
@@ -40,7 +40,7 @@ public:
 
 	virtual void getAabb(const btTransform& t,btVector3& aabbMin,btVector3& aabbMax) const;
 
-	virtual void	processAllTriangles(btTriangleCallback* callback,const btVector3& aabbMin,const btVector3& aabbMax) const;
+	virtual void	processAllTriangles(btTriangleCallback* callback,const btVector3& aabbMin,const btVector3& aabbMax,const btCollisionObject* otherObject) const;
 
 	virtual void	calculateLocalInertia(btScalar mass,btVector3& inertia) const;
 

--- a/src/BulletCollision/CollisionShapes/btTriangleMeshShape.cpp
+++ b/src/BulletCollision/CollisionShapes/btTriangleMeshShape.cpp
@@ -141,7 +141,7 @@ const btVector3& btTriangleMeshShape::getLocalScaling() const
 
 
 
-void	btTriangleMeshShape::processAllTriangles(btTriangleCallback* callback,const btVector3& aabbMin,const btVector3& aabbMax) const
+void	btTriangleMeshShape::processAllTriangles(btTriangleCallback* callback,const btVector3& aabbMin,const btVector3& aabbMax,const btCollisionObject* otherObject) const
 {
 		struct FilteredCallback : public btInternalTriangleIndexCallback
 	{
@@ -197,7 +197,7 @@ btVector3 btTriangleMeshShape::localGetSupportingVertex(const btVector3& vec) co
 
 	btVector3 aabbMax(btScalar(BT_LARGE_FLOAT),btScalar(BT_LARGE_FLOAT),btScalar(BT_LARGE_FLOAT));
 	
-	processAllTriangles(&supportCallback,-aabbMax,aabbMax);
+	processAllTriangles(&supportCallback,-aabbMax,aabbMax,NULL);
 		
 	supportVertex = supportCallback.GetSupportVertexLocal();
 

--- a/src/BulletCollision/CollisionShapes/btTriangleMeshShape.h
+++ b/src/BulletCollision/CollisionShapes/btTriangleMeshShape.h
@@ -49,7 +49,7 @@ public:
 
 	virtual void getAabb(const btTransform& t,btVector3& aabbMin,btVector3& aabbMax) const;
 
-	virtual void	processAllTriangles(btTriangleCallback* callback,const btVector3& aabbMin,const btVector3& aabbMax) const;
+	virtual void	processAllTriangles(btTriangleCallback* callback,const btVector3& aabbMin,const btVector3& aabbMax,const btCollisionObject* otherObject) const;
 
 	virtual void	calculateLocalInertia(btScalar mass,btVector3& inertia) const;
 

--- a/src/BulletCollision/Gimpact/btGImpactCollisionAlgorithm.cpp
+++ b/src/BulletCollision/Gimpact/btGImpactCollisionAlgorithm.cpp
@@ -861,7 +861,7 @@ void btGImpactCollisionAlgorithm::gimpact_vs_concave(
 	btVector3 minAABB,maxAABB;
 	shape0->getAabb(gimpactInConcaveSpace,minAABB,maxAABB);
 
-	shape1->processAllTriangles(&tricallback,minAABB,maxAABB);
+	shape1->processAllTriangles(&tricallback,minAABB,maxAABB,body0Wrap->getCollisionObject());
 
 }
 

--- a/src/BulletCollision/Gimpact/btGImpactShape.cpp
+++ b/src/BulletCollision/Gimpact/btGImpactShape.cpp
@@ -224,7 +224,7 @@ void btGImpactMeshShapePart::processAllTrianglesRay(btTriangleCallback* callback
 	unlockChildShapes();
 }
 
-void btGImpactMeshShapePart::processAllTriangles(btTriangleCallback* callback,const btVector3& aabbMin,const btVector3& aabbMax) const
+void btGImpactMeshShapePart::processAllTriangles(btTriangleCallback* callback,const btVector3& aabbMin,const btVector3& aabbMax,const btCollisionObject* otherObject) const
 {
 	lockChildShapes();
 	btAABB box;
@@ -252,12 +252,12 @@ void btGImpactMeshShapePart::processAllTriangles(btTriangleCallback* callback,co
 
 }
 
-void btGImpactMeshShape::processAllTriangles(btTriangleCallback* callback,const btVector3& aabbMin,const btVector3& aabbMax) const
+void btGImpactMeshShape::processAllTriangles(btTriangleCallback* callback,const btVector3& aabbMin,const btVector3& aabbMax,const btCollisionObject* otherObject) const
 {
 	int i = m_mesh_parts.size();
 	while(i--)
 	{
-		m_mesh_parts[i]->processAllTriangles(callback,aabbMin,aabbMax);
+		m_mesh_parts[i]->processAllTriangles(callback,aabbMin,aabbMax,otherObject);
 	}
 }
 

--- a/src/BulletCollision/Gimpact/btGImpactShape.h
+++ b/src/BulletCollision/Gimpact/btGImpactShape.h
@@ -284,7 +284,7 @@ public:
 	/*!
 	It gives the triangles in local space
 	*/
-	virtual void	processAllTriangles(btTriangleCallback* callback,const btVector3& aabbMin,const btVector3& aabbMax) const
+	virtual void	processAllTriangles(btTriangleCallback* callback,const btVector3& aabbMin,const btVector3& aabbMax,const btCollisionObject* otherObject) const
 	{
         (void) callback; (void) aabbMin; (void) aabbMax;
 	}
@@ -874,7 +874,7 @@ public:
     	return (int)m_primitive_manager.m_part;
     }
 
-	virtual void	processAllTriangles(btTriangleCallback* callback,const btVector3& aabbMin,const btVector3& aabbMax) const;
+	virtual void	processAllTriangles(btTriangleCallback* callback,const btVector3& aabbMin,const btVector3& aabbMax,const btCollisionObject* otherObject) const;
 	virtual void	processAllTrianglesRay(btTriangleCallback* callback,const btVector3& rayFrom,const btVector3& rayTo) const;
 };
 
@@ -1130,7 +1130,7 @@ public:
 	/*!
 	It gives the triangles in local space
 	*/
-	virtual void	processAllTriangles(btTriangleCallback* callback,const btVector3& aabbMin,const btVector3& aabbMax) const;
+	virtual void	processAllTriangles(btTriangleCallback* callback,const btVector3& aabbMin,const btVector3& aabbMax,const btCollisionObject* otherObject) const;
 
 	virtual void	processAllTrianglesRay (btTriangleCallback* callback,const btVector3& rayFrom,const btVector3& rayTo) const;
 

--- a/src/BulletSoftBody/btSoftBodyConcaveCollisionAlgorithm.cpp
+++ b/src/BulletSoftBody/btSoftBodyConcaveCollisionAlgorithm.cpp
@@ -215,6 +215,7 @@ void btSoftBodyConcaveCollisionAlgorithm::processCollision (const btCollisionObj
 
 	//btCollisionObject* convexBody = m_isSwapped ? body1 : body0;
 	const btCollisionObjectWrapper* triBody = m_isSwapped ? body0Wrap : body1Wrap;
+	const btCollisionObjectWrapper* otherBody = m_isSwapped ? body1Wrap : body0Wrap;
 
 	if (triBody->getCollisionShape()->isConcave())
 	{
@@ -231,7 +232,7 @@ void btSoftBodyConcaveCollisionAlgorithm::processCollision (const btCollisionObj
 			m_btSoftBodyTriangleCallback.setTimeStepAndCounters(collisionMarginTriangle,triBody,dispatchInfo,resultOut);
 
 		
-			concaveShape->processAllTriangles( &m_btSoftBodyTriangleCallback,m_btSoftBodyTriangleCallback.getAabbMin(),m_btSoftBodyTriangleCallback.getAabbMax());
+			concaveShape->processAllTriangles( &m_btSoftBodyTriangleCallback,m_btSoftBodyTriangleCallback.getAabbMin(),m_btSoftBodyTriangleCallback.getAabbMax(),otherBody->getCollisionObject());
 
 			//	resultOut->refreshContactPoints();
 
@@ -341,7 +342,7 @@ btScalar btSoftBodyConcaveCollisionAlgorithm::calculateTimeOfImpact(btCollisionO
 
 		if (triangleMesh)
 		{
-			triangleMesh->processAllTriangles(&raycastCallback,rayAabbMin,rayAabbMax);
+			triangleMesh->processAllTriangles(&raycastCallback,rayAabbMin,rayAabbMax,convexbody);
 		}
 
 

--- a/src/BulletSoftBody/btSoftBodyInternals.h
+++ b/src/BulletSoftBody/btSoftBodyInternals.h
@@ -62,7 +62,7 @@ public:
 
 	}
 
-	void	processAllTriangles(btTriangleCallback* /*callback*/,const btVector3& /*aabbMin*/,const btVector3& /*aabbMax*/) const
+	void	processAllTriangles(btTriangleCallback* /*callback*/,const btVector3& /*aabbMin*/,const btVector3& /*aabbMax*/,const btCollisionObject* /*otherObject*/) const
 	{
 		//not yet
 		btAssert(0);


### PR DESCRIPTION
Added an additional parameter to btConcaveShape::processAllTriangles() giving information about the other colliding object when appropriate.

In our case, we need to access the rigid body AABB (in addition to the sub-shapes AABB given in the original parameters) in order to have a consistant level-of-detail selection of the terrain chunks we use to perform the collision with (we perform that selection according to the size of the object, this allows us to have a more refined terrain collision mesh resolution when using small objects such as cars, and rougher resolution when colliding big objects such as aircraft - otherwise we end up testing way too many triangles, or we encounter LOD switches in subsequent frames, which is not good either since not giving a consistant collision mesh for the terrain).