### PR TITLE
Put TinyRender functions and classes inside a TinyRender namespace.

### DIFF
--- a/examples/TinyRenderer/TinyRenderer.cpp
+++ b/examples/TinyRenderer/TinyRenderer.cpp
@@ -17,6 +17,8 @@
 #include "our_gl.h"
 #include "tgaimage.h"
 
+using namespace TinyRender;
+
 struct DepthShader : public IShader
 {
 	Model* m_model;

--- a/examples/TinyRenderer/TinyRenderer.h
+++ b/examples/TinyRenderer/TinyRenderer.h
@@ -2,6 +2,7 @@
 #define TINY_RENDERER_H
 
 #include "geometry.h"
+#include "model.h"
 #include "Bullet3Common/b3AlignedObjectArray.h"
 #include "Bullet3Common/b3Vector3.h"
 #include "LinearMath/btAlignedObjectArray.h"
@@ -12,9 +13,9 @@
 struct TinyRenderObjectData
 {
 	//Camera
-	Matrix m_viewMatrix;
-	Matrix m_projectionMatrix;
-	Matrix m_viewportMatrix;
+	TinyRender::Matrix m_viewMatrix;
+	TinyRender::Matrix m_projectionMatrix;
+	TinyRender::Matrix m_viewportMatrix;
 	btVector3 m_localScaling;
 	btVector3 m_lightDirWorld;
 	btVector3 m_lightColor;
@@ -24,8 +25,8 @@ struct TinyRenderObjectData
 	float m_lightSpecularCoeff;
 
 	//Model (vertices, indices, textures, shader)
-	Matrix m_modelMatrix;
-	class Model* m_model;
+	TinyRender::Matrix m_modelMatrix;
+	TinyRender::Model* m_model;
 	//class IShader* m_shader; todo(erwincoumans) expose the shader, for now we use a default shader
 
 	//Output

--- a/examples/TinyRenderer/geometry.cpp
+++ b/examples/TinyRenderer/geometry.cpp
@@ -1,5 +1,7 @@
 #include "geometry.h"
 
+namespace TinyRender
+{
 template <>
 template <>
 vec<3, int>::vec(const vec<3, float> &v) : x(int(v.x + .5f)), y(int(v.y + .5f)), z(int(v.z + .5f))
@@ -19,4 +21,5 @@ template <>
 template <>
 vec<2, float>::vec(const vec<2, int> &v) : x(v.x), y(v.y)
 {
+}
 }

--- a/examples/TinyRenderer/geometry.h
+++ b/examples/TinyRenderer/geometry.h
@@ -4,6 +4,8 @@
 #include <cassert>
 #include <stdlib.h>
 
+namespace TinyRender
+{
 template <size_t DimCols, size_t DimRows, typename T>
 class mat;
 
@@ -318,4 +320,6 @@ typedef vec<3, float> Vec3f;
 typedef vec<3, int> Vec3i;
 typedef vec<4, float> Vec4f;
 typedef mat<4, 4, float> Matrix;
+}
+
 #endif  //__GEOMETRY_H__

--- a/examples/TinyRenderer/model.cpp
+++ b/examples/TinyRenderer/model.cpp
@@ -6,6 +6,9 @@
 #include <iostream>
 #include <sstream>
 #include "Bullet3Common/b3Logging.h"
+
+namespace TinyRender
+{
 Model::Model(const char *filename) : verts_(), faces_(), norms_(), uv_(), diffusemap_(), normalmap_(), specularmap_()
 {
 	std::ifstream in;
@@ -201,4 +204,5 @@ Vec3f Model::normal(int iface, int nthvert)
 {
 	int idx = faces_[iface][nthvert][2];
 	return norms_[idx].normalize();
+}
 }

--- a/examples/TinyRenderer/model.h
+++ b/examples/TinyRenderer/model.h
@@ -5,6 +5,8 @@
 #include "geometry.h"
 #include "tgaimage.h"
 
+namespace TinyRender
+{
 class Model
 {
 private:
@@ -52,4 +54,6 @@ public:
 	float specular(Vec2f uv);
 	std::vector<int> face(int idx);
 };
+}
+
 #endif  //__MODEL_H__

--- a/examples/TinyRenderer/our_gl.cpp
+++ b/examples/TinyRenderer/our_gl.cpp
@@ -4,6 +4,8 @@
 #include "our_gl.h"
 #include "Bullet3Common/b3MinMax.h"
 
+namespace TinyRender
+{
 IShader::~IShader() {}
 
 Matrix viewport(int x, int y, int w, int h)
@@ -204,4 +206,5 @@ void triangle(mat<4, 3, float> &clipc, IShader &shader, TGAImage &image, float *
 			}
 		}
 	}
+}
 }

--- a/examples/TinyRenderer/our_gl.h
+++ b/examples/TinyRenderer/our_gl.h
@@ -3,6 +3,8 @@
 #include "tgaimage.h"
 #include "geometry.h"
 
+namespace TinyRender
+{
 Matrix viewport(int x, int y, int w, int h);
 Matrix projection(float coeff = 0.f);  // coeff = -1/c
 Matrix lookat(Vec3f eye, Vec3f center, Vec3f up);
@@ -20,5 +22,6 @@ void triangle(mat<4, 3, float> &pts, IShader &shader, TGAImage &image, float *zb
 void triangle(mat<4, 3, float> &pts, IShader &shader, TGAImage &image, float *zbuffer, int *segmentationMaskBuffer, const Matrix &viewPortMatrix, int objectIndex);
 void triangleClipped(mat<4, 3, float> &clippedPts, mat<4, 3, float> &pts, IShader &shader, TGAImage &image, float *zbuffer, const Matrix &viewPortMatrix);
 void triangleClipped(mat<4, 3, float> &clippedPts, mat<4, 3, float> &pts, IShader &shader, TGAImage &image, float *zbuffer, int *segmentationMaskBuffer, const Matrix &viewPortMatrix, int objectIndex);
+}
 
 #endif  //__OUR_GL_H__


### PR DESCRIPTION
The TinyRender library defines some classes with very generic names, such as vec, Matrix, Model. In my case, when compiling the example browser using a different library for graphics, this was giving me issues with multiply defined symbols.