### PR TITLE
Fixing division by zero

### DIFF
--- a/src/BulletDynamics/ConstraintSolver/btBatchedConstraints.cpp
+++ b/src/BulletDynamics/ConstraintSolver/btBatchedConstraints.cpp
@@ -890,7 +890,7 @@ static void setupSpatialGridBatchesMt(
 
 	btVector3 gridExtent = bboxMax - bboxMin;
 
-	gridExtent.setMax({btScalar(1), btScalar(1), btScalar(1)});
+	gridExtent.setMax(btVector3(btScalar(1), btScalar(1), btScalar(1)));
 
 	btVector3 gridCellSize = consExtent;
 	int gridDim[3];

--- a/src/BulletDynamics/ConstraintSolver/btBatchedConstraints.cpp
+++ b/src/BulletDynamics/ConstraintSolver/btBatchedConstraints.cpp
@@ -890,6 +890,8 @@ static void setupSpatialGridBatchesMt(
 
 	btVector3 gridExtent = bboxMax - bboxMin;
 
+	gridExtent.setMax({btScalar(1), btScalar(1), btScalar(1)});
+
 	btVector3 gridCellSize = consExtent;
 	int gridDim[3];
 	gridDim[0] = int(1.0 + gridExtent.x() / gridCellSize.x());


### PR DESCRIPTION
If in
\examples\Benchmarks\BenchmarkDemo.cpp
set
468: float spacing = **0.0f**;
......
496: pos[1] += (cubeSize * **4.0f** + spacing);

then in
\src\BulletDynamics\ConstraintSolver\btBatchedConstraints.cpp
on line 891 gridExtent[1] becomes zero and assigned then to gridCellSize (line 919).
