### PR TITLE
Make sure the internal AABB is properly extended.

### DIFF
--- a/src/BulletCollision/CollisionDispatch/btCollisionWorld.cpp
+++ b/src/BulletCollision/CollisionDispatch/btCollisionWorld.cpp
@@ -1140,6 +1140,7 @@ struct btBridgedManifoldResult : public btManifoldResult
 		: btManifoldResult(obj0Wrap, obj1Wrap),
 		  m_resultCallback(resultCallback)
 	{
+		m_closestPointDistanceThreshold = resultCallback.m_closestDistanceThreshold;
 	}
 
 	virtual void addContactPoint(const btVector3& normalOnBInWorld, const btVector3& pointInWorld, btScalar depth)


### PR DESCRIPTION
The concave shape collision algorithm executes an internal `AABB` check, to know which triangle worth to be checked:
https://github.com/bulletphysics/bullet3/blob/cdd56e46411527772711da5357c856a90ad9ea67/src/BulletCollision/CollisionDispatch/btConvexConcaveCollisionAlgorithm.cpp#L79-L82
Due to precision loss, sometimes these `AABB` fails, so the contacts are not detected. To fix this issue the idea is to increase a little bit the `AABB`; this can already be done but it's not used.

This change, ensure that the sweep tests variable`m_closestDistanceThreshold` is properly taken into account.

Though, this change alone, doesn't affect the checks done to simulates the dynamics (since `btBridgedManifoldResult` is not used); So, I'm wondering what do you think @erwincoumans about the idea to add the following code:
```
const btScalar extraMargin = btMax(0.001, collisionMarginTriangle + resultOut->m_closestPointDistanceThreshold);
```
here:
https://github.com/bulletphysics/bullet3/blob/cdd56e46411527772711da5357c856a90ad9ea67/src/BulletCollision/CollisionDispatch/btConvexConcaveCollisionAlgorithm.cpp#L166
