### PR TITLE
Fix pybullet gym envs

### DIFF
--- a/examples/pybullet/gym/pybullet_envs/bullet/kuka_diverse_object_gym_env.py
+++ b/examples/pybullet/gym/pybullet_envs/bullet/kuka_diverse_object_gym_env.py
@@ -102,6 +102,9 @@ class KukaDiverseObjectEnv(KukaGymEnv):
       self.action_space = spaces.Box(low=-1, high=1, shape=(3,))  # dx, dy, da
       if self._removeHeightHack:
         self.action_space = spaces.Box(low=-1, high=1, shape=(4,))  # dx, dy, dz, da
+    self.observation_space = spaces.Box(low=0, high=255, shape=(self._height,
+                                                                self._width,
+                                                                3))
     self.viewer = None
 
   def reset(self):

--- a/examples/pybullet/gym/pybullet_envs/minitaur/envs/minitaur_stand_gym_env.py
+++ b/examples/pybullet/gym/pybullet_envs/minitaur/envs/minitaur_stand_gym_env.py
@@ -167,7 +167,7 @@ class MinitaurStandGymEnv(minitaur_gym_env.MinitaurGymEnv):
     # Use the one dimensional action to rotate both bottom legs.
     action_delta = [0, 0, -action, action, 0, 0, action, -action]
     action_all_legs = map(add, action_all_legs, action_delta)
-    return action_all_legs
+    return list(action_all_legs)
 
   def _policy_flip(self, time_step, orientation):
     """Hand coded policy to make the minitaur stand up to its two legs.


### PR DESCRIPTION
Some small fixes to make a few environments work with `gym.make()`. 

1. `KukaDiverseObjectGymEnv` doesn't have `observation_space` defined. This property is required since it inherits from `gym.Env`. 
2. `MinitaurStandGymEnv._transform_action_to_motor_command()` should return a list instead of a `map` object. Otherwise it won't work with [`minitaur.ApplyAction()`](https://github.com/bulletphysics/bullet3/blob/master/examples/pybullet/gym/pybullet_envs/minitaur/envs/minitaur.py#L577) in `minitaur.Step()`.