### PR TITLE
Remove unnecessary copy constructor in btDbvt

### DIFF
--- a/src/BulletCollision/BroadphaseCollision/btDbvt.h
+++ b/src/BulletCollision/BroadphaseCollision/btDbvt.h
@@ -131,7 +131,6 @@ subject to the following restrictions:
 struct btDbvtAabbMm
 {
     DBVT_INLINE btDbvtAabbMm(){}
-    DBVT_INLINE btDbvtAabbMm(const btDbvtAabbMm& other): mi(other.mi), mx(other.mx){}
 	DBVT_INLINE btVector3 Center() const { return ((mi + mx) / 2); }
 	DBVT_INLINE btVector3 Lengths() const { return (mx - mi); }
 	DBVT_INLINE btVector3 Extents() const { return ((mx - mi) / 2); }


### PR DESCRIPTION
The implicitly-defined copy constructor would be equivalent.

Moreover, the generation of the implicitly-defined copy assignment operator is deprecated since C++11 if the type has a user-defined copy constructor. This generates an annoying warning on recent compilers.