### PR TITLE
Modify DeepMimic Gym env step() to query policy at 30Hz

### DIFF
--- a/examples/pybullet/gym/pybullet_envs/deep_mimic/gym_env/deep_mimic_env.py
+++ b/examples/pybullet/gym/pybullet_envs/deep_mimic/gym_env/deep_mimic_env.py
@@ -93,6 +93,9 @@ class HumanoidDeepBulletEnv(gym.Env):
     
     self.viewer = None
     self._configure()
+    
+    # Query the policy at 30Hz
+    self.policy_query_30 = True
 
   def _configure(self, display=None):
     self.display = display
@@ -110,7 +113,15 @@ class HumanoidDeepBulletEnv(gym.Env):
     #step sim
     self._internal_env.update(self._time_step)
     
-
+    if self.policy_query_30:
+      # Step simulation until a new action is required
+      while not self._internal_env.need_new_action(agent_id):
+        self._p.stepSimulation()
+        self._internal_env.t += self._time_step
+          # print("t:", self._internal_env.t)
+    # print("next update time:", self._internal_env.needs_update_time)
+    # print("Performing update")
+        
     #record state
     self.state = self._internal_env.record_state(agent_id)
     


### PR DESCRIPTION
Addresses issue #2821 by stepping the simulation enough times to reach the time a new action is needed (according to the `PyBulletDeepMimicEnv.need_new_action` method). This behaviour should be consistent with the initial Tensorflow code and the paper.