### PR TITLE
Fix warning with -Wreorder

### DIFF
--- a/src/BulletCollision/BroadphaseCollision/btDbvt.h
+++ b/src/BulletCollision/BroadphaseCollision/btDbvt.h
@@ -203,8 +203,8 @@ struct btDbvntNode
 
     btDbvntNode(const btDbvtNode* n)
     : volume(n->volume)
-    , angle(0)
     , normal(0,0,0)
+    , angle(0)
     , data(n->data)
     {
         childs[0] = 0;


### PR DESCRIPTION
This patch fixes a warning when using -Wreorder with GCC.