### PR TITLE
Fix render issue in server render mode (e.g., docker)

### DIFF
--- a/examples/pybullet/gym/pybullet_envs/env_bases.py
+++ b/examples/pybullet/gym/pybullet_envs/env_bases.py
@@ -96,6 +96,7 @@ class MJCFBaseBulletEnv(gym.Env):
 			renderer=pybullet.ER_BULLET_HARDWARE_OPENGL
 			)
 		rgb_array = np.array(px)
+		rgb_array = np.reshape(np.array(px), (self._render_height, self._render_width, -1))
 		rgb_array = rgb_array[:, :, :3]
 		return rgb_array
 


### PR DESCRIPTION
px is an 1D array, and cause a runtime error when trying to strip the color channels into RGB. I fixed this by first reshape the px array into am image compatible format first.