### PR TITLE
Uses dlmopen() instead of dlopen() in b3PluginManager.cpp. This allow…

### DIFF
--- a/examples/SharedMemory/b3PluginManager.cpp
+++ b/examples/SharedMemory/b3PluginManager.cpp
@@ -22,9 +22,9 @@
     typedef void*                   B3_DYNLIB_HANDLE;
 
 #ifdef __APPLE__
-    #define B3_DYNLIB_OPEN(path)  dlmopen(LM_ID_NEWLM, path, RTLD_LAZY)
-#else
     #define B3_DYNLIB_OPEN(path)  dlopen(path, RTLD_NOW | RTLD_GLOBAL)
+#else
+    #define B3_DYNLIB_OPEN(path)  dlmopen(LM_ID_NEWLM, path, RTLD_LAZY)
 #endif
     #define B3_DYNLIB_CLOSE       dlclose
     #define B3_DYNLIB_IMPORT      dlsym

--- a/examples/SharedMemory/b3PluginManager.cpp
+++ b/examples/SharedMemory/b3PluginManager.cpp
@@ -21,7 +21,11 @@
     
     typedef void*                   B3_DYNLIB_HANDLE;
 
+#ifdef __APPLE__
     #define B3_DYNLIB_OPEN(path)  dlmopen(LM_ID_NEWLM, path, RTLD_LAZY)
+#else
+    #define B3_DYNLIB_OPEN(path)  dlopen(path, RTLD_NOW | RTLD_GLOBAL)
+#endif
     #define B3_DYNLIB_CLOSE       dlclose
     #define B3_DYNLIB_IMPORT      dlsym
 #endif

--- a/examples/SharedMemory/b3PluginManager.cpp
+++ b/examples/SharedMemory/b3PluginManager.cpp
@@ -21,7 +21,7 @@
     
     typedef void*                   B3_DYNLIB_HANDLE;
 
-    #define B3_DYNLIB_OPEN(path)  dlopen(path, RTLD_NOW | RTLD_GLOBAL)
+    #define B3_DYNLIB_OPEN(path)  dlmopen(LM_ID_NEWLM, path, RTLD_LAZY)
     #define B3_DYNLIB_CLOSE       dlclose
     #define B3_DYNLIB_IMPORT      dlsym
 #endif


### PR DESCRIPTION
Uses dlmopen() instead of dlopen() in b3PluginManager.cpp.
This allows plugins to be loaded in a separate namespace, avoiding symbol conflicts.