### PR TITLE
Update bullet.pc.cmake

### DIFF
--- a/bullet.pc.cmake
+++ b/bullet.pc.cmake
@@ -1,6 +1,11 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/@LIB_DESTINATION@
+includedir=${prefix}/@INCLUDE_INSTALL_DIR@
+
 Name: bullet
 Description: Bullet Continuous Collision Detection and Physics Library
-Requires:
 Version: @BULLET_VERSION@
-Libs: -L@CMAKE_INSTALL_PREFIX@/@LIB_DESTINATION@ -lBulletSoftBody -lBulletDynamics -lBulletCollision -lLinearMath
-Cflags: @BULLET_DOUBLE_DEF@ -I@CMAKE_INSTALL_PREFIX@/@INCLUDE_INSTALL_DIR@ -I@CMAKE_INSTALL_PREFIX@/include
+Requires:
+Libs: -L${libdir} -lBulletSoftBody -lBulletDynamics -lBulletCollision -lLinearMath
+Cflags: @BULLET_DOUBLE_DEF@ -I${includedir} -I${prefix}/include


### PR DESCRIPTION
Change pkgconfig file to match example in pkg-config man files.

This PR updates the pkgconfig file to a more standard format instead of directly using hardcoded paths. This now allows for more flexibile usage, such as installations that can be moved between locations and systems. Using `pkg-config --define-prefix` allows pkg-config to override the prefix variable based on where it thinks the library is installed to.

With the lack of proper CMake targets support, this is the easiest way to use bullet with a project using modern CMake.
