### PR TITLE
 Clears body and user data caches on syncBodyInfo and syncUserData

### DIFF
--- a/examples/SharedMemory/PhysicsClientSharedMemory.cpp
+++ b/examples/SharedMemory/PhysicsClientSharedMemory.cpp
@@ -294,8 +294,6 @@ void PhysicsClientSharedMemory::clearCachedBodies()
 		}
 	}
 	m_data->m_bodyJointMap.clear();
-	m_data->m_userDataHandleLookup.clear();
-	m_data->m_userDataMap.clear();
 }
 
 void PhysicsClientSharedMemory::resetData()
@@ -304,6 +302,8 @@ void PhysicsClientSharedMemory::resetData()
 	m_data->m_debugLinesTo.clear();
 	m_data->m_debugLinesColor.clear();
 	m_data->m_userConstraintInfoMap.clear();
+	m_data->m_userDataMap.clear();
+	m_data->m_userDataHandleLookup.clear();
 	clearCachedBodies();
 }
 void PhysicsClientSharedMemory::setSharedMemoryKey(int key)

--- a/examples/SharedMemory/PhysicsClientSharedMemory.cpp
+++ b/examples/SharedMemory/PhysicsClientSharedMemory.cpp
@@ -1270,6 +1270,7 @@ const SharedMemoryStatus* PhysicsClientSharedMemory::processServerStatus()
 
 			case CMD_SYNC_BODY_INFO_COMPLETED:
 			{
+				m_data->m_bodyJointMap.clear();
 				break;
 			}
 			case CMD_STATE_LOGGING_START_COMPLETED:
@@ -1553,6 +1554,8 @@ const SharedMemoryStatus* PhysicsClientSharedMemory::processServerStatus()
 		{
 			B3_PROFILE("CMD_SYNC_USER_DATA_COMPLETED");
 			// Remove all cached user data entries.
+			m_data->m_userDataMap.clear();
+			m_data->m_userDataHandleLookup.clear();
 			for (int i = 0; i < m_data->m_bodyJointMap.size(); i++)
 			{
 				BodyJointInfoCache** bodyJointsPtr = m_data->m_bodyJointMap.getAtIndex(i);
@@ -1560,8 +1563,6 @@ const SharedMemoryStatus* PhysicsClientSharedMemory::processServerStatus()
 				{
 					(*bodyJointsPtr)->m_userDataIds.clear();
 				}
-				m_data->m_userDataMap.clear();
-				m_data->m_userDataHandleLookup.clear();
 			}
 			const int numIdentifiers = serverCmd.m_syncUserDataArgs.m_numUserDataIdentifiers;
 			if (numIdentifiers > 0)

--- a/examples/SharedMemory/PhysicsClientSharedMemory.cpp
+++ b/examples/SharedMemory/PhysicsClientSharedMemory.cpp
@@ -282,11 +282,9 @@ void PhysicsClientSharedMemory::removeCachedBody(int bodyUniqueId)
 		m_data->m_bodyJointMap.remove(bodyUniqueId);
 	}
 }
-void PhysicsClientSharedMemory::resetData()
+
+void PhysicsClientSharedMemory::clearCachedBodies()
 {
-	m_data->m_debugLinesFrom.clear();
-	m_data->m_debugLinesTo.clear();
-	m_data->m_debugLinesColor.clear();
 	for (int i = 0; i < m_data->m_bodyJointMap.size(); i++)
 	{
 		BodyJointInfoCache** bodyJointsPtr = m_data->m_bodyJointMap.getAtIndex(i);
@@ -296,9 +294,17 @@ void PhysicsClientSharedMemory::resetData()
 		}
 	}
 	m_data->m_bodyJointMap.clear();
-	m_data->m_userConstraintInfoMap.clear();
 	m_data->m_userDataHandleLookup.clear();
 	m_data->m_userDataMap.clear();
