### PR TITLE
Actually use self collisions when specified

### DIFF
--- a/examples/pybullet/pybullet.c
+++ b/examples/pybullet/pybullet.c
@@ -2065,6 +2065,10 @@ static PyObject* pybullet_loadSoftBody(PyObject* self, PyObject* args, PyObject*
 		{
 			b3LoadSoftBodyAddNeoHookeanForce(command, NeoHookeanMu, NeoHookeanLambda, NeoHookeanDamping);
 		}
+		if (useSelfCollision)
+		{
+			b3LoadSoftBodySetSelfCollision(command, useSelfCollision);
+		}
 		b3LoadSoftBodySetFrictionCoefficient(command, frictionCoeff);
 		statusHandle = b3SubmitClientCommandAndWaitStatus(sm, command);
 		statusType = b3GetStatusType(statusHandle);


### PR DESCRIPTION
This fork fixes a small bug where the useSelfCollisions argument to pybullet's loadSoftBody method was never used or passed onto the client. I found that there existed a b3 API function for this purpose that was never called. I suspect this was simply overlooked previously.