### PR TITLE
Applying collision filters for all physic clients in pybullet_setCollisionFilterPair and pybullet_setCollisionFilterGroupMask

### DIFF
--- a/examples/pybullet/pybullet.c
+++ b/examples/pybullet/pybullet.c
@@ -6293,17 +6293,17 @@ static PyObject* pybullet_setCollisionFilterGroupMask(PyObject* self, PyObject* 
 
 	static char* kwlist[] = {"bodyUniqueId", "linkIndexA", "collisionFilterGroup", "collisionFilterMask", "physicsClientId", NULL};
 
+	if (!PyArg_ParseTupleAndKeywords(args, keywds, "iiii|i", kwlist,
+									 &bodyUniqueIdA, &linkIndexA, &collisionFilterGroup, &collisionFilterMask, &physicsClientId))
+		return NULL;
+
 	sm = getPhysicsClient(physicsClientId);
 	if (sm == 0)
 	{
 		PyErr_SetString(SpamError, "Not connected to physics server.");
 		return NULL;
 	}
-
-	if (!PyArg_ParseTupleAndKeywords(args, keywds, "iiii|i", kwlist,
-									 &bodyUniqueIdA, &linkIndexA, &collisionFilterGroup, &collisionFilterMask, &physicsClientId))
-		return NULL;
-
+	
 	commandHandle = b3CollisionFilterCommandInit(sm);
 	b3SetCollisionFilterGroupMask(commandHandle, bodyUniqueIdA, linkIndexA, collisionFilterGroup, collisionFilterMask);
 
@@ -6329,16 +6329,16 @@ static PyObject* pybullet_setCollisionFilterPair(PyObject* self, PyObject* args,
 
 	static char* kwlist[] = {"bodyUniqueIdA", "bodyUniqueIdB", "linkIndexA", "linkIndexB", "enableCollision", "physicsClientId", NULL};
 
+	if (!PyArg_ParseTupleAndKeywords(args, keywds, "iiiii|i", kwlist,
+									 &bodyUniqueIdA, &bodyUniqueIdB, &linkIndexA, &linkIndexB, &enableCollision, &physicsClientId))
+		return NULL;
+
 	sm = getPhysicsClient(physicsClientId);
 	if (sm == 0)
 	{
 		PyErr_SetString(SpamError, "Not connected to physics server.");
 		return NULL;
 	}
-
-	if (!PyArg_ParseTupleAndKeywords(args, keywds, "iiiii|i", kwlist,
-									 &bodyUniqueIdA, &bodyUniqueIdB, &linkIndexA, &linkIndexB, &enableCollision, &physicsClientId))
-		return NULL;
 
 	commandHandle = b3CollisionFilterCommandInit(sm);
 	b3SetCollisionFilterPair(commandHandle, bodyUniqueIdA, bodyUniqueIdB, linkIndexA, linkIndexB, enableCollision);


### PR DESCRIPTION
This pull request aims to fix #2070 

The pybullet_setCollisionFilterPair and pybullet_setCollisionFilterGroupMask will take into account the physicsClientId parameter passed.