### PR TITLE
Invert WORLD_ and LINK_FRAME torques for the base (linkIndex==-1)

### DIFF
--- a/examples/SharedMemory/PhysicsServerCommandProcessor.cpp
+++ b/examples/SharedMemory/PhysicsServerCommandProcessor.cpp
@@ -11054,7 +11054,7 @@ bool PhysicsServerCommandProcessor::processApplyExternalForceCommand(const struc
 
 				if (clientCmd.m_externalForceArguments.m_linkIds[i] == -1)
 				{
-					btVector3 torqueWorld = isLinkFrame ? torqueLocal : mb->getBaseWorldTransform().getBasis() * torqueLocal;
+					btVector3 torqueWorld = isLinkFrame ? mb->getBaseWorldTransform().getBasis() * torqueLocal : torqueLocal;
 					mb->addBaseTorque(torqueWorld);
 					//b3Printf("apply base torque of %f,%f,%f\n", torqueWorld[0],torqueWorld[1],torqueWorld[2]);
 				}


### PR DESCRIPTION
Invert `WORLD_` and `LINK_FRAME` torques for the base (`linkIndex==-1`)

#1949 mentions how torques in link and world frame to the base seem to be swapped

Changing the ternary operator on line 11057 leads to an applied torque (with only an x component) to the base that makes the base rotate around its own x axis when in LINK_FRAME and the world's x axis when in WORLD_FRAME (shown [here](https://github.com/JacopoPan/pybullet-examples/blob/master/README.md))

(Apologies if I misunderstood the intended behaviour)