### PR TITLE
fix the bug that prevents the pd control forces/torques being added

### DIFF
--- a/examples/SharedMemory/PhysicsServerCommandProcessor.cpp
+++ b/examples/SharedMemory/PhysicsServerCommandProcessor.cpp
@@ -9261,8 +9261,7 @@ bool PhysicsServerCommandProcessor::processSendPhysicsParametersCommand(const st
 				{
 				}
 			};
-
-#ifdef SKIP_DEFORMABLE_BODY
+            
 			if (newSolver)
 			{
 				delete oldSolver;
@@ -9271,7 +9270,6 @@ bool PhysicsServerCommandProcessor::processSendPhysicsParametersCommand(const st
 				m_data->m_solver = newSolver;
 				printf("switched solver\n");
 			}
-#endif
 		}
 	}
 

--- a/src/BulletDynamics/Dynamics/btRigidBody.cpp
+++ b/src/BulletDynamics/Dynamics/btRigidBody.cpp
@@ -206,6 +206,14 @@ void btRigidBody::applyGravity()
 	applyCentralForce(m_gravity);
 }
 
+void btRigidBody::clearGravity()
+{
+    if (isStaticOrKinematicObject())
+        return;
+    
+    applyCentralForce(-m_gravity);
+}
+
 void btRigidBody::proceedToTransform(const btTransform& newTrans)
 {
 	setCenterOfMassTransform(newTrans);

--- a/src/BulletDynamics/Dynamics/btRigidBody.h
+++ b/src/BulletDynamics/Dynamics/btRigidBody.h
@@ -205,6 +205,8 @@ public:
 	void saveKinematicState(btScalar step);
 
 	void applyGravity();
+    
+    void clearGravity();
 
 	void setGravity(const btVector3& acceleration);
 

--- a/src/BulletSoftBody/btDeformableMultiBodyDynamicsWorld.h
+++ b/src/BulletSoftBody/btDeformableMultiBodyDynamicsWorld.h
@@ -63,7 +63,9 @@ protected:
     void solveConstraints(btScalar timeStep);
     
     void updateActivationState(btScalar timeStep);
-
+    
+    void clearGravity();
+    
 public:
     btDeformableMultiBodyDynamicsWorld(btDispatcher* dispatcher, btBroadphaseInterface* pairCache, btDeformableMultiBodyConstraintSolver* constraintSolver, btCollisionConfiguration* collisionConfiguration, btDeformableBodySolver* deformableBodySolver = 0)
     : btMultiBodyDynamicsWorld(dispatcher, pairCache, (btMultiBodyConstraintSolver*)constraintSolver, collisionConfiguration),
@@ -90,6 +92,8 @@ public:
         m_selfCollision = true;
     }
 
+    virtual int stepSimulation(btScalar timeStep, int maxSubSteps = 1, btScalar fixedTimeStep = btScalar(1.) / btScalar(60.));
+    
     void setSolverCallback(btSolverCallback cb)
     {
         m_solverCallback = cb;


### PR DESCRIPTION
Fixes the following bug:
In deformable simulation, we need to move objects to temporary position x_{n+1}* = x_n + dt * v_{n+1}*, where v_{n+1}* for rigid/multibody is the velocity after gravity was applied. So we applied the gravity and cleared the force. But we accidentally clear the PD control forces/torques along with it. This commit fixes that issue by only clearing the gravity force. 

It also removes an unnecessary macro guard around constraint solver switch.