### PR TITLE
Retrieve rayTestBatch data without having to display debug lines

### DIFF
--- a/examples/SharedMemory/PhysicsServerCommandProcessor.cpp
+++ b/examples/SharedMemory/PhysicsServerCommandProcessor.cpp
@@ -5403,7 +5403,7 @@ bool PhysicsServerCommandProcessor::processRequestRaycastIntersectionsCommand(co
 			int linkIndex = -1;
 			if (bodyHandle->m_multiBody)
 			{
-				int linkIndex = clientCmd.m_userDebugDrawArgs.m_parentLinkIndex;
+				int linkIndex = clientCmd.m_requestRaycastIntersections.m_parentLinkIndex;
 				if (linkIndex == -1)
 				{
 					tr = bodyHandle->m_multiBody->getBaseWorldTransform();


### PR DESCRIPTION
Fixing the rayTestBatch issue #2131

With the proposed fix, no need to use our workaround (creating a user debugline attached to the robot and removing it just after) to get correct ray test batch data.

The PhysicsServerCommandProcessor will use the correct structure __m_requestRaycastIntersections__ in the __processRequestRaycastIntersectionsCommand__ method