### PR TITLE
delete '- ' prefix on getList()

### DIFF
--- a/examples/pybullet/gym/pybullet_envs/__init__.py
+++ b/examples/pybullet/gym/pybullet_envs/__init__.py
@@ -228,5 +228,5 @@ register(id='HumanoidFlagrunHarderBulletEnv-v0',
 
 
 def getList():
-  btenvs = ['- ' + spec.id for spec in gym.envs.registry.all() if spec.id.find('Bullet') >= 0]
+  btenvs = [spec.id for spec in gym.envs.registry.all() if spec.id.find('Bullet') >= 0]
   return btenvs


### PR DESCRIPTION
if we delete this prefix then we can randomly choose environments without having to slice strings