### PR TITLE
Make standalone example Apps run in realtime

### DIFF
--- a/examples/StandaloneMain/main_opengl_single_example.cpp
+++ b/examples/StandaloneMain/main_opengl_single_example.cpp
@@ -94,7 +94,7 @@ int main(int argc, char* argv[])
 		app->m_instancingRenderer->updateCamera(app->getUpAxis());
 
 		btScalar dtSec = btScalar(clock.getTimeInSeconds());
-		if (dtSec < 0.1)
+		if (dtSec > 0.1)
 			dtSec = 0.1;
 
 		example->stepSimulation(dtSec);


### PR DESCRIPTION
I was trying to test an idea by hacking the **BasicDemo** example and discovered the simulation in the standalone App binary would run too fast.  On closer examination I discovered: small timesteps were being clamped to be at least 0.1 second which I assume was a typo: they should be clamped to not be larger than that.

This pull request fixes the typo in the first commit, however I then introduced an explicit multi-step simulation strategy for the standalone examples.  If the extra work is not useful feel free to discard this PR and port just the first commit where the inequality operator is flipped.