### PR TITLE
fix AABB and inertia calculations

### DIFF
--- a/src/BulletCollision/CollisionShapes/btConeShape.h
+++ b/src/BulletCollision/CollisionShapes/btConeShape.h
@@ -56,15 +56,13 @@ public:
 		btTransform identity;
 		identity.setIdentity();
 		btVector3 aabbMin, aabbMax;
-		getAabb(identity, aabbMin, aabbMax);
 
+		getAabb(identity, aabbMin, aabbMax);  // This already contains the margin
 		btVector3 halfExtents = (aabbMax - aabbMin) * btScalar(0.5);
 
-		btScalar margin = getMargin();
-
-		btScalar lx = btScalar(2.) * (halfExtents.x() + margin);
-		btScalar ly = btScalar(2.) * (halfExtents.y() + margin);
-		btScalar lz = btScalar(2.) * (halfExtents.z() + margin);
+		btScalar lx = btScalar(2.) * (halfExtents.x());
+		btScalar ly = btScalar(2.) * (halfExtents.y());
+		btScalar lz = btScalar(2.) * (halfExtents.z());
 		const btScalar x2 = lx * lx;
 		const btScalar y2 = ly * ly;
 		const btScalar z2 = lz * lz;

--- a/src/BulletCollision/CollisionShapes/btConvexInternalShape.cpp
+++ b/src/BulletCollision/CollisionShapes/btConvexInternalShape.cpp
@@ -117,8 +117,8 @@ void btConvexInternalAabbCachingShape::recalcLocalAabb()
 
 	for (int i = 0; i < 3; ++i)
 	{
-		m_localAabbMax[i] = _supporting[i][i] + m_collisionMargin;
-		m_localAabbMin[i] = _supporting[i + 3][i] - m_collisionMargin;
+		m_localAabbMax[i] = _supporting[i][i];
+		m_localAabbMin[i] = _supporting[i + 3][i];
 	}
 
 #else
@@ -128,10 +128,10 @@ void btConvexInternalAabbCachingShape::recalcLocalAabb()
 		btVector3 vec(btScalar(0.), btScalar(0.), btScalar(0.));
 		vec[i] = btScalar(1.);
 		btVector3 tmp = localGetSupportingVertex(vec);
-		m_localAabbMax[i] = tmp[i] + m_collisionMargin;
+		m_localAabbMax[i] = tmp[i];
 		vec[i] = btScalar(-1.);
 		tmp = localGetSupportingVertex(vec);
-		m_localAabbMin[i] = tmp[i] - m_collisionMargin;
+		m_localAabbMin[i] = tmp[i];
 	}
 #endif
 }

--- a/src/BulletCollision/CollisionShapes/btPolyhedralConvexShape.cpp
+++ b/src/BulletCollision/CollisionShapes/btPolyhedralConvexShape.cpp
@@ -463,17 +463,17 @@ void btPolyhedralConvexShape::calculateLocalInertia(btScalar mass, btVector3& in
 #ifndef __SPU__
 	//not yet, return box inertia
 
-	btScalar margin = getMargin();
+	//btScalar margin = getMargin();
 
 	btTransform ident;
 	ident.setIdentity();
 	btVector3 aabbMin, aabbMax;
-	getAabb(ident, aabbMin, aabbMax);
+	getAabb(ident, aabbMin, aabbMax);  // This already contains the margin
 	btVector3 halfExtents = (aabbMax - aabbMin) * btScalar(0.5);
 
-	btScalar lx = btScalar(2.) * (halfExtents.x() + margin);
-	btScalar ly = btScalar(2.) * (halfExtents.y() + margin);
-	btScalar lz = btScalar(2.) * (halfExtents.z() + margin);
+	btScalar lx = btScalar(2.) * (halfExtents.x());
+	btScalar ly = btScalar(2.) * (halfExtents.y());
+	btScalar lz = btScalar(2.) * (halfExtents.z());
 	const btScalar x2 = lx * lx;
 	const btScalar y2 = ly * ly;
 	const btScalar z2 = lz * lz;
@@ -529,8 +529,8 @@ void btPolyhedralConvexAabbCachingShape::recalcLocalAabb()
 
 	for (int i = 0; i < 3; ++i)
 	{
-		m_localAabbMax[i] = _supporting[i][i] + m_collisionMargin;
-		m_localAabbMin[i] = _supporting[i + 3][i] - m_collisionMargin;
+		m_localAabbMax[i] = _supporting[i][i];
+		m_localAabbMin[i] = _supporting[i + 3][i];
 	}
 
 #else


### PR DESCRIPTION
This changes how the AABBs and the inertia is calculated for:

- btConeShape
- btConvexInternalShape
- btPolyhedralConvexShape

If i'm not wrong, the margin is added twice for inertia calculation.

Even though the inertia is approximated by the bounding box and not expected to be exact for either a cone or an arbitrary convex object, it is really noticable that small objects move wrongly. (E.g. when coins hit the ground they hardly start to rotate)

I haven't checked the inertia of other shapes, but from testing the physics in Blender they seem to look right.