### PR TITLE
prev keyword removed

### DIFF
--- a/examples/pybullet/examples/constraint.py
+++ b/examples/pybullet/examples/constraint.py
@@ -13,7 +13,6 @@ p.setRealTimeSimulation(1)
 cid = p.createConstraint(cubeId, -1, -1, -1, p.JOINT_FIXED, [0, 0, 0], [0, 0, 0], [0, 0, 1])
 print(cid)
 print(p.getConstraintUniqueId(0))
-prev = [0, 0, 1]
 a = -math.pi
 while 1:
   a = a + 0.01


### PR DESCRIPTION
The code executes without the prev keyword. I removed it and tried to run the code, it ran perfectly. 