### PR TITLE
Only clear the user data cache when a full user data sync is requested.

### DIFF
--- a/examples/SharedMemory/PhysicsClientSharedMemory.cpp
+++ b/examples/SharedMemory/PhysicsClientSharedMemory.cpp
@@ -1585,17 +1585,19 @@ const SharedMemoryStatus* PhysicsClientSharedMemory::processServerStatus()
 		if (serverCmd.m_type == CMD_SYNC_USER_DATA_COMPLETED)
 		{
 			B3_PROFILE("CMD_SYNC_USER_DATA_COMPLETED");
-			// Remove all cached user data entries.
-			for (int i = 0; i < m_data->m_bodyJointMap.size(); i++)
-			{
-				BodyJointInfoCache** bodyJointsPtr = m_data->m_bodyJointMap.getAtIndex(i);
-				if (bodyJointsPtr && *bodyJointsPtr)
+			if (serverCmd.m_syncUserDataArgs.m_clearCachedUserDataEntries) {
+				// Remove all cached user data entries.
+				for (int i = 0; i < m_data->m_bodyJointMap.size(); i++)
 				{
-					(*bodyJointsPtr)->m_userDataIds.clear();
+					BodyJointInfoCache** bodyJointsPtr = m_data->m_bodyJointMap.getAtIndex(i);
+					if (bodyJointsPtr && *bodyJointsPtr)
+					{
+						(*bodyJointsPtr)->m_userDataIds.clear();
+					}
 				}
+				m_data->m_userDataMap.clear();
+				m_data->m_userDataHandleLookup.clear();
 			}
-			m_data->m_userDataMap.clear();
-			m_data->m_userDataHandleLookup.clear();
 			const int numIdentifiers = serverCmd.m_syncUserDataArgs.m_numUserDataIdentifiers;
 			if (numIdentifiers > 0)
 			{

--- a/examples/SharedMemory/PhysicsDirect.cpp
+++ b/examples/SharedMemory/PhysicsDirect.cpp
@@ -1244,15 +1244,17 @@ void PhysicsDirect::postProcessStatus(const struct SharedMemoryStatus& serverCmd
 		case CMD_SYNC_USER_DATA_COMPLETED:
 		{
 			B3_PROFILE("CMD_SYNC_USER_DATA_COMPLETED");
-			// Remove all cached user data entries.
-			m_data->m_userDataMap.clear();
-			m_data->m_userDataHandleLookup.clear();
-			for (int i = 0; i < m_data->m_bodyJointMap.size(); i++)
-			{
-				BodyJointInfoCache2** bodyJointsPtr = m_data->m_bodyJointMap.getAtIndex(i);
-				if (bodyJointsPtr && *bodyJointsPtr)
+			if (serverCmd.m_syncUserDataArgs.m_clearCachedUserDataEntries) {
+				// Remove all cached user data entries.
+				m_data->m_userDataMap.clear();
+				m_data->m_userDataHandleLookup.clear();
+				for (int i = 0; i < m_data->m_bodyJointMap.size(); i++)
 				{
-					(*bodyJointsPtr)->m_userDataIds.clear();
+					BodyJointInfoCache2** bodyJointsPtr = m_data->m_bodyJointMap.getAtIndex(i);
+					if (bodyJointsPtr && *bodyJointsPtr)
+					{
+						(*bodyJointsPtr)->m_userDataIds.clear();
+					}
 				}
 			}
 			const int numIdentifiers = serverCmd.m_syncUserDataArgs.m_numUserDataIdentifiers;

--- a/examples/SharedMemory/PhysicsServerCommandProcessor.cpp
+++ b/examples/SharedMemory/PhysicsServerCommandProcessor.cpp
@@ -6161,6 +6161,8 @@ bool PhysicsServerCommandProcessor::processSyncUserDataCommand(const struct Shar
 	{
 		memcpy(bufferServerToClient, &userDataHandles[0], sizeof(int) * userDataHandles.size());
 	}
+	// Only clear the client-side cache when a full sync is requested
+	serverStatusOut.m_syncUserDataArgs.m_clearCachedUserDataEntries = clientCmd.m_syncUserDataRequestArgs.m_numRequestedBodies == 0;
 	serverStatusOut.m_syncUserDataArgs.m_numUserDataIdentifiers = userDataHandles.size();
 	serverStatusOut.m_type = CMD_SYNC_USER_DATA_COMPLETED;
 	return hasStatus;

--- a/examples/SharedMemory/SharedMemoryCommands.h
+++ b/examples/SharedMemory/SharedMemoryCommands.h
@@ -1057,6 +1057,8 @@ struct SyncUserDataArgs
 	// User data identifiers stored in m_bulletStreamDataServerToClientRefactor
 	// as as array of integers.
 	int m_numUserDataIdentifiers;
+	// Whether the client should clear its user data cache.
+	bool m_clearCachedUserDataEntries;
 };
 
 struct UserDataRequestArgs

--- a/examples/SharedMemory/SharedMemoryPublic.h
+++ b/examples/SharedMemory/SharedMemoryPublic.h
@@ -7,7 +7,8 @@
 //Please don't replace an existing magic number:
 //instead, only ADD a new one at the top, comment-out previous one
 
-#define SHARED_MEMORY_MAGIC_NUMBER 202001230
+#define SHARED_MEMORY_MAGIC_NUMBER 202002030
+//#define SHARED_MEMORY_MAGIC_NUMBER 202001230
 //#define SHARED_MEMORY_MAGIC_NUMBER 201911280
 //#define SHARED_MEMORY_MAGIC_NUMBER 201911180
 //#define SHARED_MEMORY_MAGIC_NUMBER 201909030


### PR DESCRIPTION
When syncing a single user data entry, we shouldn't clear the client-side user data cache.