### PR TITLE
Call drawRect on Mac to fix OpenGL issue

### DIFF
--- a/examples/OpenGLWindow/MacOpenGLWindowObjC.m
+++ b/examples/OpenGLWindow/MacOpenGLWindowObjC.m
@@ -403,6 +403,8 @@ int Mac_createWindow(struct MacOpenGLWindowInternalData* m_internalData,struct M
     
     // OpenGL init!
     [m_internalData->m_myview MakeContext : ci->m_openglVersion];
+	
+    [m_internalData->m_myview drawRect: frame];
     
     // https://developer.apple.com/library/mac/#documentation/GraphicsAnimation/Conceptual/HighResolutionOSX/CapturingScreenContents/CapturingScreenContents.html#//apple_ref/doc/uid/TP40012302-CH10-SW1
     //support HighResolutionOSX for Retina Macbook


### PR DESCRIPTION
This fixes an issue on Mac where an OpenGL window doesn't show anything until it is resized.

I'm not sure if this is an issue for others, or if this fix has side effects, but this was an issue I ran into and I figured I would at least share my solution in case someone else stumbles onto it.