### PR TITLE
fix array size in inverse kinematics orientation command

### DIFF
--- a/examples/SharedMemory/SharedMemoryCommands.h
+++ b/examples/SharedMemory/SharedMemoryCommands.h
@@ -783,7 +783,7 @@ struct CalculateInverseKinematicsArgs
 	//	double m_jointPositionsQ[MAX_DEGREE_OF_FREEDOM];
 	double m_targetPositions[MAX_DEGREE_OF_FREEDOM*3];
 	int m_numEndEffectorLinkIndices;
-	double m_targetOrientation[4];  //orientation represented as quaternion, x,y,z,w
+	double m_targetOrientation[MAX_DEGREE_OF_FREEDOM*4];  //orientation represented as quaternion, x,y,z,w
 	int m_endEffectorLinkIndices[MAX_DEGREE_OF_FREEDOM];
 	double m_lowerLimit[MAX_DEGREE_OF_FREEDOM];
 	double m_upperLimit[MAX_DEGREE_OF_FREEDOM];

--- a/examples/SharedMemory/SharedMemoryPublic.h
+++ b/examples/SharedMemory/SharedMemoryPublic.h
@@ -7,7 +7,10 @@
 //Please don't replace an existing magic number:
 //instead, only ADD a new one at the top, comment-out previous one
 
-#define SHARED_MEMORY_MAGIC_NUMBER 202005070
+
+
+#define SHARED_MEMORY_MAGIC_NUMBER 202007060
+//#define SHARED_MEMORY_MAGIC_NUMBER 202005070
 //#define SHARED_MEMORY_MAGIC_NUMBER 202002030
 //#define SHARED_MEMORY_MAGIC_NUMBER 202001230
 //#define SHARED_MEMORY_MAGIC_NUMBER 201911280


### PR DESCRIPTION
bump up shared memory version, since this was a potentially incompatible change