### PR TITLE
deactivate objects AFTER synchronizeMotionStates

### DIFF
--- a/src/BulletDynamics/Dynamics/btDiscreteDynamicsWorld.cpp
+++ b/src/BulletDynamics/Dynamics/btDiscreteDynamicsWorld.cpp
@@ -433,6 +433,7 @@ int btDiscreteDynamicsWorld::stepSimulation(btScalar timeStep, int maxSubSteps, 
 		{
 			internalSingleStepSimulation(fixedTimeStep);
 			synchronizeMotionStates();
+	                updateActivationState(fixedTimeStep);
 		}
 	}
 	else
@@ -487,8 +488,6 @@ void btDiscreteDynamicsWorld::internalSingleStepSimulation(btScalar timeStep)
 
 	///update vehicle simulation
 	updateActions(timeStep);
-
-	updateActivationState(timeStep);
 
 	if (0 != m_internalTickCallback)
 	{


### PR DESCRIPTION
This PR tries to fix a bug where sometimes the final `MotionState::setWorldTransform()` is not called after an active object has moved a little but was deactivated.  In particular it is trying to solve a problem described in [this forum thread](https://pybullet.org/Bullet/phpBB3/viewtopic.php?f=9&t=12921).

Dunno how safe this change is since it does subtly change the behavior of `btDiscreteDynamicsWorld::internalSingleStepSimulation()`, and accidentally swaps the order of `updateActivationState()` with the internal callback, but I figured I would submit it for review.  Feel free to discard, or suggest an alternative fix.
