### PR TITLE
Adds an option to syncUserData to specify the bodies for which to sync.

### DIFF
--- a/examples/SharedMemory/PhysicsClientC_API.cpp
+++ b/examples/SharedMemory/PhysicsClientC_API.cpp
@@ -3714,8 +3714,19 @@ B3_SHARED_API b3SharedMemoryCommandHandle b3InitSyncUserDataCommand(b3PhysicsCli
 	b3Assert(command);
 
 	command->m_type = CMD_SYNC_USER_DATA;
+	command->m_syncUserDataRequestArgs.m_numRequestedBodies = 0;
 	return (b3SharedMemoryCommandHandle)command;
 }
+
+B3_SHARED_API void b3AddBodyToSyncUserDataRequest(b3SharedMemoryCommandHandle commandHandle, int bodyUniqueId)
+{
+	struct SharedMemoryCommand* command = (struct SharedMemoryCommand*)commandHandle;
+	b3Assert(command);
+	b3Assert(command->m_type == CMD_SYNC_USER_DATA);
+
+	command->m_syncUserDataRequestArgs.m_requestedBodyIds[command->m_syncUserDataRequestArgs.m_numRequestedBodies++] = bodyUniqueId;
+}
+
 
 B3_SHARED_API b3SharedMemoryCommandHandle b3InitAddUserDataCommand(b3PhysicsClientHandle physClient, int bodyUniqueId, int linkIndex, int visualShapeIndex, const char* key, UserDataValueType valueType, int valueLength, const void* valueData)
 {

--- a/examples/SharedMemory/PhysicsClientC_API.h
+++ b/examples/SharedMemory/PhysicsClientC_API.h
@@ -130,6 +130,7 @@ extern "C"
 
 	///user data handling
 	B3_SHARED_API b3SharedMemoryCommandHandle b3InitSyncUserDataCommand(b3PhysicsClientHandle physClient);
+	B3_SHARED_API void b3AddBodyToSyncUserDataRequest(b3SharedMemoryCommandHandle commandHandle, int bodyUniqueId);
 	B3_SHARED_API b3SharedMemoryCommandHandle b3InitAddUserDataCommand(b3PhysicsClientHandle physClient, int bodyUniqueId, int linkIndex, int visualShapeIndex, const char* key, enum UserDataValueType valueType, int valueLength, const void* valueData);
 	B3_SHARED_API b3SharedMemoryCommandHandle b3InitRemoveUserDataCommand(b3PhysicsClientHandle physClient, int userDataId);
 

--- a/examples/SharedMemory/PhysicsServerCommandProcessor.cpp
+++ b/examples/SharedMemory/PhysicsServerCommandProcessor.cpp
@@ -6139,7 +6139,24 @@ bool PhysicsServerCommandProcessor::processSyncUserDataCommand(const struct Shar
 	BT_PROFILE("CMD_SYNC_USER_DATA");
 
 	b3AlignedObjectArray<int> userDataHandles;
-	m_data->m_userDataHandles.getUsedHandles(userDataHandles);
+	if (clientCmd.m_syncUserDataRequestArgs.m_numRequestedBodies == 0)
+	{
+		m_data->m_userDataHandles.getUsedHandles(userDataHandles);
+	}
+	else
+	{
+		for (int i=0; i<clientCmd.m_syncUserDataRequestArgs.m_numRequestedBodies; ++i) {
+			const int bodyUniqueId = clientCmd.m_syncUserDataRequestArgs.m_requestedBodyIds[i];
+			InternalBodyData* body = m_data->m_bodyHandles.getHandle(bodyUniqueId);
+			if (!body)
+			{
+				return hasStatus;
+			}
+			for (int j=0; j < body->m_userDataHandles.size(); ++j) {
+				userDataHandles.push_back(body->m_userDataHandles[j]);
+			}
+		}
+	}
 	if (userDataHandles.size())
 	{
 		memcpy(bufferServerToClient, &userDataHandles[0], sizeof(int) * userDataHandles.size());

--- a/examples/SharedMemory/SharedMemoryCommands.h
+++ b/examples/SharedMemory/SharedMemoryCommands.h
@@ -1044,6 +1044,14 @@ struct b3StateSerializationArguments
 	int m_stateId;
 };
 
+struct SyncUserDataRequestArgs
+{
+	// The number of bodies for which we'd like to sync the user data of. When 0, all bodies are synced.
+	int m_numRequestedBodies;
+	// The body IDs for which we'd like to sync the user data of.
+	int m_requestedBodyIds[MAX_REQUESTED_BODIES_LENGTH];
+};
+
 struct SyncUserDataArgs
 {
 	// User data identifiers stored in m_bulletStreamDataServerToClientRefactor
@@ -1148,6 +1156,7 @@ struct SharedMemoryCommand
 		struct b3CustomCommand m_customCommandArgs;
 		struct b3StateSerializationArguments m_loadStateArguments;
 		struct RequestCollisionShapeDataArgs m_requestCollisionShapeDataArguments;
+		struct SyncUserDataRequestArgs m_syncUserDataRequestArgs;
 		struct UserDataRequestArgs m_userDataRequestArgs;
 		struct AddUserDataRequestArgs m_addUserDataRequestArgs;
 		struct UserDataRequestArgs m_removeUserDataRequestArgs;

--- a/examples/SharedMemory/SharedMemoryPublic.h
+++ b/examples/SharedMemory/SharedMemoryPublic.h
@@ -494,6 +494,7 @@ enum b3VREventType
 
 #define MAX_SDF_BODIES 512
 #define MAX_USER_DATA_KEY_LENGTH 256
+#define MAX_REQUESTED_BODIES_LENGTH 256
 
 enum b3VRButtonInfo
 {

--- a/examples/SharedMemory/SharedMemoryPublic.h
+++ b/examples/SharedMemory/SharedMemoryPublic.h
@@ -7,7 +7,8 @@
 //Please don't replace an existing magic number:
 //instead, only ADD a new one at the top, comment-out previous one
 
-#define SHARED_MEMORY_MAGIC_NUMBER 201911280
+#define SHARED_MEMORY_MAGIC_NUMBER 202001230
+//#define SHARED_MEMORY_MAGIC_NUMBER 201911280
 //#define SHARED_MEMORY_MAGIC_NUMBER 201911180
 //#define SHARED_MEMORY_MAGIC_NUMBER 201909030
 //#define SHARED_MEMORY_MAGIC_NUMBER 201908110

--- a/examples/pybullet/unittests/userDataTest.py
+++ b/examples/pybullet/unittests/userDataTest.py
@@ -28,7 +28,7 @@ class TestUserDataMethods(unittest.TestCase):
 
   def testLoadingUserDataFromURDF(self):
     body_id = self.client.loadURDF(OBJECT_WITH_USER_DATA_PATH)
-    self.client.syncUserData()
+    self.client.syncUserData(body_id)
     num_user_data = self.client.getNumUserData(body_id)
 
     self.assertEqual(num_user_data, 7)


### PR DESCRIPTION
When the user data of a few bodies are modified (e.g. one new object is added to a large scene), it is useful to only sync the user data of a subset of bodies.

If no bodies are specified, the old behavior of synchronizing the complete state remains.