### PR TITLE
Reduce visibility of Bullet symbols in PyBullet

### DIFF
--- a/examples/pybullet/pybullet.c
+++ b/examples/pybullet/pybullet.c
@@ -10842,6 +10842,9 @@ static struct PyModuleDef moduledef = {
 };
 #endif
 
+#if __GNUC__ >= 4
+__attribute__((visibility ("default")))
+#endif
 PyMODINIT_FUNC
 #if PY_MAJOR_VERSION >= 3
 PyInit_pybullet(void)

--- a/setup.py
+++ b/setup.py
@@ -370,6 +370,8 @@ if _platform == "linux" or _platform == "linux2":
     CXX_FLAGS += '-DDYNAMIC_LOAD_X11_FUNCTIONS '
     CXX_FLAGS += '-DHAS_SOCKLEN_T '
     CXX_FLAGS += '-fno-inline-functions-called-once '
+    CXX_FLAGS += '-fvisibility=hidden '
+    CXX_FLAGS += '-fvisibility-inlines-hidden '
     EGL_CXX_FLAGS += '-DBT_USE_EGL '
     EGL_CXX_FLAGS += '-fPIC ' # for plugins
 


### PR DESCRIPTION
Avoids version conflicts in programs using PyBullet, which also link against Bullet libraries.

This addresses #2189 for Linux - it will no longer crash, and pybullet works when imported in Blender 2.79 or 2.8; the command line shown below also works with this fix.

---

A simple way to reproduce the original issue on Linux is (which will crash):

```
LD_PRELOAD=/usr/lib/libBulletSoftBody.so python3.7m -c "import pybullet; i = pybullet.connect(pybullet.DIRECT); pybullet.resetSimulation(i)"
```

*(Where libBulletSoftBody.so and PyBullet are different versions / compilations of Bullet; also crashes with preloading libBulletDynamics.so, and possibly others)*

---

**Implementation notes**

* I assume this solution could be extended to MacOS and BSD (or other GNU-C compatible compilers).
* I did not fix / review the CMake and Premake installations of PyBullet.
* I'm not sure if this should also be extended for eglRenderer.
* The GCC 4.0 version check came from https://gcc.gnu.org/wiki/Visibility .
* `-fvisibility-inlines-hidden` might be redundant / implied by `-fvisibility=hidden` (I did not check).

I'm a bit surprised that this visibility isn't handled by pypi / setuptools / CPython / ... internally (using the `PyMODINIT_FUNC` macro and built-in flags). I might investigate further wether this solution could move upstream into those tools (whichever might be the responsible project).

An alternative solution would be to add versioning information to Bullet libraries (which should be done regardless). However, I feel for PyBullet this is the cleaner solution to address the issue at hand: it shouldn't expose the Bullet symbols.

One thing to keep in mind, is that this reduced visibility probably makes it impossible to link against PyBullet as a generic Bullet shared-library. However, I feel that's not a valid use-case, as people probably build Bullet the "standard" (CMake / Premake) way, and not through setup.py.