### PR TITLE
Decrease the dof count when decreasing the number of links.

### DIFF
--- a/src/BulletDynamics/Featherstone/btMultiBody.cpp
+++ b/src/BulletDynamics/Featherstone/btMultiBody.cpp
@@ -1855,7 +1855,6 @@ void btMultiBody::fillConstraintJacobianMultiDof(int link,
 {
 	// temporary space
 	int num_links = getNumLinks();
-	int m_dofCount = getNumDofs();
 	scratch_v.resize(3 * num_links + 3);  //(num_links + base) offsets + (num_links + base) normals_lin + (num_links + base) normals_ang
 	scratch_m.resize(num_links + 1);
 

--- a/src/BulletDynamics/Featherstone/btMultiBody.h
+++ b/src/BulletDynamics/Featherstone/btMultiBody.h
@@ -542,6 +542,25 @@ public:
 
 	void setNumLinks(int numLinks)  //careful: when changing the number of m_links, make sure to re-initialize or update existing m_links
 	{
+		int oldNumLinks = m_links.size();
+
+		if (oldNumLinks > numLinks)  //when decreasing the number of links, also decrease the dof counter
+		{
+			if (numLinks == 0)
+			{
+				m_dofCount = 0;
+				m_posVarCnt = 0;
+			}
+			else
+			{
+				for (int i = numLinks; i < oldNumLinks; ++i)
+				{
+					m_dofCount -= m_links[i].m_dofCount;
+					m_posVarCnt -= m_links[i].m_posVarCount;
+				}
+			}
+		}
+
 		m_links.resize(numLinks);
 	}
 


### PR DESCRIPTION
I don`t know what m_posVarCnt is being used for, but it looks like it should be decreased as well, so I  did.

Also removed a redeclaration of m_dofCount in btMultiBody.cpp.