### PR TITLE
Fix warning with -Wunused-parameter

### DIFF
--- a/src/BulletCollision/BroadphaseCollision/btOverlappingPairCache.h
+++ b/src/BulletCollision/BroadphaseCollision/btOverlappingPairCache.h
@@ -68,7 +68,7 @@ public:
 
 	virtual void processAllOverlappingPairs(btOverlapCallback*, btDispatcher* dispatcher) = 0;
 
-	virtual void processAllOverlappingPairs(btOverlapCallback* callback, btDispatcher* dispatcher, const struct btDispatcherInfo& dispatchInfo)
+	virtual void processAllOverlappingPairs(btOverlapCallback* callback, btDispatcher* dispatcher, const struct btDispatcherInfo& /*dispatchInfo*/)
 	{
 		processAllOverlappingPairs(callback, dispatcher);
 	}


### PR DESCRIPTION
This fixes an annoying warning with -Wunused-parameter in user-included header.