### PR TITLE
Enable deferred collide for btDbvtBroadphase

### DIFF
--- a/src/BulletCollision/BroadphaseCollision/btDbvtBroadphase.cpp
+++ b/src/BulletCollision/BroadphaseCollision/btDbvtBroadphase.cpp
@@ -130,7 +130,7 @@ struct btDbvtTreeCollider : btDbvt::ICollide
 //
 btDbvtBroadphase::btDbvtBroadphase(btOverlappingPairCache* paircache)
 {
-	m_deferedcollide = false;
+	m_deferedcollide = true;
 	m_needcleanup = true;
 	m_releasepaircache = (paircache != 0) ? false : true;
 	m_prediction = 0;


### PR DESCRIPTION
See post on forum: https://pybullet.org/Bullet/phpBB3/viewtopic.php?f=9&t=12571

It is significantly faster when many objects are active and moving.

It everything is sleeping it is probably slightly slower, but I don't think it makes sense to optimize for the fast case--