### PR TITLE
Change confusing variable name in btDiscreteDynamicsWorldMT API.

### DIFF
--- a/src/BulletDynamics/Dynamics/btDiscreteDynamicsWorldMt.cpp
+++ b/src/BulletDynamics/Dynamics/btDiscreteDynamicsWorldMt.cpp
@@ -147,10 +147,10 @@ void btConstraintSolverPoolMt::reset()
 
 btDiscreteDynamicsWorldMt::btDiscreteDynamicsWorldMt(btDispatcher* dispatcher,
 													 btBroadphaseInterface* pairCache,
-													 btConstraintSolverPoolMt* constraintSolver,
+													 btConstraintSolverPoolMt* solverPool,
 													 btConstraintSolver* constraintSolverMt,
 													 btCollisionConfiguration* collisionConfiguration)
-	: btDiscreteDynamicsWorld(dispatcher, pairCache, constraintSolver, collisionConfiguration)
+	: btDiscreteDynamicsWorld(dispatcher, pairCache, solverPool, collisionConfiguration)
 {
 	if (m_ownsIslandManager)
 	{

--- a/src/BulletDynamics/Dynamics/btDiscreteDynamicsWorldMt.h
+++ b/src/BulletDynamics/Dynamics/btDiscreteDynamicsWorldMt.h
@@ -120,7 +120,7 @@ public:
 
 	btDiscreteDynamicsWorldMt(btDispatcher * dispatcher,
 							  btBroadphaseInterface * pairCache,
-							  btConstraintSolverPoolMt * constraintSolver,  // Note this should be a solver-pool for multi-threading
+							  btConstraintSolverPoolMt * solverPool,        // Note this should be a solver-pool for multi-threading
 							  btConstraintSolver * constraintSolverMt,      // single multi-threaded solver for large islands (or NULL)
 							  btCollisionConfiguration * collisionConfiguration);
 	virtual ~btDiscreteDynamicsWorldMt();


### PR DESCRIPTION
The third parameter is confusingly named. The constructor takes one pool, and one solver, not two solvers.