### PR TITLE
apply custom pair-cache filter to predictive contacts

### DIFF
--- a/src/BulletCollision/BroadphaseCollision/btOverlappingPairCache.h
+++ b/src/BulletCollision/BroadphaseCollision/btOverlappingPairCache.h
@@ -61,7 +61,8 @@ public:
 	virtual void cleanOverlappingPair(btBroadphasePair& pair, btDispatcher* dispatcher) = 0;
 
 	virtual int getNumOverlappingPairs() const = 0;
-
+	virtual bool needsBroadphaseCollision(btBroadphaseProxy * proxy0, btBroadphaseProxy * proxy1) const = 0; // stephengold added 2020-02-12
+	virtual btOverlapFilterCallback* getOverlapFilterCallback() = 0; // stephengold added 2020-02-12
 	virtual void cleanProxyFromPairs(btBroadphaseProxy* proxy, btDispatcher* dispatcher) = 0;
 
 	virtual void setOverlapFilterCallback(btOverlapFilterCallback* callback) = 0;
@@ -380,6 +381,14 @@ public:
 	{
 	}
 
+	bool needsBroadphaseCollision(btBroadphaseProxy*, btBroadphaseProxy*) const // stephengold added 2020-02-12
+	{ // stephengold added 2020-02-12
+		return true; // stephengold added 2020-02-12
+	} // stephengold added 2020-02-12
+	btOverlapFilterCallback* getOverlapFilterCallback() // stephengold added 2020-02-12
+	{ // stephengold added 2020-02-12
+		return 0; // stephengold added 2020-02-12
+	} // stephengold added 2020-02-12
 	virtual void setOverlapFilterCallback(btOverlapFilterCallback* /*callback*/)
 	{
 	}

--- a/src/BulletCollision/BroadphaseCollision/btOverlappingPairCache.h
+++ b/src/BulletCollision/BroadphaseCollision/btOverlappingPairCache.h
@@ -61,8 +61,8 @@ public:
 	virtual void cleanOverlappingPair(btBroadphasePair& pair, btDispatcher* dispatcher) = 0;
 
 	virtual int getNumOverlappingPairs() const = 0;
-	virtual bool needsBroadphaseCollision(btBroadphaseProxy * proxy0, btBroadphaseProxy * proxy1) const = 0; // stephengold added 2020-02-12
-	virtual btOverlapFilterCallback* getOverlapFilterCallback() = 0; // stephengold added 2020-02-12
+	virtual bool needsBroadphaseCollision(btBroadphaseProxy * proxy0, btBroadphaseProxy * proxy1) const = 0;
+	virtual btOverlapFilterCallback* getOverlapFilterCallback() = 0;
 	virtual void cleanProxyFromPairs(btBroadphaseProxy* proxy, btDispatcher* dispatcher) = 0;
 
 	virtual void setOverlapFilterCallback(btOverlapFilterCallback* callback) = 0;
@@ -381,14 +381,14 @@ public:
 	{
 	}
 
-	bool needsBroadphaseCollision(btBroadphaseProxy*, btBroadphaseProxy*) const // stephengold added 2020-02-12
-	{ // stephengold added 2020-02-12
-		return true; // stephengold added 2020-02-12
-	} // stephengold added 2020-02-12
-	btOverlapFilterCallback* getOverlapFilterCallback() // stephengold added 2020-02-12
-	{ // stephengold added 2020-02-12
-		return 0; // stephengold added 2020-02-12
-	} // stephengold added 2020-02-12
+	bool needsBroadphaseCollision(btBroadphaseProxy*, btBroadphaseProxy*) const
+	{
+		return true;
+	}
+	btOverlapFilterCallback* getOverlapFilterCallback()
+	{
+		return 0;
+	}
 	virtual void setOverlapFilterCallback(btOverlapFilterCallback* /*callback*/)
 	{
 	}

--- a/src/BulletDynamics/Dynamics/btDiscreteDynamicsWorld.cpp
+++ b/src/BulletDynamics/Dynamics/btDiscreteDynamicsWorld.cpp
@@ -800,14 +800,14 @@ public:
 		///don't do CCD when the collision filters are not matching
 		if (!ClosestConvexResultCallback::needsCollision(proxy0))
 			return false;
-		if (m_pairCache->getOverlapFilterCallback()) { // stephengold added 2020-02-12
-			btBroadphaseProxy* proxy1 = m_me->getBroadphaseHandle(); // stephengold added 2020-02-12
-			bool collides = m_pairCache->needsBroadphaseCollision(proxy0, proxy1); // stephengold added 2020-02-12
-			if (!collides) // stephengold added 2020-02-12
-			{ // stephengold added 2020-02-12
-				return false; // stephengold added 2020-02-12
-			} // stephengold added 2020-02-12
-		} // stephengold added 2020-02-12
+		if (m_pairCache->getOverlapFilterCallback()) {
+			btBroadphaseProxy* proxy1 = m_me->getBroadphaseHandle();
+			bool collides = m_pairCache->needsBroadphaseCollision(proxy0, proxy1);
+			if (!collides)
+			{
+				return false;
+			}
+		}
 
 		btCollisionObject* otherObj = (btCollisionObject*)proxy0->m_clientObject;
 

--- a/src/BulletDynamics/Dynamics/btDiscreteDynamicsWorld.cpp
+++ b/src/BulletDynamics/Dynamics/btDiscreteDynamicsWorld.cpp
@@ -800,6 +800,14 @@ public:
 		///don't do CCD when the collision filters are not matching
 		if (!ClosestConvexResultCallback::needsCollision(proxy0))
 			return false;
+		if (m_pairCache->getOverlapFilterCallback()) { // stephengold added 2020-02-12
+			btBroadphaseProxy* proxy1 = m_me->getBroadphaseHandle(); // stephengold added 2020-02-12
+			bool collides = m_pairCache->needsBroadphaseCollision(proxy0, proxy1); // stephengold added 2020-02-12
+			if (!collides) // stephengold added 2020-02-12
+			{ // stephengold added 2020-02-12
+				return false; // stephengold added 2020-02-12
+			} // stephengold added 2020-02-12
+		} // stephengold added 2020-02-12
 
 		btCollisionObject* otherObj = (btCollisionObject*)proxy0->m_clientObject;
 


### PR DESCRIPTION
If the pair cache has a custom overlap filter (set using `setOverlapFilterCallback()`), apply that same filter to the predictive contacts generated for continuous collision detection (CCD).