### PR TITLE
Remove unneeded keyword `register`

### DIFF
--- a/src/LinearMath/btAlignedObjectArray.h
+++ b/src/LinearMath/btAlignedObjectArray.h
@@ -38,13 +38,6 @@ subject to the following restrictions:
 #include <new>  //for placement new
 #endif          //BT_USE_PLACEMENT_NEW
 
-// The register keyword is deprecated in C++11 so don't use it.
-#if __cplusplus > 199711L
-#define BT_REGISTER
-#else
-#define BT_REGISTER register
-#endif
-
 ///The btAlignedObjectArray template class uses a subset of the stl::vector interface for its methods
 ///It is developed to replace stl::vector to avoid portability issues, including STL alignment issues to add SIMD/SSE data
 template <typename T>
@@ -209,7 +202,7 @@ public:
 
 	SIMD_FORCE_INLINE void resize(int newsize, const T& fillData = T())
 	{
-		const BT_REGISTER int curSize = size();
+		const int curSize = size();
 
 		if (newsize < curSize)
 		{
@@ -236,7 +229,7 @@ public:
 	}
 	SIMD_FORCE_INLINE T& expandNonInitializing()
 	{
-		const BT_REGISTER int sz = size();
+		const int sz = size();
 		if (sz == capacity())
 		{
 			reserve(allocSize(size()));
@@ -248,7 +241,7 @@ public:
 
 	SIMD_FORCE_INLINE T& expand(const T& fillValue = T())
 	{
-		const BT_REGISTER int sz = size();
+		const int sz = size();
 		if (sz == capacity())
 		{
 			reserve(allocSize(size()));
@@ -263,7 +256,7 @@ public:
 
 	SIMD_FORCE_INLINE void push_back(const T& _Val)
 	{
-		const BT_REGISTER int sz = size();
+		const int sz = size();
 		if (sz == capacity())
 		{
 			reserve(allocSize(size()));


### PR DESCRIPTION
Why is it unneeded?

C++11 has deprecated it,
c++17 removed.

So, how about older (c++98)?

According to Herb Sutter, it is as meaningful
as whitespace.

http://www.drdobbs.com/keywords-that-arent-or-comments-by-anoth/184403859