### PR TITLE
parse fall contact bodies

### DIFF
--- a/examples/pybullet/gym/pybullet_envs/deep_mimic/env/humanoid_stable_pd.py
+++ b/examples/pybullet/gym/pybullet_envs/deep_mimic/env/humanoid_stable_pd.py
@@ -19,9 +19,11 @@ jointFrictionForce = 0
 
 class HumanoidStablePD(object):
 
-  def __init__(self, pybullet_client, mocap_data, timeStep, useFixedBase=True):
+  def __init__( self, pybullet_client, mocap_data, timeStep, 
+                useFixedBase=True, arg_parser=None):
     self._pybullet_client = pybullet_client
     self._mocap_data = mocap_data
+    self._arg_parser = arg_parser
     print("LOADING humanoid!")
 
     self._sim_model = self._pybullet_client.loadURDF(
@@ -135,7 +137,10 @@ class HumanoidStablePD(object):
     self._jointDofCounts = [4, 4, 4, 1, 4, 4, 1, 4, 1, 4, 4, 1]
 
     #only those body parts/links are allowed to touch the ground, otherwise the episode terminates
-    self._allowed_body_parts = [5, 11]
+    fall_contact_bodies = []
+    if self._arg_parser is not None:
+      fall_contact_bodies = self._arg_parser.parse_ints("fall_contact_bodies")
+    self._fall_contact_body_parts = fall_contact_bodies
 
     #[x,y,z] base position and [x,y,z,w] base orientation!
     self._totalDofs = 7
@@ -594,7 +599,7 @@ class HumanoidStablePD(object):
         part = p[3]
       if (p[2] == self._sim_model):
         part = p[4]
-      if (part >= 0 and part not in self._allowed_body_parts):
+      if (part >= 0 and part in self._fall_contact_body_parts):
         #print("terminating part:", part)
         terminates = True
 

--- a/examples/pybullet/gym/pybullet_envs/deep_mimic/env/pybullet_deep_mimic_env.py
+++ b/examples/pybullet/gym/pybullet_envs/deep_mimic/env/pybullet_deep_mimic_env.py
@@ -55,7 +55,7 @@ class PyBulletDeepMimicEnv(Env):
       timeStep = 1. / 600.
       useFixedBase = False
       self._humanoid = humanoid_stable_pd.HumanoidStablePD(self._pybullet_client, self._mocapData,
-                                                           timeStep, useFixedBase)
+                                                           timeStep, useFixedBase, self._arg_parser)
       self._isInitialized = True
 
       self._pybullet_client.setTimeStep(timeStep)


### PR DESCRIPTION
This pull request adds parsing of the `--fall_contact_bodies` argument for the DeepMimic example.

This is necessary for training and running different policies like "CartWheel", where the hands need to be able to touch the ground.