### PR TITLE
Include dlerror() in handling of failed dlopen()

### DIFF
--- a/examples/OpenGLWindow/X11OpenGLWindow.cpp
+++ b/examples/OpenGLWindow/X11OpenGLWindow.cpp
@@ -220,7 +220,7 @@ struct InternalData2
 		if (!m_x11_library)
 		{
 			// TODO: Properly handle this error.
-			fprintf(stderr, "Error opening X11 library %s\n", X11_LIBRARY);
+			fprintf(stderr, "Error opening X11 library %s: %s\n", X11_LIBRARY, dlerror());
 			exit(EXIT_FAILURE);
 		}
 


### PR DESCRIPTION
X11OpenGLWindow::X11OpenGLWindow() ends up calling dlopen() to get libX11.
When this fails, it only reports that it failed, and what filename it was looking for.
This commit adds dlerror() to the error message, which makes investigating failures easier.