### PR TITLE
Made a small fix for MCST lcc compiler and e2k (Elbrus 2000) architecture

### DIFF
--- a/examples/ThirdPartyLibs/optionalX11/X11/Xmd.h
+++ b/examples/ThirdPartyLibs/optionalX11/X11/Xmd.h
@@ -63,7 +63,8 @@ SOFTWARE.
 	defined(__sparc64__) ||                   \
 	defined(__s390x__) ||                     \
 	defined(__amd64__) || defined(amd64) ||   \
-	defined(__powerpc64__)
+	defined(__powerpc64__) ||                 \
+	defined(__e2k__)
 #if !defined(__ILP32__) /* amd64-x32 is 32bit */
 #define LONG64          /* 32/64-bit architecture */
 #endif                  /* !__ILP32__ */

--- a/test/GwenOpenGLTest/UnitTest.cpp
+++ b/test/GwenOpenGLTest/UnitTest.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
 	GWEN
 	Copyright (c) 2010 Facepunch Studios
 	See license in Gwen.h


### PR DESCRIPTION
- GwenOpenGLTest/UnitTest.cpp: strip UTF-8 BOM for compatibility with MCST lcc compiler < 1.24
- X11/Xmd.h: added define for MCST e2k (Elbrus 2000) architecture