### PR TITLE
Update gzguts.h - make it compilable on Mac OS Catalina

### DIFF
--- a/examples/ThirdPartyLibs/zlib/gzguts.h
+++ b/examples/ThirdPartyLibs/zlib/gzguts.h
@@ -20,6 +20,7 @@
 
 #include <stdio.h>
 #include "zlib.h"
+#include <unistd.h>
 #ifdef STDC
 #include <string.h>
 #include <stdlib.h>


### PR DESCRIPTION
Adding this makes the library build successfully on Mac Catalina with Miniconda 3.7 on the latest CLANG. Otherwise you get errors that in C99 the functions "write", "close", and "read" aren't defined.