### PR TITLE
Fix "seperate" typos

### DIFF
--- a/Extras/ConvexDecomposition/cd_wavefront.cpp
+++ b/Extras/ConvexDecomposition/cd_wavefront.cpp
@@ -176,7 +176,7 @@ public:
 		mHard[(int)c] = ST_DATA;
 	}
 
-	void DefaultSymbols(void);  // set up default symbols for hard seperator and comment symbol of the '#' character.
+	void DefaultSymbols(void);  // set up default symbols for hard separator and comment symbol of the '#' character.
 
 	bool EOS(char c)
 	{
@@ -197,7 +197,7 @@ private:
 	inline bool IsHard(char c);
 	inline char *SkipSpaces(char *foo);
 	inline bool IsWhiteSpace(char c);
-	inline bool IsNonSeparator(char c);  // non seperator,neither hard nor soft
+	inline bool IsNonSeparator(char c);  // non separator, neither hard nor soft
 
 	bool mMyAlloc;  // whether or not *I* allocated the buffer and am responsible for deleting it.
 	char *mData;    // ascii data to parse.

--- a/src/Bullet3OpenCL/BroadphaseCollision/b3GpuParallelLinearBvh.cpp
+++ b/src/Bullet3OpenCL/BroadphaseCollision/b3GpuParallelLinearBvh.cpp
@@ -496,7 +496,7 @@ void b3GpuParallelLinearBvh::constructBinaryRadixTree()
 		clFinish(m_queue);
 	}
 
