### PR TITLE
initialize m_numUserCollisionShapes correctly for b3InitRemoveBodyCom…

### DIFF
--- a/examples/SharedMemory/PhysicsClientC_API.cpp
+++ b/examples/SharedMemory/PhysicsClientC_API.cpp
@@ -2989,6 +2989,7 @@ B3_SHARED_API b3SharedMemoryCommandHandle b3InitRemoveBodyCommand(b3PhysicsClien
 	command->m_updateFlags = BODY_DELETE_FLAG;
 	command->m_removeObjectArgs.m_numBodies = 1;
 	command->m_removeObjectArgs.m_bodyUniqueIds[0] = bodyUniqueId;
+	command->m_removeObjectArgs.m_numUserCollisionShapes = 0;
 	command->m_removeObjectArgs.m_numUserConstraints = 0;
 
 	return (b3SharedMemoryCommandHandle)command;


### PR DESCRIPTION
Due to the missing initialization of the variable
`m_numUserCollisionShapes`
the "collisionShape used" check in PhysicsServerCommandProcessor.cpp:8956 was executed randomly.