### PR TITLE
pip egl install: added btThreads.cpp

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -463,15 +463,16 @@ egl_renderer_sources = \
 +["src/BulletCollision/CollisionShapes/btConvexInternalShape.cpp"]\
 +["src/Bullet3Common/b3Logging.cpp"]\
 +["src/LinearMath/btAlignedAllocator.cpp"]\
-+["src/LinearMath/btGeometryUtil.cpp"]\
 +["src/LinearMath/btConvexHull.cpp"]\
-+["src/LinearMath/btConvexHullComputer.cpp"]\
++["src/LinearMath/btConvexHullComputer.cpp"] \
++["src/LinearMath/btGeometryUtil.cpp"]\
++["src/LinearMath/btQuickprof.cpp"] \
++["src/LinearMath/btThreads.cpp"] \
 +["src/Bullet3Common/b3AlignedAllocator.cpp"] \
 +["examples/ThirdPartyLibs/glad/gl.c"]\
 +["examples/OpenGLWindow/GLInstancingRenderer.cpp"]\
 +["examples/OpenGLWindow/GLRenderToTexture.cpp"] \
-+["examples/OpenGLWindow/LoadShader.cpp"] \
-+["src/LinearMath/btQuickprof.cpp"]
++["examples/OpenGLWindow/LoadShader.cpp"]
 
 if 'BT_USE_EGL' in CXX_FLAGS:
     sources += ['examples/ThirdPartyLibs/glad/egl.c']


### PR DESCRIPTION
This fixes the following error I was getting (also sorts files in alphabetical order):
```b3Warning[examples/SharedMemory/b3PluginManager.cpp,275]:
Error: ~/bullet3/examples/pybullet/gym/eglRenderer.cpython-35m-x86_64-linux-gnu.so: undefined symbol: _Z23btGetCurrentThreadIndexv```
