### PR TITLE
Fix initialization order

### DIFF
--- a/src/BulletDynamics/ConstraintSolver/btSequentialImpulseConstraintSolver.h
+++ b/src/BulletDynamics/ConstraintSolver/btSequentialImpulseConstraintSolver.h
@@ -80,11 +80,11 @@ struct btSISolverSingleIterationData
 		m_orderNonContactConstraintPool(orderNonContactConstraintPool),
 		m_orderFrictionConstraintPool(orderFrictionConstraintPool),
 		m_tmpConstraintSizesPool(tmpConstraintSizesPool),
+		m_seed(seed),
 		m_resolveSingleConstraintRowGeneric(resolveSingleConstraintRowGeneric),
 		m_resolveSingleConstraintRowLowerLimit(resolveSingleConstraintRowLowerLimit),
 		m_resolveSplitPenetrationImpulse(resolveSplitPenetrationImpulse),
 		m_kinematicBodyUniqueIdToSolverBodyTable(kinematicBodyUniqueIdToSolverBodyTable),
-		m_seed(seed),
 		m_fixedBodyId(fixedBodyId),
 		m_maxOverrideNumSolverIterations(maxOverrideNumSolverIterations)
 	{


### PR DESCRIPTION
This commit is necessary in order to fix the error that we get in godot with the flag: "-Werror=reorder"