### PR TITLE
Add __version__ information for pybullet

### DIFF
--- a/examples/pybullet/pybullet.c
+++ b/examples/pybullet/pybullet.c
@@ -10825,6 +10825,8 @@ initpybullet(void)
 	if (m == NULL) return;
 #endif
 
+	PyModule_AddStringConstant(m, "__version__", "2.4.8");
+
 	PyModule_AddIntConstant(m, "SHARED_MEMORY",
 							eCONNECT_SHARED_MEMORY);                                    // user read
 	PyModule_AddIntConstant(m, "DIRECT", eCONNECT_DIRECT);                              // user read


### PR DESCRIPTION
I would like to know the version information from ```__version__```.
This PR adds version information for pybullet and we can access version like the following code.

```
In [1]: import pybullet
pybullet build time: Mar 22 2019 18:28:58

In [2]: pybullet.__version__
Out[2]: '2.4.8'
```