### PR TITLE
Fix warning in examples/Utils/ChromeTraceUtil.cpp

### DIFF
--- a/examples/Utils/ChromeTraceUtil.cpp
+++ b/examples/Utils/ChromeTraceUtil.cpp
@@ -5,6 +5,7 @@
 #include "LinearMath/btAlignedObjectArray.h"
 #include "Bullet3Common/b3Logging.h"
 #include <stdio.h>
+#include <climits>
 
 struct btTiming
 {
@@ -111,16 +112,15 @@ struct btTimings
 			sprintf(newname, "%s%d", name, counter2++);
 
 #ifdef _WIN32
-
 			fprintf(gTimingFile, "{\"cat\":\"timing\",\"pid\":1,\"tid\":%d,\"ts\":%I64d.%s ,\"ph\":\"B\",\"name\":\"%s\",\"args\":{}},\n",
 					threadId, startTimeDiv1000, startTimeRem1000Str, newname);
 			fprintf(gTimingFile, "{\"cat\":\"timing\",\"pid\":1,\"tid\":%d,\"ts\":%I64d.%s ,\"ph\":\"E\",\"name\":\"%s\",\"args\":{}}",
 					threadId, endTimeDiv1000, endTimeRem1000Str, newname);
-
 #else
-			fprintf(gTimingFile, "{\"cat\":\"timing\",\"pid\":1,\"tid\":%d,\"ts\":%" PRIu64 ".%s ,\"ph\":\"B\",\"name\":\"%s\",\"args\":{}},\n",
+			// Note: on 64b build, PRIu64 resolves in 'lu' whereas timings ('ts') have to be printed as 'llu'.
+			fprintf(gTimingFile, "{\"cat\":\"timing\",\"pid\":1,\"tid\":%d,\"ts\":%llu.%s ,\"ph\":\"B\",\"name\":\"%s\",\"args\":{}},\n",
 					threadId, startTimeDiv1000, startTimeRem1000Str, newname);
-			fprintf(gTimingFile, "{\"cat\":\"timing\",\"pid\":1,\"tid\":%d,\"ts\":%" PRIu64 ".%s ,\"ph\":\"E\",\"name\":\"%s\",\"args\":{}}",
+			fprintf(gTimingFile, "{\"cat\":\"timing\",\"pid\":1,\"tid\":%d,\"ts\":%llu.%s ,\"ph\":\"E\",\"name\":\"%s\",\"args\":{}}",
 					threadId, endTimeDiv1000, endTimeRem1000Str, newname);
 #endif
 #endif


### PR DESCRIPTION
Fix warning in examples/Utils/ChromeTraceUtil.cpp :
bullet3/examples/Utils/ChromeTraceUtil.cpp:122:62: warning:
format ‘%lu’ expects argument of type ‘long unsigned int’,
but argument 4 has type ‘long long unsigned int’ [-Wformat=]:
startTimeDiv1000
Tested:
- examples/ExampleBrowser/App_ExampleBrowser --tracing
- press the P key to write the profiler json file
- head /tmp/timings_0.json
- open /tmp/timings_0.json with chrome://tracing