-	//Find the number of nodes seperating each internal node and the root node
+	//Find the number of nodes separating each internal node and the root node
 	//so that the AABBs can be set using the next kernel.
 	//Also determine the maximum number of nodes separating an internal node and the root node.
 	{

--- a/src/Bullet3OpenCL/NarrowphaseCollision/b3StridingMeshInterface.h
+++ b/src/Bullet3OpenCL/NarrowphaseCollision/b3StridingMeshInterface.h
@@ -68,7 +68,7 @@ public:
 
 	virtual void unLockReadOnlyVertexBase(int subpart) const = 0;
 
-	/// getNumSubParts returns the number of seperate subparts
+	/// getNumSubParts returns the number of separate subparts
 	/// each subpart has a continuous array of vertices and indices
 	virtual int getNumSubParts() const = 0;
 

--- a/src/Bullet3OpenCL/NarrowphaseCollision/b3TriangleIndexVertexArray.h
+++ b/src/Bullet3OpenCL/NarrowphaseCollision/b3TriangleIndexVertexArray.h
@@ -100,7 +100,7 @@ public:
 
 	virtual void unLockReadOnlyVertexBase(int subpart) const { (void)subpart; }
 
-	/// getNumSubParts returns the number of seperate subparts
+	/// getNumSubParts returns the number of separate subparts
 	/// each subpart has a continuous array of vertices and indices
 	virtual int getNumSubParts() const
 	{

--- a/src/Bullet3OpenCL/NarrowphaseCollision/b3VoronoiSimplexSolver.cpp
+++ b/src/Bullet3OpenCL/NarrowphaseCollision/b3VoronoiSimplexSolver.cpp
@@ -183,9 +183,9 @@ bool b3VoronoiSimplexSolver::updateClosestVectorAndPoints()
 				const b3Vector3& c = m_simplexVectorW[2];
 				const b3Vector3& d = m_simplexVectorW[3];
 
-				bool hasSeperation = closestPtPointTetrahedron(p, a, b, c, d, m_cachedBC);
+				bool hasSeparation = closestPtPointTetrahedron(p, a, b, c, d, m_cachedBC);
 
-				if (hasSeperation)
+				if (hasSeparation)
 				{
 					m_cachedP1 = m_simplexPointsP[0] * m_cachedBC.m_barycentricCoords[0] +
 								 m_simplexPointsP[1] * m_cachedBC.m_barycentricCoords[1] +

--- a/src/BulletCollision/CollisionShapes/btStridingMeshInterface.h
+++ b/src/BulletCollision/CollisionShapes/btStridingMeshInterface.h
@@ -58,7 +58,7 @@ public:
 
 	virtual void unLockReadOnlyVertexBase(int subpart) const = 0;
 
-	/// getNumSubParts returns the number of seperate subparts
+	/// getNumSubParts returns the number of separate subparts
 	/// each subpart has a continuous array of vertices and indices
 	virtual int getNumSubParts() const = 0;
 

--- a/src/BulletCollision/CollisionShapes/btTriangleIndexVertexArray.h
+++ b/src/BulletCollision/CollisionShapes/btTriangleIndexVertexArray.h
@@ -100,7 +100,7 @@ public:
 
 	virtual void unLockReadOnlyVertexBase(int subpart) const { (void)subpart; }
 
-	/// getNumSubParts returns the number of seperate subparts
+	/// getNumSubParts returns the number of separate subparts
 	/// each subpart has a continuous array of vertices and indices
 	virtual int getNumSubParts() const
 	{

--- a/src/BulletCollision/NarrowPhaseCollision/btComputeGjkEpaPenetration.h
+++ b/src/BulletCollision/NarrowPhaseCollision/btComputeGjkEpaPenetration.h
@@ -95,11 +95,11 @@ int btComputeGjkEpaPenetration(const btConvexTemplate& a, const btConvexTemplate
 		for (;;)
 		//while (true)
 		{
-			btVector3 seperatingAxisInA = (-m_cachedSeparatingAxis) * localTransA.getBasis();
-			btVector3 seperatingAxisInB = m_cachedSeparatingAxis * localTransB.getBasis();
+			btVector3 separatingAxisInA = (-m_cachedSeparatingAxis) * localTransA.getBasis();
+			btVector3 separatingAxisInB = m_cachedSeparatingAxis * localTransB.getBasis();
 
-			btVector3 pInA = a.getLocalSupportWithoutMargin(seperatingAxisInA);
-			btVector3 qInB = b.getLocalSupportWithoutMargin(seperatingAxisInB);
+			btVector3 pInA = a.getLocalSupportWithoutMargin(separatingAxisInA);
+			btVector3 qInB = b.getLocalSupportWithoutMargin(separatingAxisInB);
 
 			btVector3 pWorld = localTransA(pInA);
 			btVector3 qWorld = localTransB(qInB);

--- a/src/BulletCollision/NarrowPhaseCollision/btGjkPairDetector.cpp
+++ b/src/BulletCollision/NarrowPhaseCollision/btGjkPairDetector.cpp
@@ -79,11 +79,11 @@ void btGjkPairDetector::getClosestPoints(const ClosestPointInput &input, Result 
 
 static void btComputeSupport(const btConvexShape *convexA, const btTransform &localTransA, const btConvexShape *convexB, const btTransform &localTransB, const btVector3 &dir, bool check2d, btVector3 &supAworld, btVector3 &supBworld, btVector3 &aMinb)
 {
-	btVector3 seperatingAxisInA = (dir)*localTransA.getBasis();
-	btVector3 seperatingAxisInB = (-dir) * localTransB.getBasis();
+	btVector3 separatingAxisInA = (dir)*localTransA.getBasis();
+	btVector3 separatingAxisInB = (-dir) * localTransB.getBasis();
 
-	btVector3 pInANoMargin = convexA->localGetSupportVertexWithoutMarginNonVirtual(seperatingAxisInA);
-	btVector3 qInBNoMargin = convexB->localGetSupportVertexWithoutMarginNonVirtual(seperatingAxisInB);
+	btVector3 pInANoMargin = convexA->localGetSupportVertexWithoutMarginNonVirtual(separatingAxisInA);
+	btVector3 qInBNoMargin = convexB->localGetSupportVertexWithoutMarginNonVirtual(separatingAxisInB);
 
 	btVector3 pInA = pInANoMargin;
 	btVector3 qInB = qInBNoMargin;
@@ -839,11 +839,11 @@ void btGjkPairDetector::getClosestPointsNonVirtual(const ClosestPointInput &inpu
 			for (;;)
 			//while (true)
 			{
-				btVector3 seperatingAxisInA = (-m_cachedSeparatingAxis) * localTransA.getBasis();
-				btVector3 seperatingAxisInB = m_cachedSeparatingAxis * localTransB.getBasis();
+				btVector3 separatingAxisInA = (-m_cachedSeparatingAxis) * localTransA.getBasis();
+				btVector3 separatingAxisInB = m_cachedSeparatingAxis * localTransB.getBasis();
 
-				btVector3 pInA = m_minkowskiA->localGetSupportVertexWithoutMarginNonVirtual(seperatingAxisInA);
-				btVector3 qInB = m_minkowskiB->localGetSupportVertexWithoutMarginNonVirtual(seperatingAxisInB);
+				btVector3 pInA = m_minkowskiA->localGetSupportVertexWithoutMarginNonVirtual(separatingAxisInA);
+				btVector3 qInB = m_minkowskiB->localGetSupportVertexWithoutMarginNonVirtual(separatingAxisInB);
 
 				btVector3 pWorld = localTransA(pInA);
 				btVector3 qWorld = localTransB(qInB);
@@ -1116,11 +1116,11 @@ void btGjkPairDetector::getClosestPointsNonVirtual(const ClosestPointInput &inpu
 
 			btScalar d2 = 0.f;
 			{
-				btVector3 seperatingAxisInA = (-orgNormalInB) * localTransA.getBasis();
-				btVector3 seperatingAxisInB = orgNormalInB * localTransB.getBasis();
+				btVector3 separatingAxisInA = (-orgNormalInB) * localTransA.getBasis();
+				btVector3 separatingAxisInB = orgNormalInB * localTransB.getBasis();
 
-				btVector3 pInA = m_minkowskiA->localGetSupportVertexWithoutMarginNonVirtual(seperatingAxisInA);
-				btVector3 qInB = m_minkowskiB->localGetSupportVertexWithoutMarginNonVirtual(seperatingAxisInB);
+				btVector3 pInA = m_minkowskiA->localGetSupportVertexWithoutMarginNonVirtual(separatingAxisInA);
+				btVector3 qInB = m_minkowskiB->localGetSupportVertexWithoutMarginNonVirtual(separatingAxisInB);
 
 				btVector3 pWorld = localTransA(pInA);
 				btVector3 qWorld = localTransB(qInB);
@@ -1130,11 +1130,11 @@ void btGjkPairDetector::getClosestPointsNonVirtual(const ClosestPointInput &inpu
 
 			btScalar d1 = 0;
 			{
-				btVector3 seperatingAxisInA = (normalInB)*localTransA.getBasis();
-				btVector3 seperatingAxisInB = -normalInB * localTransB.getBasis();
+				btVector3 separatingAxisInA = (normalInB)*localTransA.getBasis();
+				btVector3 separatingAxisInB = -normalInB * localTransB.getBasis();
 
-				btVector3 pInA = m_minkowskiA->localGetSupportVertexWithoutMarginNonVirtual(seperatingAxisInA);
-				btVector3 qInB = m_minkowskiB->localGetSupportVertexWithoutMarginNonVirtual(seperatingAxisInB);
+				btVector3 pInA = m_minkowskiA->localGetSupportVertexWithoutMarginNonVirtual(separatingAxisInA);
+				btVector3 qInB = m_minkowskiB->localGetSupportVertexWithoutMarginNonVirtual(separatingAxisInB);
 
 				btVector3 pWorld = localTransA(pInA);
 				btVector3 qWorld = localTransB(qInB);
@@ -1143,11 +1143,11 @@ void btGjkPairDetector::getClosestPointsNonVirtual(const ClosestPointInput &inpu
 			}
 			btScalar d0 = 0.f;
 			{
-				btVector3 seperatingAxisInA = (-normalInB) * input.m_transformA.getBasis();
-				btVector3 seperatingAxisInB = normalInB * input.m_transformB.getBasis();
+				btVector3 separatingAxisInA = (-normalInB) * input.m_transformA.getBasis();
+				btVector3 separatingAxisInB = normalInB * input.m_transformB.getBasis();
 
-				btVector3 pInA = m_minkowskiA->localGetSupportVertexWithoutMarginNonVirtual(seperatingAxisInA);
-				btVector3 qInB = m_minkowskiB->localGetSupportVertexWithoutMarginNonVirtual(seperatingAxisInB);
+				btVector3 pInA = m_minkowskiA->localGetSupportVertexWithoutMarginNonVirtual(separatingAxisInA);
+				btVector3 qInB = m_minkowskiB->localGetSupportVertexWithoutMarginNonVirtual(separatingAxisInB);
 
 				btVector3 pWorld = localTransA(pInA);
 				btVector3 qWorld = localTransB(qInB);

--- a/src/BulletCollision/NarrowPhaseCollision/btGjkPairDetector.h
+++ b/src/BulletCollision/NarrowPhaseCollision/btGjkPairDetector.h
@@ -64,9 +64,9 @@ public:
 	{
 		m_minkowskiB = minkB;
 	}
-	void setCachedSeperatingAxis(const btVector3& seperatingAxis)
+	void setCachedSeparatingAxis(const btVector3& separatingAxis)
 	{
-		m_cachedSeparatingAxis = seperatingAxis;
+		m_cachedSeparatingAxis = separatingAxis;
 	}
 
 	const btVector3& getCachedSeparatingAxis() const

--- a/src/BulletCollision/NarrowPhaseCollision/btMinkowskiPenetrationDepthSolver.cpp
+++ b/src/BulletCollision/NarrowPhaseCollision/btMinkowskiPenetrationDepthSolver.cpp
@@ -65,7 +65,7 @@ bool btMinkowskiPenetrationDepthSolver::calcPenDepth(btSimplexSolverInterface& s
 	btScalar minProj = btScalar(BT_LARGE_FLOAT);
 	btVector3 minNorm(btScalar(0.), btScalar(0.), btScalar(0.));
 	btVector3 minA, minB;
-	btVector3 seperatingAxisInA, seperatingAxisInB;
+	btVector3 separatingAxisInA, separatingAxisInB;
 	btVector3 pInA, qInB, pWorld, qWorld, w;
 
 #ifndef __SPU__
@@ -75,8 +75,8 @@ bool btMinkowskiPenetrationDepthSolver::calcPenDepth(btSimplexSolverInterface& s
 
 	btVector3 supportVerticesABatch[NUM_UNITSPHERE_POINTS + MAX_PREFERRED_PENETRATION_DIRECTIONS * 2];
 	btVector3 supportVerticesBBatch[NUM_UNITSPHERE_POINTS + MAX_PREFERRED_PENETRATION_DIRECTIONS * 2];
-	btVector3 seperatingAxisInABatch[NUM_UNITSPHERE_POINTS + MAX_PREFERRED_PENETRATION_DIRECTIONS * 2];
-	btVector3 seperatingAxisInBBatch[NUM_UNITSPHERE_POINTS + MAX_PREFERRED_PENETRATION_DIRECTIONS * 2];
+	btVector3 separatingAxisInABatch[NUM_UNITSPHERE_POINTS + MAX_PREFERRED_PENETRATION_DIRECTIONS * 2];
+	btVector3 separatingAxisInBBatch[NUM_UNITSPHERE_POINTS + MAX_PREFERRED_PENETRATION_DIRECTIONS * 2];
 	int i;
 
 	int numSampleDirections = NUM_UNITSPHERE_POINTS;
@@ -84,8 +84,8 @@ bool btMinkowskiPenetrationDepthSolver::calcPenDepth(btSimplexSolverInterface& s
 	for (i = 0; i < numSampleDirections; i++)
 	{
 		btVector3 norm = getPenetrationDirections()[i];
-		seperatingAxisInABatch[i] = (-norm) * transA.getBasis();
-		seperatingAxisInBBatch[i] = norm * transB.getBasis();
+		separatingAxisInABatch[i] = (-norm) * transA.getBasis();
+		separatingAxisInBBatch[i] = norm * transB.getBasis();
 	}
 
 	{
@@ -98,8 +98,8 @@ bool btMinkowskiPenetrationDepthSolver::calcPenDepth(btSimplexSolverInterface& s
 				convexA->getPreferredPenetrationDirection(i, norm);
 				norm = transA.getBasis() * norm;
 				getPenetrationDirections()[numSampleDirections] = norm;
-				seperatingAxisInABatch[numSampleDirections] = (-norm) * transA.getBasis();
-				seperatingAxisInBBatch[numSampleDirections] = norm * transB.getBasis();
+				separatingAxisInABatch[numSampleDirections] = (-norm) * transA.getBasis();
+				separatingAxisInBBatch[numSampleDirections] = norm * transB.getBasis();
 				numSampleDirections++;
 			}
 		}
@@ -115,15 +115,15 @@ bool btMinkowskiPenetrationDepthSolver::calcPenDepth(btSimplexSolverInterface& s
 				convexB->getPreferredPenetrationDirection(i, norm);
 				norm = transB.getBasis() * norm;
 				getPenetrationDirections()[numSampleDirections] = norm;
-				seperatingAxisInABatch[numSampleDirections] = (-norm) * transA.getBasis();
-				seperatingAxisInBBatch[numSampleDirections] = norm * transB.getBasis();
+				separatingAxisInABatch[numSampleDirections] = (-norm) * transA.getBasis();
+				separatingAxisInBBatch[numSampleDirections] = norm * transB.getBasis();
 				numSampleDirections++;
 			}
 		}
 	}
 
-	convexA->batchedUnitVectorGetSupportingVertexWithoutMargin(seperatingAxisInABatch, supportVerticesABatch, numSampleDirections);
-	convexB->batchedUnitVectorGetSupportingVertexWithoutMargin(seperatingAxisInBBatch, supportVerticesBBatch, numSampleDirections);
+	convexA->batchedUnitVectorGetSupportingVertexWithoutMargin(separatingAxisInABatch, supportVerticesABatch, numSampleDirections);
+	convexB->batchedUnitVectorGetSupportingVertexWithoutMargin(separatingAxisInBBatch, supportVerticesBBatch, numSampleDirections);
 
 	for (i = 0; i < numSampleDirections; i++)
 	{
@@ -134,8 +134,8 @@ bool btMinkowskiPenetrationDepthSolver::calcPenDepth(btSimplexSolverInterface& s
 		}
 		if (norm.length2() > 0.01)
 		{
-			seperatingAxisInA = seperatingAxisInABatch[i];
-			seperatingAxisInB = seperatingAxisInBBatch[i];
+			separatingAxisInA = separatingAxisInABatch[i];
+			separatingAxisInB = separatingAxisInBBatch[i];
 
 			pInA = supportVerticesABatch[i];
 			qInB = supportVerticesBBatch[i];
@@ -199,10 +199,10 @@ bool btMinkowskiPenetrationDepthSolver::calcPenDepth(btSimplexSolverInterface& s
 	for (int i = 0; i < numSampleDirections; i++)
 	{
 		const btVector3& norm = getPenetrationDirections()[i];
-		seperatingAxisInA = (-norm) * transA.getBasis();
-		seperatingAxisInB = norm * transB.getBasis();
-		pInA = convexA->localGetSupportVertexWithoutMarginNonVirtual(seperatingAxisInA);
-		qInB = convexB->localGetSupportVertexWithoutMarginNonVirtual(seperatingAxisInB);
+		separatingAxisInA = (-norm) * transA.getBasis();
+		separatingAxisInB = norm * transB.getBasis();
+		pInA = convexA->localGetSupportVertexWithoutMarginNonVirtual(separatingAxisInA);
+		qInB = convexB->localGetSupportVertexWithoutMarginNonVirtual(separatingAxisInB);
 		pWorld = transA(pInA);
 		qWorld = transB(qInB);
 		w = qWorld - pWorld;
@@ -259,7 +259,7 @@ bool btMinkowskiPenetrationDepthSolver::calcPenDepth(btSimplexSolverInterface& s
 	input.m_maximumDistanceSquared = btScalar(BT_LARGE_FLOAT);  //minProj;
 
 	btIntermediateResult res;
-	gjkdet.setCachedSeperatingAxis(-minNorm);
+	gjkdet.setCachedSeparatingAxis(-minNorm);
 	gjkdet.getClosestPoints(input, res, debugDraw);
 
 	btScalar correctedMinNorm = minProj - res.m_depth;

--- a/src/BulletCollision/NarrowPhaseCollision/btMprPenetration.h
+++ b/src/BulletCollision/NarrowPhaseCollision/btMprPenetration.h
@@ -309,11 +309,11 @@ inline void btMprSupport(const btConvexTemplate &a, const btConvexTemplate &b,
 						 const btMprCollisionDescription &colDesc,
 						 const btVector3 &dir, btMprSupport_t *supp)
 {
-	btVector3 seperatingAxisInA = dir * a.getWorldTransform().getBasis();
-	btVector3 seperatingAxisInB = -dir * b.getWorldTransform().getBasis();
+	btVector3 separatingAxisInA = dir * a.getWorldTransform().getBasis();
+	btVector3 separatingAxisInB = -dir * b.getWorldTransform().getBasis();
 
-	btVector3 pInA = a.getLocalSupportWithMargin(seperatingAxisInA);
-	btVector3 qInB = b.getLocalSupportWithMargin(seperatingAxisInB);
+	btVector3 pInA = a.getLocalSupportWithMargin(separatingAxisInA);
+	btVector3 qInB = b.getLocalSupportWithMargin(separatingAxisInB);
 
 	supp->v1 = a.getWorldTransform()(pInA);
 	supp->v2 = b.getWorldTransform()(qInB);


### PR DESCRIPTION
I noticed some typos in Bullet while I was working on Godot, so I'm upstreaming some typo fixes. "Separate" is the dominant English spelling and is already more common in Bullet.

Three notes with this PR:

* I didn't attempt to build and use this, it's probably good since it's just typo fixes, though I suppose  Travis and AppVeyor will be the judge of this.

* There are some more typos in `examples/ThirdPartyLibs/Gwen`, but I didn't touch these due to being a third-party library. Where is the upstream Gwen?

* VS Code generated a `.vscode/settings.json`. Should this be in the `.gitignore`?