### PR TITLE
Multibody memory invalid writing

### DIFF
--- a/src/BulletDynamics/Featherstone/btMultiBody.h
+++ b/src/BulletDynamics/Featherstone/btMultiBody.h
@@ -492,6 +492,7 @@ void addJointTorque(int i, btScalar Q);
 	void setNumLinks(int numLinks)//careful: when changing the number of m_links, make sure to re-initialize or update existing m_links
 	{
 		m_links.resize(numLinks);
+		m_matrixBuf.resize(n_links + 1);
 	}
 
 	btScalar getLinearDamping() const


### PR DESCRIPTION
If you create a multibody with 0 links, and then later you resize it, the matrixBuffer is not resized and line of code like https://github.com/bulletphysics/bullet3/blob/fd161fa061539257036dd8f651bda3d3bf079556/src/BulletDynamics/Featherstone/btMultiBody.cpp#L1919
will write on a wrong segment of memory.

This change make sure to resize everything.

Found this error while implementing multibody inside Godot