### PR TITLE
btOverlappingPairCache: add a getInternalGhostPairCallback() method

### DIFF
--- a/src/BulletCollision/BroadphaseCollision/btOverlappingPairCache.h
+++ b/src/BulletCollision/BroadphaseCollision/btOverlappingPairCache.h
@@ -77,7 +77,7 @@ public:
 
 	virtual bool hasDeferredRemoval() = 0;
 
-        virtual btOverlappingPairCallback* getInternalGhostPairCallback() = 0;
+	virtual btOverlappingPairCallback* getInternalGhostPairCallback() = 0;
 	virtual void setInternalGhostPairCallback(btOverlappingPairCallback* ghostPairCallback) = 0;
 
 	virtual void sortOverlappingPairs(btDispatcher* dispatcher) = 0;
@@ -246,10 +246,10 @@ private:
 		return false;
 	}
 
-        virtual btOverlappingPairCallback* getInternalGhostPairCallback()
-        {
-            return m_ghostPairCallback;
-        }
+	virtual btOverlappingPairCallback* getInternalGhostPairCallback()
+	{
+		return m_ghostPairCallback;
+	}
 	virtual void setInternalGhostPairCallback(btOverlappingPairCallback * ghostPairCallback)
 	{
 		m_ghostPairCallback = ghostPairCallback;
@@ -346,10 +346,10 @@ public:
 		return m_hasDeferredRemoval;
 	}
 
-        virtual btOverlappingPairCallback* getInternalGhostPairCallback()
-        {
-            return m_ghostPairCallback;
-        }
+	virtual btOverlappingPairCallback* getInternalGhostPairCallback()
+	{
+		return m_ghostPairCallback;
+	}
 	virtual void setInternalGhostPairCallback(btOverlappingPairCallback* ghostPairCallback)
 	{
 		m_ghostPairCallback = ghostPairCallback;
@@ -416,10 +416,10 @@ public:
 		return true;
 	}
 
-        virtual btOverlappingPairCallback* getInternalGhostPairCallback()
-        {
-            return 0;
-        }
+	virtual btOverlappingPairCallback* getInternalGhostPairCallback()
+	{
+		return 0;
+	}
 	virtual void setInternalGhostPairCallback(btOverlappingPairCallback* /* ghostPairCallback */)
 	{
 	}

--- a/src/BulletCollision/BroadphaseCollision/btOverlappingPairCache.h
+++ b/src/BulletCollision/BroadphaseCollision/btOverlappingPairCache.h
@@ -77,6 +77,7 @@ public:
 
 	virtual bool hasDeferredRemoval() = 0;
 
+        virtual btOverlappingPairCallback* getInternalGhostPairCallback() = 0;
 	virtual void setInternalGhostPairCallback(btOverlappingPairCallback* ghostPairCallback) = 0;
 
 	virtual void sortOverlappingPairs(btDispatcher* dispatcher) = 0;
@@ -245,6 +246,10 @@ private:
 		return false;
 	}
 
+        virtual btOverlappingPairCallback* getInternalGhostPairCallback()
+        {
+            return m_ghostPairCallback;
+        }
 	virtual void setInternalGhostPairCallback(btOverlappingPairCallback * ghostPairCallback)
 	{
 		m_ghostPairCallback = ghostPairCallback;
@@ -341,6 +346,10 @@ public:
 		return m_hasDeferredRemoval;
 	}
 
+        virtual btOverlappingPairCallback* getInternalGhostPairCallback()
+        {
+            return m_ghostPairCallback;
+        }
 	virtual void setInternalGhostPairCallback(btOverlappingPairCallback* ghostPairCallback)
 	{
 		m_ghostPairCallback = ghostPairCallback;
@@ -407,6 +416,10 @@ public:
 		return true;
 	}
 
+        virtual btOverlappingPairCallback* getInternalGhostPairCallback()
+        {
+            return 0;
+        }
 	virtual void setInternalGhostPairCallback(btOverlappingPairCallback* /* ghostPairCallback */)
 	{
 	}


### PR DESCRIPTION
This is useful because `m_ghostPairCallback` points to caller-allocated storage. To avoid a memory leak, the caller needs to deallocate it before freeing the cache. Having a getter saves the caller from needing to keep track of the pointer.