### PR TITLE
Fix examples\pybullet\premake4.lua parsing error

### DIFF
--- a/examples/pybullet/premake4.lua
+++ b/examples/pybullet/premake4.lua
@@ -182,6 +182,7 @@ if not _OPTIONS["no-enet"] then
 			"../../examples/SharedMemory/plugins/collisionFilterPlugin/collisionFilterPlugin.cpp",
 			"../../examples/SharedMemory/plugins/pdControlPlugin/pdControlPlugin.cpp",
 			"../../examples/SharedMemory/plugins/pdControlPlugin/pdControlPlugin.h",
+		}
 			
 			
 


### PR DESCRIPTION
There is missing } after previous edit (226819), which leads to error when using build_visual_studio_vr_pybullet_double.bat

Adding it back fixed the error.

Just for reference, corresponding error:
```
D:\tools\bullet3\build3>premake4  --double --enable_multithreading --midi --enable_static_vr_plugin --enable_openvr --enable_pybullet --python_include_dir="c://include" --python_lib_dir="c://libs"   --targetdir="../bin" vs2010
 6.2.0 (Windows)
Project root directory: D:/tools/bullet3/build3/../
D:/tools/bullet3/examples/pybullet/premake4.lua:187: unexpected symbol near 'if'
```

I doubt it is worth to open any issue for it, thus only this PR.