### PR TITLE
Remove unused custom vector math cmake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,6 @@ IF(NOT WIN32)
 ENDIF(NOT WIN32)
 
 OPTION(USE_MSVC_INCREMENTAL_LINKING "Use MSVC Incremental Linking" OFF)
-OPTION(USE_CUSTOM_VECTOR_MATH "Use custom vectormath library" OFF)
 
 #statically linking VC++ isn't supported for WindowsPhone/WindowsStore
 IF (CMAKE_SYSTEM_NAME STREQUAL WindowsPhone OR CMAKE_SYSTEM_NAME STREQUAL WindowsStore)


### PR DESCRIPTION
This option is not used anywhere in the codebase. Seems to have hung around for over a decade at this point - came across it whilst configuring and was curious what it is.

Judging from some old articles on game engine designers weighing bullet and ODS, I'd wager it had to do with the new SIMD vector library that Bullet used a while back. But that's just a guess.

Anyway, doesn't appear to be needed anymore. Figured I'd help remove _some_ cruft :)