### PR TITLE
Fix processInitPoseCommand: must update Aabbs after resetting body pose

### DIFF
--- a/examples/SharedMemory/PhysicsServerCommandProcessor.cpp
+++ b/examples/SharedMemory/PhysicsServerCommandProcessor.cpp
@@ -10197,6 +10197,7 @@ bool PhysicsServerCommandProcessor::processInitPoseCommand(const struct SharedMe
 		scratch_m.resize(nLinks + 1);
 
 		mb->updateCollisionObjectWorldTransforms(scratch_q, scratch_m);
+		m_data->m_dynamicsWorld->updateAabbs();
 	}
 
 	if (body && body->m_rigidBody)


### PR DESCRIPTION
Closes #2881 
I found that the reason why this [probelm](https://github.com/bulletphysics/bullet3/issues/2881) occurs. This is becaues after resetting the pose of the body Aabbs are not updated. I tested the error case (collision is not detected thought it supposed to) mentioned in #2881, and checked that collision is detected after this commit. 


I found this bug when compare the behavior of inside `btDbvt::rayTestInternal` method when I change parameter of code in #2881 as  follows:
```python
result = test_smallsphere([0.0, 0, 0.000]) # case A
result = test_smallsphere([0.0, 0, 0.1]) # case B 
``` 
I noticed that when case B, `btRayAabb2`  [here](https://github.com/bulletphysics/bullet3/blob/63e1d7d84055532e5f29484fa34c1af604f595f1/src/BulletCollision/BroadphaseCollision/btDbvt.h#L1252
) returns false although it should not so. I further found that `node->volume.Mins()` and `node->volume.Maxs()` in [here](https://github.com/bulletphysics/bullet3/blob/63e1d7d84055532e5f29484fa34c1af604f595f1/src/BulletCollision/BroadphaseCollision/btDbvt.h#L1248) do not change after `    p.resetBasePositionAndOrientation(ss, pos, [0, 0, 0, 1])` is called. Then, I fixed this bug.



