### PR TITLE
fix sorting bug in btAxisSweep3Internal.h

### DIFF
--- a/src/BulletCollision/BroadphaseCollision/btAxisSweep3Internal.h
+++ b/src/BulletCollision/BroadphaseCollision/btAxisSweep3Internal.h
@@ -721,27 +721,23 @@ void btAxisSweep3Internal<BP_FP_INT_TYPE>::updateHandle(BP_FP_INT_TYPE handle, c
 	for (int axis = 0; axis < 3; axis++)
 	{
 		BP_FP_INT_TYPE emin = pHandle->m_minEdges[axis];
+        int dmin = (int)min[axis] - (int)m_pEdges[axis][emin].m_pos;
+        m_pEdges[axis][emin].m_pos = min[axis];
+        
+        if (dmin < 0)
+            sortMinDown(axis, emin,dispatcher,true);
+        else if (dmin > 0)
+            sortMinUp(axis, emin,dispatcher,true);
+        
+        
 		BP_FP_INT_TYPE emax = pHandle->m_maxEdges[axis];
-
-		int dmin = (int)min[axis] - (int)m_pEdges[axis][emin].m_pos;
 		int dmax = (int)max[axis] - (int)m_pEdges[axis][emax].m_pos;
-
-		m_pEdges[axis][emin].m_pos = min[axis];
 		m_pEdges[axis][emax].m_pos = max[axis];
-
-		// expand (only adds overlaps)
-		if (dmin < 0)
-			sortMinDown(axis, emin, dispatcher, true);
-
+        
 		if (dmax > 0)
-			sortMaxUp(axis, emax, dispatcher, true);
-
-		// shrink (only removes overlaps)
-		if (dmin > 0)
-			sortMinUp(axis, emin, dispatcher, true);
-
-		if (dmax < 0)
-			sortMaxDown(axis, emax, dispatcher, true);
+			sortMaxUp(axis, emax,dispatcher,true);
+		else if (dmax < 0)
+			sortMaxDown(axis, emax,dispatcher,true);
 
 #ifdef DEBUG_BROADPHASE
 		debugPrintAxis(axis);


### PR DESCRIPTION
2 situations may lead to wrong sorting result in btAxisSweep3Internal::updateHandle

situation1:
The resorting of pHandle->m_minEdges[axis] change the value of pHandle->m_maxEdges[axis], so the value of emax is no longer equals to pHandle->m_maxEdges[axis].

situation2:
it' s hard to describe in text so I have made a example
edge values before updating: [0, 1, 2, 3]
after change edge[1] to 5 and edge[2] to 6: [0, 5, 6, 3]
try to do sortMinUp(emin = 1) and you will find that the value of pHandleNext->m_minEdges[axis] does not increase while it ought to.

to fix this bug, the modification of edge value and resorting should be done step by step.
