### PR TITLE
Bugfix for camera_adjust and move_and_look_at in locomotion environments

### DIFF
--- a/examples/pybullet/gym/pybullet_envs/env_bases.py
+++ b/examples/pybullet/gym/pybullet_envs/env_bases.py
@@ -26,7 +26,7 @@ class MJCFBaseBulletEnv(gym.Env):
     self.scene = None
     self.physicsClientId = -1
     self.ownsPhysicsClient = 0
-    self.camera = Camera()
+    self.camera = Camera(self)
     self.isRender = render
     self.robot = robot
     self.seed()
@@ -160,11 +160,12 @@ class MJCFBaseBulletEnv(gym.Env):
 
 class Camera:
 
-  def __init__(self):
+  def __init__(self, env):
+    self.env = env
     pass
 
   def move_and_look_at(self, i, j, k, x, y, z):
     lookat = [x, y, z]
     distance = 10
     yaw = 10
-    self._p.resetDebugVisualizerCamera(distance, yaw, -20, lookat)
+    self.env._p.resetDebugVisualizerCamera(distance, yaw, -20, lookat)

--- a/examples/pybullet/gym/pybullet_envs/env_bases.py
+++ b/examples/pybullet/gym/pybullet_envs/env_bases.py
@@ -26,7 +26,7 @@ class MJCFBaseBulletEnv(gym.Env):
     self.scene = None
     self.physicsClientId = -1
     self.ownsPhysicsClient = 0
-    self.camera = Camera(self)
+    self.camera = Camera()
     self.isRender = render
     self.robot = robot
     self.seed()
@@ -160,12 +160,11 @@ class MJCFBaseBulletEnv(gym.Env):
 
 class Camera:
 
-  def __init__(self, env):
-    self.env = env
+  def __init__(self):
     pass
 
   def move_and_look_at(self, i, j, k, x, y, z):
     lookat = [x, y, z]
     distance = 10
     yaw = 10
-    self.env._p.resetDebugVisualizerCamera(distance, yaw, -20, lookat)
+    self._p.resetDebugVisualizerCamera(distance, yaw, -20, lookat)

--- a/examples/pybullet/gym/pybullet_envs/gym_locomotion_envs.py
+++ b/examples/pybullet/gym/pybullet_envs/gym_locomotion_envs.py
@@ -125,7 +125,7 @@ class WalkerBaseBulletEnv(MJCFBaseBulletEnv):
     return state, sum(self.rewards), bool(done), {}
 
   def camera_adjust(self):
-    x, y, z = self.robot.body_xyz
+    x, y, z = self.body_xyz
     self.camera_x = 0.98 * self.camera_x + (1 - 0.98) * x
     self.camera.move_and_look_at(self.camera_x, y - 2.0, 1.4, x, y, 1.0)
 

--- a/examples/pybullet/gym/pybullet_envs/gym_locomotion_envs.py
+++ b/examples/pybullet/gym/pybullet_envs/gym_locomotion_envs.py
@@ -125,7 +125,7 @@ class WalkerBaseBulletEnv(MJCFBaseBulletEnv):
     return state, sum(self.rewards), bool(done), {}
 
   def camera_adjust(self):
-    x, y, z = self.body_xyz
+    x, y, z = self.robot.body_xyz
     self.camera_x = 0.98 * self.camera_x + (1 - 0.98) * x
     self.camera.move_and_look_at(self.camera_x, y - 2.0, 1.4, x, y, 1.0)
 


### PR DESCRIPTION
Fixes an issue I was experiencing trying to call camera_adjust on the pybullet_envs locomotion environments. Previously when running this snippet:

```python
import gym
import pybullet_envs

env = gym.make("Walker2DBulletEnv-v0", render=True)
env.reset()

env.camera_adjust()
```

I would get the following error:
```
Traceback (most recent call last):
  File "bullet_test.py", line 7, in <module>
    env.camera_adjust()
  File "/home/sgillen/miniconda3/envs/bullet_fork/lib/python3.6/site-packages/pybullet_envs/gym_locomotion_envs.py", line 128, in camera_adjust
    x, y, z = self.body_xyz
AttributeError: 'Walker2DBulletEnv' object has no attribute 'body_xyz'
```

The change I'm submitting is working for my use case, but I did not see any tests to run to make sure I did not break anything somewhere else (although it looks like camera_adjust is not currently used anywhere in pybullet). If you'd like though I can expand the above snippet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bulletphysics/bullet3/2771)
<!-- Reviewable:end -->
