### PR TITLE
Fixing issue where mass of motors is uneven

### DIFF
--- a/examples/pybullet/gym/pybullet_data/laikago/laikago.urdf
+++ b/examples/pybullet/gym/pybullet_data/laikago/laikago.urdf
@@ -36,7 +36,7 @@
   </contact>
     <inertial>
        <origin rpy="0 0 0" xyz="0.02 0 0"/>
-       <mass value="0.241"/>
+       <mass value="1.095"/>
        <inertia ixx="0" ixy="0" ixz="0" iyy="0" iyz="0" izz="0"/>
     </inertial>
 	
@@ -262,7 +262,7 @@
   </contact>
     <inertial>
       <origin rpy="0 0 0" xyz="0.02 0 0"/>
-       <mass value="0.241"/>
+       <mass value="1.095"/>
        <inertia ixx="0" ixy="0" ixz="0" iyy="0" iyz="0" izz="0"/>
     </inertial>
 	


### PR DESCRIPTION
Mass of motors was being tilted to the left, due to FL hip motor and RL hip motor having a mass of 1.095 and FR hip motor and BR hip motor having a mass of 0.241. This led to issues with the laikago tilting. May require further investigation to see if the laikago is at the proper center of mass.

Would other people be able to investigate this further to see if there are other issues?