### PR TITLE
Alternative names for member variables using unions for more intuitive usage.

### DIFF
--- a/src/LinearMath/btQuadWord.h
+++ b/src/LinearMath/btQuadWord.h
@@ -37,6 +37,13 @@ protected:
 	union {
 		vec_float4 mVec128;
 		btScalar m_floats[4];
+		struct
+		{
+			btScalar X;
+			btScalar Y;
+			btScalar Z;
+			btScalar W;
+		};
 	};
 
 public:
@@ -52,6 +59,13 @@ protected:
 	union {
 		btSimdFloat4 mVec128;
 		btScalar m_floats[4];
+		struct
+		{
+			btScalar X;
+			btScalar Y;
+			btScalar Z;
+			btScalar W;
+		};
 	};
 
 public:
@@ -64,7 +78,16 @@ public:
 		mVec128 = v128;
 	}
 #else
-	btScalar m_floats[4];
+	union {
+		btScalar m_floats[4];
+		struct
+		{
+			btScalar X;
+			btScalar Y;
+			btScalar Z;
+			btScalar W;
+		};
+	};
 #endif  // BT_USE_SSE
 
 #endif  //__CELLOS_LV2__ __SPU__

--- a/src/LinearMath/btVector3.h
+++ b/src/LinearMath/btVector3.h
@@ -84,7 +84,16 @@ public:
 	BT_DECLARE_ALIGNED_ALLOCATOR();
 
 #if defined(__SPU__) && defined(__CELLOS_LV2__)
-	btScalar m_floats[4];
+	union {
+		btScalar m_floats[4];
+		struct
+		{
+			btScalar X;
+			btScalar Y;
+			btScalar Z;
+			btScalar W;
+		};
+	};
 
 public:
 	SIMD_FORCE_INLINE const vec_float4& get128() const
@@ -98,6 +107,13 @@ public:
 	union {
 		btSimdFloat4 mVec128;
 		btScalar m_floats[4];
+		struct
+		{
+			btScalar X;
+			btScalar Y;
+			btScalar Z;
+			btScalar W;
+		};
 	};
 	SIMD_FORCE_INLINE btSimdFloat4 get128() const
 	{
@@ -108,7 +124,16 @@ public:
 		mVec128 = v128;
 	}
 #else
-	btScalar m_floats[4];
+	union {
+		btScalar m_floats[4];
+		struct
+		{
+			btScalar X;
+			btScalar Y;
+			btScalar Z;
+			btScalar W;
+		};
+	};
 #endif
 #endif  //__CELLOS_LV2__ __SPU__
 


### PR DESCRIPTION
The pull request is meant to make the usage of vector and quaternion classes slightly more intuitive. While I'm fully aware of the presence of getters and setters for these members they tend to be difficult to work with when you need to use them often. The original name itself (m_floats) is also far away from being intuitive, especially since the values can be either floats or doubles (the change to this name (e.g. to something like m_scalars) cannot be done due to many projects relying on the old naming). For this reason I'd propose using a simple union to refer to these elements in an alternative way - the way that you'd normally (at least in most cases) refer to the members of a vector or a quaternion. This change should not affect binary compatibility.