### PR TITLE
CWE-190 integer overflow in btConvexHullComputer

### DIFF
--- a/src/LinearMath/btConvexHullComputer.cpp
+++ b/src/LinearMath/btConvexHullComputer.cpp
@@ -105,7 +105,7 @@ public:
 
 		Point64 cross(const Point32& b) const
 		{
-			return Point64(y * b.z - z * b.y, z * b.x - x * b.z, x * b.y - y * b.x);
+			return Point64(((int64_t)y) * b.z - ((int64_t)z) * b.y, ((int64_t)z) * b.x - ((int64_t)x) * b.z, ((int64_t)x) * b.y - ((int64_t)y) * b.x);
 		}
 
 		Point64 cross(const Point64& b) const
@@ -115,7 +115,7 @@ public:
 
 		int64_t dot(const Point32& b) const
 		{
-			return x * b.x + y * b.y + z * b.z;
+			return ((int64_t)x) * b.x + ((int64_t)y) * b.y + ((int64_t)z) * b.z;
 		}
 
 		int64_t dot(const Point64& b) const


### PR DESCRIPTION
Fixed integer overflow in btConvexHullComputer.cpp

Example to reproduce similar issue

```
#include <iostream>
#include <limits.h>

int main(int, char **)
{
	int x = INT_MAX;
	long long y0 = x * 5;
	long long y1 = (long long)x * 5;
	std::cout << "y0=" << y0 << " y1=" << y1 << std::endl;
	return 0;
}
```

Output: y0=2147483643 y1=10737418235

Coverity report:

![cwe190-1](https://user-images.githubusercontent.com/1494580/92316598-c7b8ed00-eff6-11ea-9317-3ab7c6806b8c.jpg)

