### PR TITLE
Fix code files encoding to make them all UTF-8

### DIFF
--- a/Extras/GIMPACTUtils/btGImpactConvexDecompositionShape.h
+++ b/Extras/GIMPACTUtils/btGImpactConvexDecompositionShape.h
@@ -1,5 +1,5 @@
 /*! \file btGImpactConvexDecompositionShape.h
-\author Francisco León Nájera
+\author Francisco Leon Najera
 */
 /*
 This source file is part of GIMPACT Library.

--- a/Extras/VHACD/src/vhacdVolume.cpp
+++ b/Extras/VHACD/src/vhacdVolume.cpp
@@ -25,7 +25,7 @@ namespace VHACD
 {
 /********************************************************/
 /* AABB-triangle overlap test code                      */
-/* by Tomas Akenine-Möller                              */
+/* by Tomas Akenine-MÃ¶ller                              */
 /* Function: int triBoxOverlap(float boxcenter[3],      */
 /*          float boxhalfsize[3],float triverts[3][3]); */
 /* History:                                             */

--- a/examples/TinyAudio/RtAudio.cpp
+++ b/examples/TinyAudio/RtAudio.cpp
@@ -3477,7 +3477,7 @@ bool RtApiAsio ::probeDeviceOpen(unsigned int device, StreamMode mode, unsigned 
 	{
 		// Standard method failed. This can happen with strict/misbehaving drivers that return valid buffer size ranges
 		// but only accept the preferred buffer size as parameter for ASIOCreateBuffers. eg. Creatives ASIO driver
-		// in that case, let's be naïve and try that instead
+		// in that case, let's be naÃ¯ve and try that instead
 		*bufferSize = preferSize;
 		stream_.bufferSize = *bufferSize;
 		result = ASIOCreateBuffers(handle->bufferInfos, nChannels, stream_.bufferSize, &asioCallbacks);

--- a/src/BulletCollision/Gimpact/btGImpactShape.h
+++ b/src/BulletCollision/Gimpact/btGImpactShape.h
@@ -1,5 +1,5 @@
 /*! \file btGImpactShape.h
-\author Francisco Len Nßjera
+\author Francisco Leon Najera
 */
 /*
 This source file is part of GIMPACT Library.

--- a/src/BulletDynamics/ConstraintSolver/btGeneric6DofSpring2Constraint.cpp
+++ b/src/BulletDynamics/ConstraintSolver/btGeneric6DofSpring2Constraint.cpp
@@ -32,7 +32,7 @@ Cons:
 
 /*
 2007-09-09
-btGeneric6DofConstraint Refactored by Francisco Le?n
+btGeneric6DofConstraint Refactored by Francisco Leon
 email: projectileman@yahoo.com
 http://gimpact.sf.net
 */
@@ -311,9 +311,9 @@ void btGeneric6DofSpring2Constraint::calculateAngleInfo()
 		case RO_XYZ:
 		{
 			//Is this the "line of nodes" calculation choosing planes YZ (B coordinate system) and xy (A coordinate system)? (http://en.wikipedia.org/wiki/Euler_angles)
-			//The two planes are non-homologous, so this is a Tait Bryan angle formalism and not a proper Euler
+			//The two planes are non-homologous, so this is a Tait-Bryan angle formalism and not a proper Euler
 			//Extrinsic rotations are equal to the reversed order intrinsic rotations so the above xyz extrinsic rotations (axes are fixed) are the same as the zy'x" intrinsic rotations (axes are refreshed after each rotation)
-			//that is why xy and YZ planes are chosen (this will describe a zy'x" intrinsic rotation) (see the figure on the left at http://en.wikipedia.org/wiki/Euler_angles under Tait Bryan angles)
+			//that is why xy and YZ planes are chosen (this will describe a zy'x" intrinsic rotation) (see the figure on the left at http://en.wikipedia.org/wiki/Euler_angles under Tait-Bryan angles)
 			// x' = Nperp = N.cross(axis2)
 			// y' = N = axis2.cross(axis0)
 			// z' = z

--- a/src/BulletDynamics/MLCPSolvers/btLemkeSolver.h
+++ b/src/BulletDynamics/MLCPSolvers/btLemkeSolver.h
@@ -20,7 +20,7 @@ subject to the following restrictions:
 #include "btMLCPSolverInterface.h"
 #include "btLemkeAlgorithm.h"
 
-///The btLemkeSolver is based on "Fast Implementation of Lemke’s Algorithm for Rigid Body Contact Simulation (John E. Lloyd) "
+///The btLemkeSolver is based on "Fast Implementation of Lemke's Algorithm for Rigid Body Contact Simulation (John E. Lloyd) "
 ///It is a slower but more accurate solver. Increase the m_maxLoops for better convergence, at the cost of more CPU time.
 ///The original implementation of the btLemkeAlgorithm was done by Kilian Grundl from the MBSim team
 class btLemkeSolver : public btMLCPSolverInterface

--- a/src/BulletSoftBody/btSoftBody.cpp
+++ b/src/BulletSoftBody/btSoftBody.cpp
@@ -518,7 +518,7 @@ void btSoftBody::addAeroForceToNode(const btVector3& windVelocity, int nodeIndex
 					fDrag = 0.5f * kDG * medium.m_density * rel_v2 * tri_area * n_dot_v * (-rel_v_nrm);
 
 					// Check angle of attack
-					// cos(10º) = 0.98480
+					// cos(10Â°) = 0.98480
 					if (0 < n_dot_v && n_dot_v < 0.98480f)
 						fLift = 0.5f * kLF * medium.m_density * rel_v_len * tri_area * btSqrt(1.0f - n_dot_v * n_dot_v) * (nrm.cross(rel_v_nrm).cross(rel_v_nrm));
 
@@ -604,7 +604,7 @@ void btSoftBody::addAeroForceToFace(const btVector3& windVelocity, int faceIndex
 				fDrag = 0.5f * kDG * medium.m_density * rel_v2 * tri_area * n_dot_v * (-rel_v_nrm);
 
 				// Check angle of attack
-				// cos(10º) = 0.98480
+				// cos(10Â°) = 0.98480
 				if (0 < n_dot_v && n_dot_v < 0.98480f)
 					fLift = 0.5f * kLF * medium.m_density * rel_v_len * tri_area * btSqrt(1.0f - n_dot_v * n_dot_v) * (nrm.cross(rel_v_nrm).cross(rel_v_nrm));
 


### PR DESCRIPTION
I was checking encoding issues in Godot's codebase and found a couple coming from vendored Bullet files, so I went through the Bullet codebase to fix them.

I skipped everything in the `data/` folder to avoid modifying text files where the encoding might be required for proper parsing.
There's still `examples/OpenGLWindow/TwFonts.h` with a weird encoding due to it trying to embed the whole extended ASCII table in a comment (including control characters), but as it's thirdparty I skipped it (I also don't know how this table could be correctly embedded in a UTF-8 file).

I normalized Francisco León Nájera to Francisco Leon Najera as was already done in most other source files they authored, but if preferred I could also reencode it as Francisco León Nájera in UTF-8.