### PR TITLE
in btSimpleBroadphase::destroyProxy(), remove pairs before freeing proxy

### DIFF
--- a/src/BulletCollision/BroadphaseCollision/btSimpleBroadphase.cpp
+++ b/src/BulletCollision/BroadphaseCollision/btSimpleBroadphase.cpp
@@ -123,10 +123,10 @@ protected:
 
 void btSimpleBroadphase::destroyProxy(btBroadphaseProxy* proxyOrg, btDispatcher* dispatcher)
 {
+	m_pairCache->removeOverlappingPairsContainingProxy(proxyOrg, dispatcher);
+
 	btSimpleBroadphaseProxy* proxy0 = static_cast<btSimpleBroadphaseProxy*>(proxyOrg);
 	freeHandle(proxy0);
-
-	m_pairCache->removeOverlappingPairsContainingProxy(proxyOrg, dispatcher);
 
 	//validate();
 }


### PR DESCRIPTION
While testing some Java bindings to allow jMonkeyEngine to use Bullet 2.87 with `btSimpleBroadphase`, I encountered an `EXCEPTION_ACCESS_VIOLATION` crash in certain situations, which I traced back to `btSimpleBroadphase::destroyProxy()`. There, Bullet calls `freeHandle()` on the proxy before passing it to `btOverlappingPairCache::removeOverlappingPairsContainingProxy()`. That order of operations appears to be incorrect. Reversing the order avoids the crash.