### PR TITLE
Change b3GetLinkState to use numLinks in status handle

### DIFF
--- a/examples/SharedMemory/PhysicsClientC_API.cpp
+++ b/examples/SharedMemory/PhysicsClientC_API.cpp
@@ -1008,10 +1008,10 @@ B3_SHARED_API int b3GetLinkState(b3PhysicsClientHandle physClient, b3SharedMemor
   int bodyIndex = status->m_sendActualStateArgs.m_bodyUniqueId;
   b3Assert(bodyIndex>=0);
   b3Assert(linkIndex >= 0);
-  int numJoints = b3GetNumJoints(physClient,bodyIndex);
-  b3Assert(linkIndex < numJoints);
+  int numLinks = status->m_sendActualStateArgs.m_numLinks;
+  b3Assert(linkIndex < numLinks);
 
-  if ((bodyIndex>=0) && (linkIndex >= 0) && linkIndex < numJoints)
+  if ((bodyIndex>=0) && (linkIndex >= 0) && linkIndex < numLinks)
   {
 	  b3Transform wlf,com,inertial;
 	


### PR DESCRIPTION
Changes the b3GetLinkState function to use numLinks from the
SharedMemoryStatus returned from RequestActualState instead of the
cached number of link value returned by b3GetNumJoints.

The cached value can be outdated when a new body is added and
SyncBodyInfo isn't called, while using the value in the status is always
up-to-date.