+}
+
+void PhysicsClientSharedMemory::resetData()
+{
+	m_data->m_debugLinesFrom.clear();
+	m_data->m_debugLinesTo.clear();
+	m_data->m_debugLinesColor.clear();
+	m_data->m_userConstraintInfoMap.clear();
+	clearCachedBodies();
 }
 void PhysicsClientSharedMemory::setSharedMemoryKey(int key)
 {
@@ -1270,7 +1276,7 @@ const SharedMemoryStatus* PhysicsClientSharedMemory::processServerStatus()
 
 			case CMD_SYNC_BODY_INFO_COMPLETED:
 			{
-				m_data->m_bodyJointMap.clear();
+				clearCachedBodies();
 				break;
 			}
 			case CMD_STATE_LOGGING_START_COMPLETED:
@@ -1554,8 +1560,6 @@ const SharedMemoryStatus* PhysicsClientSharedMemory::processServerStatus()
 		{
 			B3_PROFILE("CMD_SYNC_USER_DATA_COMPLETED");
 			// Remove all cached user data entries.
-			m_data->m_userDataMap.clear();
-			m_data->m_userDataHandleLookup.clear();
 			for (int i = 0; i < m_data->m_bodyJointMap.size(); i++)
 			{
 				BodyJointInfoCache** bodyJointsPtr = m_data->m_bodyJointMap.getAtIndex(i);
@@ -1564,6 +1568,8 @@ const SharedMemoryStatus* PhysicsClientSharedMemory::processServerStatus()
 					(*bodyJointsPtr)->m_userDataIds.clear();
 				}
 			}
+			m_data->m_userDataMap.clear();
+			m_data->m_userDataHandleLookup.clear();
 			const int numIdentifiers = serverCmd.m_syncUserDataArgs.m_numUserDataIdentifiers;
 			if (numIdentifiers > 0)
 			{

--- a/examples/SharedMemory/PhysicsClientSharedMemory.h
+++ b/examples/SharedMemory/PhysicsClientSharedMemory.h
@@ -15,6 +15,7 @@ protected:
 	void processBodyJointInfo(int bodyUniqueId, const struct SharedMemoryStatus& serverCmd);
 	void resetData();
 	void removeCachedBody(int bodyUniqueId);
+	void clearCachedBodies();
 	virtual void renderSceneInternal(){};
 
 public:

--- a/examples/SharedMemory/PhysicsDirect.cpp
+++ b/examples/SharedMemory/PhysicsDirect.cpp
@@ -912,6 +912,7 @@ void PhysicsDirect::postProcessStatus(const struct SharedMemoryStatus& serverCmd
 			break;
 		}
 		case CMD_SYNC_BODY_INFO_COMPLETED:
+			m_data->m_bodyJointMap.clear();
 		case CMD_MJCF_LOADING_COMPLETED:
 		case CMD_SDF_LOADING_COMPLETED:
 		{
@@ -1193,6 +1194,8 @@ void PhysicsDirect::postProcessStatus(const struct SharedMemoryStatus& serverCmd
 		{
 			B3_PROFILE("CMD_SYNC_USER_DATA_COMPLETED");
 			// Remove all cached user data entries.
+			m_data->m_userDataMap.clear();
+			m_data->m_userDataHandleLookup.clear();
 			for (int i = 0; i < m_data->m_bodyJointMap.size(); i++)
 			{
 				BodyJointInfoCache2** bodyJointsPtr = m_data->m_bodyJointMap.getAtIndex(i);
@@ -1200,8 +1203,6 @@ void PhysicsDirect::postProcessStatus(const struct SharedMemoryStatus& serverCmd
 				{
 					(*bodyJointsPtr)->m_userDataIds.clear();
 				}
-				m_data->m_userDataMap.clear();
-				m_data->m_userDataHandleLookup.clear();
 			}
 			const int numIdentifiers = serverCmd.m_syncUserDataArgs.m_numUserDataIdentifiers;
 			int* identifiers = new int[numIdentifiers];

--- a/examples/SharedMemory/PhysicsDirect.cpp
+++ b/examples/SharedMemory/PhysicsDirect.cpp
@@ -142,6 +142,12 @@ void PhysicsDirect::resetData()
 	m_data->m_debugLinesFrom.clear();
 	m_data->m_debugLinesTo.clear();
 	m_data->m_debugLinesColor.clear();
+	m_data->m_userConstraintInfoMap.clear();
+	clearCachedBodies();
+}
+
+void PhysicsDirect::clearCachedBodies()
+{
 	for (int i = 0; i < m_data->m_bodyJointMap.size(); i++)
 	{
 		BodyJointInfoCache2** bodyJointsPtr = m_data->m_bodyJointMap.getAtIndex(i);
@@ -151,7 +157,8 @@ void PhysicsDirect::resetData()
 		}
 	}
 	m_data->m_bodyJointMap.clear();
-	m_data->m_userConstraintInfoMap.clear();
+	m_data->m_userDataMap.clear();
+	m_data->m_userDataHandleLookup.clear();
 }
 
 // return true if connection succesfull, can also check 'isConnected'
@@ -912,7 +919,7 @@ void PhysicsDirect::postProcessStatus(const struct SharedMemoryStatus& serverCmd
 			break;
 		}
 		case CMD_SYNC_BODY_INFO_COMPLETED:
-			m_data->m_bodyJointMap.clear();
+			clearCachedBodies();
 		case CMD_MJCF_LOADING_COMPLETED:
 		case CMD_SDF_LOADING_COMPLETED:
 		{

--- a/examples/SharedMemory/PhysicsDirect.cpp
+++ b/examples/SharedMemory/PhysicsDirect.cpp
@@ -143,6 +143,8 @@ void PhysicsDirect::resetData()
 	m_data->m_debugLinesTo.clear();
 	m_data->m_debugLinesColor.clear();
 	m_data->m_userConstraintInfoMap.clear();
+	m_data->m_userDataMap.clear();
+	m_data->m_userDataHandleLookup.clear();
 	clearCachedBodies();
 }
 
@@ -157,8 +159,6 @@ void PhysicsDirect::clearCachedBodies()
 		}
 	}
 	m_data->m_bodyJointMap.clear();
-	m_data->m_userDataMap.clear();
-	m_data->m_userDataHandleLookup.clear();
 }
 
 // return true if connection succesfull, can also check 'isConnected'

--- a/examples/SharedMemory/PhysicsDirect.h
+++ b/examples/SharedMemory/PhysicsDirect.h
@@ -34,6 +34,8 @@ protected:
 
 	void removeCachedBody(int bodyUniqueId);
 
+	void clearCachedBodies();
+
 public:
 	PhysicsDirect(class PhysicsCommandProcessorInterface* physSdk, bool passSdkOwnership);
 


### PR DESCRIPTION
When working with two physics clients on a single physics server, the following problem can occur:

Client 1 adds bodies
Client 2 calls syncBodyInfo() - receives state of all bodies correctly.
Client 1 calls resetSimulation()
Client 2 calls syncBodyInfo() - still has all bodies in the cache (e.g. getNumBodies() does not return 0).

Similar problems happen with user data when resetSimulation() is called in multi-client setups.