### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,18 @@ track down the issue, but more work is required to cover all OpenCL kernels.
 All source code files are licensed under the permissive zlib license
 (http://opensource.org/licenses/Zlib) unless marked differently in a particular folder/file.
 
+## Build instructions for Bullet using vcpkg
+
+You can download and install Bullet using the [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    vcpkg install bullet3
+
+The Bullet port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ## Build instructions for Bullet using premake. You can also use cmake instead.
 
 **Windows**


### PR DESCRIPTION
Bullet is available as a port in vcpkg, a C++ library manager that simplifies installation for Bullet and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build Bullet, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/bullet3/portfile.cmake). We try to keep the library maintained as close as possible to the original library.