### PR TITLE
Fix multi-line comment warning with -Wcomment

### DIFF
--- a/src/BulletCollision/CollisionDispatch/btCollisionWorldImporter.cpp
+++ b/src/BulletCollision/CollisionDispatch/btCollisionWorldImporter.cpp
@@ -292,8 +292,8 @@ btCollisionShape* btCollisionWorldImporter::convertCollisionShape(btCollisionSha
 			}
 			break;
 		}
-#endif  //SUPPORT_GIMPACT_SHAPE_IMPORT                                                                        \
-		//The btCapsuleShape* API has issue passing the margin/scaling/halfextents unmodified through the API \
+#endif  //SUPPORT_GIMPACT_SHAPE_IMPORT
+		//The btCapsuleShape* API has issue passing the margin/scaling/halfextents unmodified through the API
 		//so deal with this
 		case CAPSULE_SHAPE_PROXYTYPE:
 		{

--- a/src/BulletCollision/CollisionDispatch/btConvexConvexAlgorithm.cpp
+++ b/src/BulletCollision/CollisionDispatch/btConvexConvexAlgorithm.cpp
@@ -503,9 +503,9 @@ void btConvexConvexAlgorithm ::processCollision(const btCollisionObjectWrapper* 
 
 					gjkPairDetector.getClosestPoints(input, withoutMargin, dispatchInfo.m_debugDraw);
 					//gjkPairDetector.getClosestPoints(input,dummy,dispatchInfo.m_debugDraw);
-#endif  //ZERO_MARGIN                                                    \
-	//btScalar l2 = gjkPairDetector.getCachedSeparatingAxis().length2(); \
-	//if (l2>SIMD_EPSILON)
+#endif  //ZERO_MARGIN
+					//btScalar l2 = gjkPairDetector.getCachedSeparatingAxis().length2();
+					//if (l2>SIMD_EPSILON)
 					{
 						sepNormalWorldSpace = withoutMargin.m_reportedNormalOnWorld;  //gjkPairDetector.getCachedSeparatingAxis()*(1.f/l2);
 						//minDist = -1e30f;//gjkPairDetector.getCachedSeparatingDistance();


### PR DESCRIPTION
Fixes an annoying warning with -Wcomment under GCC.
This is probably some leftover from clang-format.