### PR TITLE
Remove unnecessary copy constructor in btBroadphasePair

### DIFF
--- a/src/BulletCollision/BroadphaseCollision/btBroadphaseProxy.h
+++ b/src/BulletCollision/BroadphaseCollision/btBroadphaseProxy.h
@@ -187,13 +187,6 @@ btBroadphasePair
 
 	BT_DECLARE_ALIGNED_ALLOCATOR();
 
-	btBroadphasePair(const btBroadphasePair& other)
-		: m_pProxy0(other.m_pProxy0),
-		  m_pProxy1(other.m_pProxy1),
-		  m_algorithm(other.m_algorithm),
-		  m_internalInfo1(other.m_internalInfo1)
-	{
-	}
 	btBroadphasePair(btBroadphaseProxy & proxy0, btBroadphaseProxy & proxy1)
 	{
 		//keep them sorted, so the std::set operations work


### PR DESCRIPTION
The implicitly-defined copy constructor would be equivalent.

Moreover, the generation of the implicitly-defined copy assignment operator is deprecated since C++11 if the type has a user-defined copy constructor. This generates an annoying warning on recent compilers.