### PR TITLE
EGL plugin: added EGL_VISIBLE_DEVICE and OpenGL 3.3 selection

### DIFF
--- a/examples/pybullet/examples/testrender.py
+++ b/examples/pybullet/examples/testrender.py
@@ -19,7 +19,7 @@ pybullet.setAdditionalSearchPath(pybullet_data.getDataPath())
 
 #pybullet.loadPlugin("eglRendererPlugin")
 pybullet.loadURDF("plane.urdf", [0, 0, -1])
-pybullet.loadURDF("r2d2.urdf")
+r2d2 = pybullet.loadURDF("r2d2.urdf")
 
 pybullet.setGravity(0, 0, -10)
 camTargetPos = [0, 0, 0]
@@ -78,6 +78,8 @@ while (1):
     #plt.show()
     plt.pause(0.01)
 
+  pybullet.removeBody(r2d2)
+  r2d2 = pybullet.loadURDF("r2d2.urdf")
 main_stop = time.time()
 
 print("Total time %f" % (main_stop - main_start))


### PR DESCRIPTION
This version has the following two changes:

1. you can select the EGL device you want to use by setting the environment variable EGL_RENDER_DEVICE=X. Just start at 0 and iterate up until it tells you "Invalid render_device choice"
2. It requests an EGL context with OpenGL version > 3.3, which is needed for the EGL plugin. On the machines I was using so far EGL was nice and gave me up to date OpenGL versions, but this was needed for my Intel HD / Mesa laptop.
