### PR TITLE
Fix memory leak in RestoreState

### DIFF
--- a/examples/SharedMemory/PhysicsServerCommandProcessor.cpp
+++ b/examples/SharedMemory/PhysicsServerCommandProcessor.cpp
@@ -12152,6 +12152,7 @@ bool PhysicsServerCommandProcessor::processRestoreStateCommand(const struct Shar
 			b3Error("Error in restoreState: cannot load file %s\n", clientCmd.m_fileArguments.m_fileName);
 		}
 	}
+	delete importer;
 	if (ok)
 	{
 		serverCmd.m_type = CMD_RESTORE_STATE_COMPLETED;


### PR DESCRIPTION
The `btMultiBodyWorldImporter` within `processRestoreStateCommand` is not deallocated, leading to memory issues if this method is called many times. This pull request simply adds a `delete` statement at the end of the method.