### PR TITLE
[crash fix for btCollisionDispatcherMt] a better approach to merge new manifolds when using the jobs CPU dispatcher

### DIFF
--- a/src/BulletCollision/CollisionDispatch/btCollisionDispatcherMt.h
+++ b/src/BulletCollision/CollisionDispatch/btCollisionDispatcherMt.h
@@ -30,7 +30,7 @@ public:
 	virtual void dispatchAllCollisionPairs(btOverlappingPairCache* pairCache, const btDispatcherInfo& info, btDispatcher* dispatcher) BT_OVERRIDE;
 
 protected:
-	btAlignedObjectArray<btAlignedObjectArray<btPersistentManifold*>> m_batchManifoldsPtr;
+	btAlignedObjectArray<btAlignedObjectArray<btPersistentManifold*> > m_batchManifoldsPtr;
 	bool m_batchUpdating;
 	int m_grainSize;
 };

--- a/src/BulletCollision/CollisionDispatch/btCollisionDispatcherMt.h
+++ b/src/BulletCollision/CollisionDispatch/btCollisionDispatcherMt.h
@@ -30,6 +30,7 @@ public:
 	virtual void dispatchAllCollisionPairs(btOverlappingPairCache* pairCache, const btDispatcherInfo& info, btDispatcher* dispatcher) BT_OVERRIDE;
 
 protected:
+	btAlignedObjectArray<btAlignedObjectArray<btPersistentManifold*>> m_batchManifoldsPtr;
 	bool m_batchUpdating;
 	int m_grainSize;
 };


### PR DESCRIPTION
Hi, after several ways I found to resolve the issue, I think this is the most elegant as it only requires few minimal changes in the multi threaded dispatcher (which is the only place the bug happens) implementation without touching anything else.

Notes:
- The crash only happens using btHashedOverlappingPairCache probably because btSortedOverlappingPairCache uses a deferred pair removal policy by default.
- This PR might resolve a similar issue already reported in the past which I believe is related to #2002 

The scenario is the following:
```
mOverlappingPairCache = new btHashedOverlappingPairCache();
mOverlappingPairCache->setInternalGhostPairCallback( mGhostPairCallback );
mDynamicsWorld = new btDiscreteDynamicsWorldMt( mDispatcher, mBroadphase, mSolverPool, mSolver, mCollisionConfiguration );
```
Then, push 2 objects in the world, in my case I have the Capsule and a Box and make them to collide to trigger the collision pair cache creation and starts to collect manifolds information.
mDynamicsWorld->stepSimulation( TickSec * mEditorTimeScale, smPhysicsMaxSubSteps, smPhysicsStepTime );

then what I do is to perform a manual call to my ghost object:
`collWorld->getDispatcher()->dispatchAllCollisionPairs(   mGhostObject->getOverlappingPairCache(), collWorld->getDispatchInfo(), collWorld->getDispatcher() );`

In the next frame the `mDynamicsWorld->stepSimulation` should trigger an assert then a crash in:
`void btCollisionDispatcherMt::releaseManifold -> btAssert(findIndex < m_manifoldsPtr.size());`

What happens is that in the multi-threaded implementation of dispatchAllCollisionPairs we are clearing the m_manifoldsPtr array object which collects all the manifolds from any pair cache and then query again all the contact manifold using getAllContactManifolds and not assuming that the object can collect any manifolds from any pair cache which can be created and dispatched from user code (in my case, the ghost object). This causes some manifolds to get cleared from m_manifoldsPtr array object before the pair cache invoke the deletion, then when the deletion is triggered you reach that assert because the element has not been found in the array.
For a reason I didn't really investigate however,  as I said before, the problem doesn't happen if a btSortedOverlappingPairCache is used probably because of the deferred removal policy, but it might causes missing collision as described in #2002 

The fix consists on avoiding to defer the manifold collecting operation to the main thread, instead a local array per thread is used to collect manifolds and then merged together to the main thread when all jobs are finished, keeping everything lockless, fast as before and without the crash.

Hope it helps