### PR TITLE
Add --dynamic-runtime option to compile with /MD[d] in MSVC for compat

### DIFF
--- a/build3/premake4.lua
+++ b/build3/premake4.lua
@@ -370,12 +370,24 @@ end
 		defines {"BT_CLAMP_VELOCITY_TO=9999"}
 	end
 
+	newoption
+	{
+		trigger = "dynamic-runtime",
+		description = "Enable dynamic DLL CRT runtime"
+	}
 	configurations {"Release", "Debug"}
 	configuration "Release"
-		flags { "Optimize", "EnableSSE2","StaticRuntime", "NoMinimalRebuild", "FloatFast"}
+		flags { "Optimize", "EnableSSE2", "NoMinimalRebuild", "FloatFast"}
+		if not _OPTIONS["dynamic-runtime"] then
+			flags { "StaticRuntime" } 
+		end
 	configuration "Debug"
 		defines {"_DEBUG=1"}
-		flags { "Symbols", "StaticRuntime" , "NoMinimalRebuild", "NoEditAndContinue" ,"FloatFast"}
+		flags { "Symbols" , "NoMinimalRebuild", "NoEditAndContinue" ,"FloatFast"}
+		if not _OPTIONS["dynamic-runtime"] then
+			flags { "StaticRuntime" } 
+		end
+
 
 	if os.is("Linux") or os.is("macosx") then
 		if os.is64bit() then

--- a/build_visual_studio_vr_pybullet_double_dynamic.bat
+++ b/build_visual_studio_vr_pybullet_double_dynamic.bat
@@ -1,0 +1,28 @@
+IF NOT EXIST bin mkdir bin
+IF NOT EXIST bin\openvr_api.dll  copy examples\ThirdPartyLibs\openvr\bin\win32\openvr_api.dll bin
+IF NOT EXIST bin\openvr64pi.dll  copy examples\ThirdPartyLibs\openvr\bin\win64\openvr_api.dll bin\openvr64pi.dll
+
+#aargh, see https://github.com/ValveSoftware/openvr/issues/412
+
+
+#find a python version (hopefully just 1) and use this
+dir c:\python* /b /ad > tmp1234.txt
+
+set /p myvar1= < tmp1234.txt
+set myvar=c:/%myvar1%
+del tmp1234.txt
+
+rem you can also override and hardcode the Python path like this (just remove the # hashmark in next line)
+rem SET myvar=c:\python-3.5.2
+
+cd build3
+
+
+premake4  --dynamic-runtime --double --standalone-examples --enable_stable_pd --enable_multithreading --midi --enable_static_vr_plugin --enable_openvr --enable_pybullet --python_include_dir="%myvar%/include" --python_lib_dir="%myvar%/libs"   --targetdir="../bin" vs2010 
+
+rem premake4  --double   --enable_multithreading --midi --enable_static_vr_plugin --enable_openvr --enable_pybullet --python_include_dir="%myvar%/include" --python_lib_dir="%myvar%/libs"   --targetdir="../binserver" vs2010 
+rem premake4  --double --enable_grpc --enable_multithreading --midi --enable_static_vr_plugin --enable_openvr --enable_pybullet --python_include_dir="%myvar%/include" --python_lib_dir="%myvar%/libs"   --targetdir="../binserver" vs2010 
+rem premake4  --serial --audio --double --midi --enable_openvr --enable_pybullet --python_include_dir="%myvar%/include" --python_lib_dir="%myvar%/libs"   --targetdir="../bin" vs2010 
+
+start vs2010
+


### PR DESCRIPTION
I wanted to try Bullet in an environment where I can't control the MSVC CRT in use, so I needed to use /MD[d] instead of /MT[d] as the CRT option. This PR adds --dynamic-runtime option to the premake build to that effect.

I don't know if you want this as an option since by default the example browser won't build with it (not a problem for me), or at the least you might not want the .bat by default. But it works from a library POV and is useful for people in my position (I saw a thread or 2 in the forum about it) so I thought I'd send a PR.

Cheers Erwin! You probably don't remember but we met at Siggraph many MANY years ago when I was running Ogre3d and we shared a BOF room once. :)