### PR TITLE
Update the installation of the bullet_robotics package

### DIFF
--- a/Extras/BulletRobotics/CMakeLists.txt
+++ b/Extras/BulletRobotics/CMakeLists.txt
@@ -8,72 +8,130 @@ INCLUDE_DIRECTORIES(
 		${BULLET_PHYSICS_SOURCE_DIR}/examples/ThirdPartyLibs/clsocket/src
 )
 
-SET(BulletRobotics_SRCS
-		../../examples/SharedMemory/plugins/collisionFilterPlugin/collisionFilterPlugin.cpp
-		../../examples/SharedMemory/plugins/pdControlPlugin/pdControlPlugin.cpp
-		../../examples/SharedMemory/plugins/pdControlPlugin/pdControlPlugin.h
-		../../examples/SharedMemory/b3RobotSimulatorClientAPI_NoGUI.cpp
-		../../examples/SharedMemory/b3RobotSimulatorClientAPI_NoGUI.h
-		../../examples/SharedMemory/b3RobotSimulatorClientAPI_NoDirect.cpp
-		../../examples/SharedMemory/b3RobotSimulatorClientAPI_NoDirect.h
-		../../examples/SharedMemory/IKTrajectoryHelper.cpp
-		../../examples/SharedMemory/IKTrajectoryHelper.h
-		../../examples/SharedMemory/plugins/tinyRendererPlugin/tinyRendererPlugin.cpp
-		../../examples/SharedMemory/plugins/tinyRendererPlugin/TinyRendererVisualShapeConverter.cpp
-		../../examples/OpenGLWindow/SimpleCamera.cpp
-		../../examples/OpenGLWindow/SimpleCamera.h
+SET(BulletRobotics_INCLUDES
+  ../../examples/CommonInterfaces/Common2dCanvasInterface.h
+  ../../examples/CommonInterfaces/CommonCallbacks.h
+  ../../examples/CommonInterfaces/CommonCameraInterface.h
+  ../../examples/CommonInterfaces/CommonExampleInterface.h
+  ../../examples/CommonInterfaces/CommonFileIOInterface.h
+  ../../examples/CommonInterfaces/CommonGraphicsAppInterface.h
+  ../../examples/CommonInterfaces/CommonGUIHelperInterface.h
+  ../../examples/CommonInterfaces/CommonMultiBodyBase.h
+  ../../examples/CommonInterfaces/CommonParameterInterface.h
+  ../../examples/CommonInterfaces/CommonRenderInterface.h
+  ../../examples/CommonInterfaces/CommonRigidBodyBase.h
+  ../../examples/CommonInterfaces/CommonWindowInterface.h
+
+  ../../examples/OpenGLWindow/SimpleCamera.h
+
+  ../../examples/TinyRenderer/geometry.h
+  ../../examples/TinyRenderer/model.h
+  ../../examples/TinyRenderer/tgaimage.h
+  ../../examples/TinyRenderer/our_gl.h
+  ../../examples/TinyRenderer/TinyRenderer.h
+
+  ../../examples/SharedMemory/plugins/collisionFilterPlugin/collisionFilterPlugin.h
+  ../../examples/SharedMemory/plugins/pdControlPlugin/pdControlPlugin.h
+  ../../examples/SharedMemory/b3RobotSimulatorClientAPI_NoGUI.h
+  ../../examples/SharedMemory/b3RobotSimulatorClientAPI_NoDirect.h
+  ../../examples/SharedMemory/IKTrajectoryHelper.h
+  ../../examples/SharedMemory/plugins/tinyRendererPlugin/tinyRendererPlugin.h
+  ../../examples/SharedMemory/plugins/tinyRendererPlugin/TinyRendererVisualShapeConverter.h
+  ../../examples/SharedMemory/InProcessMemory.h
+  ../../examples/SharedMemory/PhysicsServer.h
+  ../../examples/SharedMemory/PhysicsClient.h
+  ../../examples/SharedMemory/PhysicsServerSharedMemory.h
+  ../../examples/SharedMemory/PhysicsDirect.h
+  ../../examples/SharedMemory/PhysicsDirectC_API.h
+  ../../examples/SharedMemory/PhysicsServerCommandProcessor.h
+  ../../examples/SharedMemory/b3PluginManager.h
+  ../../examples/SharedMemory/PhysicsClientSharedMemory.h
+  ../../examples/SharedMemory/PhysicsClientSharedMemory_C_API.h
+  ../../examples/SharedMemory/PhysicsClientC_API.h
+  ../../examples/SharedMemory/SharedMemoryPublic.h
+  ../../examples/SharedMemory/Win32SharedMemory.h
+  ../../examples/SharedMemory/PosixSharedMemory.h
+
+  ../../examples/Utils/b3ResourcePath.h
+  ../../examples/Utils/RobotLoggingUtil.h
+  ../../examples/Utils/b3Clock.h
+  ../../examples/Utils/b3ResourcePath.h
+  ../../examples/Utils/ChromeTraceUtil.h
+  ../../examples/Utils/b3ERPCFMHelper.hpp
+  ../../examples/Utils/b3ReferenceFrameHelper.hpp  
+
+  ../../examples/ThirdPartyLibs/tinyxml2/tinyxml2.h
+  ../../examples/ThirdPartyLibs/Wavefront/tiny_obj_loader.h
+  ../../examples/ThirdPartyLibs/stb_image/stb_image.h
+  ../../examples/ThirdPartyLibs/BussIK/Jacobian.h
+  ../../examples/ThirdPartyLibs/BussIK/LinearR2.h
+  ../../examples/ThirdPartyLibs/BussIK/LinearR3.h
+  ../../examples/ThirdPartyLibs/BussIK/LinearR4.h
+  ../../examples/ThirdPartyLibs/BussIK/MatrixRmn.h
+  ../../examples/ThirdPartyLibs/BussIK/Node.h
+  ../../examples/ThirdPartyLibs/BussIK/Tree.h
+  ../../examples/ThirdPartyLibs/BussIK/VectorRn.h
+
+  ../../examples/Importers/ImportColladaDemo/LoadMeshFromCollada.h
+  ../../examples/Importers/ImportObjDemo/LoadMeshFromObj.h
+  ../../examples/Importers/ImportObjDemo/Wavefront2GLInstanceGraphicsShape.h
+  ../../examples/Importers/ImportMJCFDemo/BulletMJCFImporter.h
+  ../../examples/Importers/ImportURDFDemo/BulletUrdfImporter.h
+  ../../examples/Importers/ImportURDFDemo/MyMultiBodyCreator.h
+  ../../examples/Importers/ImportURDFDemo/URDF2Bullet.h
+  ../../examples/Importers/ImportURDFDemo/UrdfParser.h
+  ../../examples/Importers/ImportURDFDemo/urdfStringSplit.h
+  ../../examples/Importers/ImportURDFDemo/URDFImporterInterface.h
+  ../../examples/Importers/ImportURDFDemo/URDFJointTypes.h
+  ../../examples/Importers/ImportURDFDemo/SDFAudioTypes.h
+  ../../examples/Importers/ImportURDFDemo/UrdfRenderingInterface.h
+  ../../examples/Importers/ImportURDFDemo/MultiBodyCreationInterface.h
+  ../../examples/Importers/ImportMeshUtility/b3ImportMeshUtility.h
+  
+  ../../examples/MultiThreading/b3PosixThreadSupport.h
+  ../../examples/MultiThreading/b3Win32ThreadSupport.h
+  ../../examples/MultiThreading/b3ThreadSupportInterface.h
+)
+
+SET(BulletRobotics_SRCS ${BulletRobotics_INCLUDES}
+    ../../examples/OpenGLWindow/SimpleCamera.cpp
+
 		../../examples/TinyRenderer/geometry.cpp
 		../../examples/TinyRenderer/model.cpp
 		../../examples/TinyRenderer/tgaimage.cpp
 		../../examples/TinyRenderer/our_gl.cpp
 		../../examples/TinyRenderer/TinyRenderer.cpp
+
+    ../../examples/SharedMemory/plugins/collisionFilterPlugin/collisionFilterPlugin.cpp
+		../../examples/SharedMemory/plugins/pdControlPlugin/pdControlPlugin.cpp
+		../../examples/SharedMemory/b3RobotSimulatorClientAPI_NoGUI.cpp
+		../../examples/SharedMemory/b3RobotSimulatorClientAPI_NoDirect.cpp
+		../../examples/SharedMemory/IKTrajectoryHelper.cpp
+		../../examples/SharedMemory/plugins/tinyRendererPlugin/tinyRendererPlugin.cpp
+		../../examples/SharedMemory/plugins/tinyRendererPlugin/TinyRendererVisualShapeConverter.cpp
 		../../examples/SharedMemory/InProcessMemory.cpp
 		../../examples/SharedMemory/PhysicsClient.cpp
-		../../examples/SharedMemory/PhysicsClient.h
 		../../examples/SharedMemory/PhysicsServer.cpp
-		../../examples/SharedMemory/PhysicsServer.h
 		../../examples/SharedMemory/PhysicsServerSharedMemory.cpp
-		../../examples/SharedMemory/PhysicsServerSharedMemory.h
 		../../examples/SharedMemory/PhysicsDirect.cpp
-		../../examples/SharedMemory/PhysicsDirect.h
 		../../examples/SharedMemory/PhysicsDirectC_API.cpp
-		../../examples/SharedMemory/PhysicsDirectC_API.h
 		../../examples/SharedMemory/PhysicsServerCommandProcessor.cpp
-		../../examples/SharedMemory/PhysicsServerCommandProcessor.h
 		../../examples/SharedMemory/b3PluginManager.cpp
-		../../examples/SharedMemory/b3PluginManager.h
-				
 		../../examples/SharedMemory/PhysicsClientSharedMemory.cpp
-		../../examples/SharedMemory/PhysicsClientSharedMemory.h
 		../../examples/SharedMemory/PhysicsClientSharedMemory_C_API.cpp
-		../../examples/SharedMemory/PhysicsClientSharedMemory_C_API.h
 		../../examples/SharedMemory/PhysicsClientC_API.cpp
-	
-		../../examples/SharedMemory/PhysicsClientC_API.h
-		../../examples/SharedMemory/SharedMemoryPublic.h
-
 		../../examples/SharedMemory/Win32SharedMemory.cpp
-		../../examples/SharedMemory/Win32SharedMemory.h
 		../../examples/SharedMemory/PosixSharedMemory.cpp
-		../../examples/SharedMemory/PosixSharedMemory.h
 
 		../../examples/Utils/b3ResourcePath.cpp
-		../../examples/Utils/b3ResourcePath.h
 		../../examples/Utils/RobotLoggingUtil.cpp
-		../../examples/Utils/RobotLoggingUtil.h
 		../../examples/Utils/b3Clock.cpp
 		../../examples/Utils/b3ResourcePath.cpp
-		../../examples/Utils/b3ERPCFMHelper.hpp
-		../../examples/Utils/b3ReferenceFrameHelper.hpp
 		../../examples/Utils/ChromeTraceUtil.cpp
 
 		../../examples/ThirdPartyLibs/tinyxml2/tinyxml2.cpp
-
 		../../examples/ThirdPartyLibs/Wavefront/tiny_obj_loader.cpp
-		../../examples/ThirdPartyLibs/Wavefront/tiny_obj_loader.h
-
 		../../examples/ThirdPartyLibs/stb_image/stb_image.cpp
-
 		../../examples/ThirdPartyLibs/BussIK/Jacobian.cpp
 		../../examples/ThirdPartyLibs/BussIK/LinearR2.cpp
 		../../examples/ThirdPartyLibs/BussIK/LinearR3.cpp
@@ -127,11 +185,18 @@ ELSE(WIN32)
 ENDIF(WIN32)
 
 IF(BUILD_ENET)
-	set(BulletRobotics_SRCS ${BulletRobotics_SRCS} 
-		../../examples/SharedMemory/PhysicsClientUDP.cpp
-		../../examples/SharedMemory/PhysicsClientUDP_C_API.cpp
-		../../examples/SharedMemory/PhysicsClientUDP.h		
-		../../examples/SharedMemory/PhysicsClientUDP_C_API.h
+  set(BulletRobotics_ENET_INCLUDES 
+    ../../examples/SharedMemory/PhysicsClientUDP.h		
+    ../../examples/SharedMemory/PhysicsClientUDP_C_API.h
+    ../../examples/ThirdPartyLibs/enet/include/enet/win32.h
+		../../examples/ThirdPartyLibs/enet/include/enet/unix.h
+		../../examples/ThirdPartyLibs/enet/include/enet/callbacks.h
+		../../examples/ThirdPartyLibs/enet/include/enet/list.h
+		../../examples/ThirdPartyLibs/enet/include/enet/protocol.h
+  )
+  set(BulletRobotics_ENET_SRCS
+    ../../examples/SharedMemory/PhysicsClientUDP.cpp
+    ../../examples/SharedMemory/PhysicsClientUDP_C_API.cpp
 		../../examples/ThirdPartyLibs/enet/win32.c
 		../../examples/ThirdPartyLibs/enet/unix.c
 		../../examples/ThirdPartyLibs/enet/callbacks.c
@@ -141,20 +206,46 @@ IF(BUILD_ENET)
 		../../examples/ThirdPartyLibs/enet/packet.c
 		../../examples/ThirdPartyLibs/enet/peer.c
 		../../examples/ThirdPartyLibs/enet/protocol.c
+  )
+
+  set(BulletRobotics_INCLUDES
+    ${BulletRobotics_INCLUDES}
+    ${BulletRobotics_ENET_INCLUDES}
+	)
+
+  set(BulletRobotics_SRCS
+    ${BulletRobotics_SRCS}
+    ${BulletRobotics_ENET_INCLUDES}
+    ${BulletRobotics_ENET_SRCS}
 	)
 
 ENDIF(BUILD_ENET)
 
 IF(BUILD_CLSOCKET)
-	set(BulletRobotics_SRCS ${BulletRobotics_SRCS}
-		../../examples/SharedMemory/PhysicsClientTCP.cpp
-		../../examples/SharedMemory/PhysicsClientTCP.h
-		../../examples/SharedMemory/PhysicsClientTCP_C_API.cpp
-		../../examples/SharedMemory/PhysicsClientTCP_C_API.h
-		../../examples/ThirdPartyLibs/clsocket/src/SimpleSocket.cpp
-		../../examples/ThirdPartyLibs/clsocket/src/ActiveSocket.cpp
-		../../examples/ThirdPartyLibs/clsocket/src/PassiveSocket.cpp
-	)
+  set(BulletRobotics_CLSOCKET_INCLUDES 
+    ../../examples/SharedMemory/PhysicsClientTCP.h
+    ../../examples/SharedMemory/PhysicsClientTCP_C_API.h
+    ../../examples/ThirdPartyLibs/clsocket/src/SimpleSocket.h
+    ../../examples/ThirdPartyLibs/clsocket/src/ActiveSocket.h
+    ../../examples/ThirdPartyLibs/clsocket/src/PassiveSocket.h
+  )
+  set(BulletRobotics_CLSOCKET_SRCS
+    ../../examples/SharedMemory/PhysicsClientTCP.cpp
+    ../../examples/SharedMemory/PhysicsClientTCP_C_API.cpp
+    ../../examples/ThirdPartyLibs/clsocket/src/SimpleSocket.cpp
+    ../../examples/ThirdPartyLibs/clsocket/src/ActiveSocket.cpp
+    ../../examples/ThirdPartyLibs/clsocket/src/PassiveSocket.cpp
+  )
+
+  set(BulletRobotics_INCLUDES
+    ${BulletRobotics_INCLUDES}
+    ${BulletRobotics_CLSOCKET_INCLUDES}
+  )
+  set(BulletRobotics_SRCS
+    ${BulletRobotics_SRCS}
+    ${BulletRobotics_CLSOCKET_INCLUDES}
+    ${BulletRobotics_CLSOCKET_SRCS}
+  )
 ENDIF()
 
 ADD_DEFINITIONS(-DPHYSICS_SERVER_DIRECT)
@@ -171,27 +262,43 @@ ENDIF (BUILD_SHARED_LIBS)
 
 IF (INSTALL_EXTRA_LIBS)
 	INSTALL(FILES
-		../../examples/SharedMemory/PhysicsClientC_API.h
-		../../examples/SharedMemory/PhysicsClientSharedMemory_C_API.h
-		../../examples/SharedMemory/PhysicsClientSharedMemory2_C_API.h
-		../../examples/SharedMemory/PhysicsDirectC_API.h
-		../../examples/SharedMemory/PhysicsClientUDP_C_API.h
-		../../examples/SharedMemory/PhysicsClientTCP_C_API.h
-		../../examples/SharedMemory/SharedMemoryInProcessPhysicsC_API.h
-		../../examples/SharedMemory/SharedMemoryPublic.h
-		../../examples/SharedMemory/b3RobotSimulatorClientAPI_NoGUI.h
-		../../examples/SharedMemory/b3RobotSimulatorClientAPI_NoDirect.h
+      ../../examples/SharedMemory/PhysicsClientC_API.h
+      ../../examples/SharedMemory/PhysicsClientSharedMemory_C_API.h
+      ../../examples/SharedMemory/PhysicsClientSharedMemory2_C_API.h
+      ../../examples/SharedMemory/PhysicsDirectC_API.h
+      ../../examples/SharedMemory/PhysicsClientUDP_C_API.h
+      ../../examples/SharedMemory/PhysicsClientTCP_C_API.h
+      ../../examples/SharedMemory/SharedMemoryInProcessPhysicsC_API.h
+      ../../examples/SharedMemory/SharedMemoryPublic.h
+      ../../examples/SharedMemory/b3RobotSimulatorClientAPI_NoGUI.h
+      ../../examples/SharedMemory/b3RobotSimulatorClientAPI_NoDirect.h
 		DESTINATION include/bullet
-		)
+  )
+  
+  INSTALL(FILES
+    ${BulletRobotics_INCLUDES}
+    DESTINATION include/bullet_robotics
+  )
+
 	INSTALL(TARGETS
 		BulletRobotics
 		LIBRARY DESTINATION lib${LIB_SUFFIX}
 		ARCHIVE DESTINATION lib${LIB_SUFFIX}
-		)
+	)
 		
-		IF (APPLE AND BUILD_SHARED_LIBS AND FRAMEWORK)
-			SET_TARGET_PROPERTIES(BulletRobotics  PROPERTIES FRAMEWORK true)
-			SET_TARGET_PROPERTIES(BulletRobotics PROPERTIES PUBLIC_HEADER "PhysicsClientC_API.h" )
-		ENDIF (APPLE AND BUILD_SHARED_LIBS AND FRAMEWORK)
-		
+  IF (APPLE AND BUILD_SHARED_LIBS AND FRAMEWORK)
+    SET_TARGET_PROPERTIES(BulletRobotics  PROPERTIES FRAMEWORK true)
+    SET_TARGET_PROPERTIES(BulletRobotics PROPERTIES PUBLIC_HEADER "PhysicsClientC_API.h" )
+  ENDIF (APPLE AND BUILD_SHARED_LIBS AND FRAMEWORK)	
 ENDIF (INSTALL_EXTRA_LIBS)
+
+IF(NOT MSVC)
+    CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/bullet_robotics.pc.cmake
+                   ${CMAKE_CURRENT_BINARY_DIR}/bullet_robotics.pc @ONLY)
+  	INSTALL(
+      FILES
+      ${CMAKE_CURRENT_BINARY_DIR}/bullet_robotics.pc
+      DESTINATION
+      ${PKGCONFIG_INSTALL_PREFIX}
+    )
+ENDIF(NOT MSVC)

--- a/Extras/BulletRobotics/bullet_robotics.pc.cmake
+++ b/Extras/BulletRobotics/bullet_robotics.pc.cmake
@@ -1,0 +1,6 @@
+Name: bullet_robotics
+Description: Bullet extras that include several utilities for robotics including a urdf parser
+Requires: bullet
+Version: @BULLET_VERSION@
+Libs: -L@CMAKE_INSTALL_PREFIX@/@LIB_DESTINATION@ -lBulletRobotics
+Cflags: @BULLET_DOUBLE_DEF@ -I@CMAKE_INSTALL_PREFIX@/@INCLUDE_INSTALL_DIR@ -I@CMAKE_INSTALL_PREFIX@/include/bullet_robotics


### PR DESCRIPTION
- Create a bullet_robotics.pc for the bulletRobotics extras package.
- Install all necessary includes in include/bullet_robotics.
- The .pc adds directly the bullet_robotics folder as include directory.
  This is due to some relative include in the examples.