### PR TITLE
btCollisionObject.h: add getters for m_objectsWithoutCollisionCheck

### DIFF
--- a/src/BulletCollision/CollisionDispatch/btCollisionObject.h
+++ b/src/BulletCollision/CollisionDispatch/btCollisionObject.h
@@ -251,6 +251,16 @@ public:
 		m_checkCollideWith = m_objectsWithoutCollisionCheck.size() > 0;
 	}
 
+        int getNumObjectsWithoutCollision() const
+	{
+		return m_objectsWithoutCollisionCheck.size();
+	}
+
+	const btCollisionObject* getObjectWithoutCollision(int index)
+	{
+		return m_objectsWithoutCollisionCheck[index];
+	}
+
 	virtual bool checkCollideWithOverride(const btCollisionObject* co) const
 	{
 		int index = m_objectsWithoutCollisionCheck.findLinearSearch(co);


### PR DESCRIPTION
`btCollisionObject` has an API to add/remove collision objects from its `m_objectsWithoutCollisionCheck` list. However, without extending the class there's no way to determine how many objects are in the list or to enumerate them.

This pull request fills this gap by adding 2 methods to `btCollisionObject`.