### PR TITLE
Fix potential nullptr dereference in btSimulationIslandManager

### DIFF
--- a/src/BulletCollision/CollisionDispatch/btSimulationIslandManager.cpp
+++ b/src/BulletCollision/CollisionDispatch/btSimulationIslandManager.cpp
@@ -318,12 +318,12 @@ void btSimulationIslandManager::buildIslands(btDispatcher* dispatcher, btCollisi
 			((colObj1) && colObj1->getActivationState() != ISLAND_SLEEPING))
 		{
 			//kinematic objects don't merge islands, but wake up all connected objects
-			if (colObj0->isKinematicObject() && colObj0->getActivationState() != ISLAND_SLEEPING)
+			if ((colObj0) && colObj0->isKinematicObject() && colObj0->getActivationState() != ISLAND_SLEEPING)
 			{
 				if (colObj0->hasContactResponse())
 					colObj1->activate();
 			}
-			if (colObj1->isKinematicObject() && colObj1->getActivationState() != ISLAND_SLEEPING)
+			if ((colObj1) && colObj1->isKinematicObject() && colObj1->getActivationState() != ISLAND_SLEEPING)
 			{
 				if (colObj1->hasContactResponse())
 					colObj0->activate();


### PR DESCRIPTION
In _btSimulationIslandManager::buildIslands()_:

If `colObj0` is nullptr and `((colObj1) && colObj1->getActivationState() != ISLAND_SLEEPING))` is true, then we dereference a nullptr.

(And same the other way around with `colObj1`.)