### PR TITLE
Fix parameter check in bFile::safeSwapPtr

### DIFF
--- a/src/Bullet3Serialize/Bullet2FileLoader/b3File.cpp
+++ b/src/Bullet3Serialize/Bullet2FileLoader/b3File.cpp
@@ -851,11 +851,11 @@ void bFile::swapData(char *data, short type, int arraySize, bool ignoreEndianFla
 
 void bFile::safeSwapPtr(char *dst, const char *src)
 {
+	if (!src || !dst)
+		return;
+
 	int ptrFile = mFileDNA->getPointerSize();
 	int ptrMem = mMemoryDNA->getPointerSize();
-
-	if (!src && !dst)
-		return;
 
 	if (ptrFile == ptrMem)
 	{


### PR DESCRIPTION
If either the source or destination pointers are nullptr, we shouldn't continue otherwise we dereference nullptr or memcpy with nullptr which is undefined.

(Also move the check to return as soon as possible.)