### PR TITLE
Fix potential nullptr dereference in HullLibrary::extrudable

### DIFF
--- a/src/LinearMath/btConvexHull.cpp
+++ b/src/LinearMath/btConvexHull.cpp
@@ -451,7 +451,7 @@ btHullTriangle *HullLibrary::extrudable(btScalar epsilon)
 			t = m_tris[i];
 		}
 	}
-	return (t->rise > epsilon) ? t : NULL;
+	return (t && (t->rise > epsilon)) ? t : NULL;
 }
 
 int4 HullLibrary::FindSimplex(btVector3 *verts, int verts_count, btAlignedObjectArray<int> &allow)


### PR DESCRIPTION
If `m_tris` is empty or the loop fails to assign `t`, it will attempt to dereference nullptr in the return statement.