### PR TITLE
Add ability to get the original vertex index from the convex hull

### DIFF
--- a/src/LinearMath/btConvexHullComputer.cpp
+++ b/src/LinearMath/btConvexHullComputer.cpp
@@ -2673,6 +2673,7 @@ btScalar btConvexHullComputer::compute(const void* coords, bool doubleCoords, in
 	}
 
 	vertices.resize(0);
+	original_vertex_index.resize(0);
 	edges.resize(0);
 	faces.resize(0);
 
@@ -2683,6 +2684,7 @@ btScalar btConvexHullComputer::compute(const void* coords, bool doubleCoords, in
 	{
 		btConvexHullInternal::Vertex* v = oldVertices[copied];
 		vertices.push_back(hull.getCoordinates(v));
+		original_vertex_index.push_back(v->point.index);
 		btConvexHullInternal::Edge* firstEdge = v->edges;
 		if (firstEdge)
 		{

--- a/src/LinearMath/btConvexHullComputer.h
+++ b/src/LinearMath/btConvexHullComputer.h
@@ -66,6 +66,9 @@ public:
 	// Vertices of the output hull
 	btAlignedObjectArray<btVector3> vertices;
 
+	// The original vertex index in the input coords array
+	btAlignedObjectArray<int> original_vertex_index;
+
 	// Edges of the output hull
 	btAlignedObjectArray<Edge> edges;
 


### PR DESCRIPTION
This makes it possible to know which input vertices were picked to
to define the hull.

With this information it is much easier to map certain features from the
input mesh/point cloud to the output convex hull.

This code is ported from the bundled bullet library in blender.

I'm a Blender developer and we are planning to remove our mini fork of bullet and use the upstream version.

Currently, the only thing that seems to be preventing us from doing so is this small change to the convex hull generation.

If this is not good enough, I'm willing to solve any issues so that we can hopefully be in sync with upstream bullet.