### PR TITLE
Debug patch for btGeneric6DofSpring2Constraint

### DIFF
--- a/src/BulletDynamics/ConstraintSolver/btGeneric6DofSpring2Constraint.cpp
+++ b/src/BulletDynamics/ConstraintSolver/btGeneric6DofSpring2Constraint.cpp
@@ -403,9 +403,13 @@ void btGeneric6DofSpring2Constraint::calculateAngleInfo()
 			btAssert(false);
 	}
 
-	m_calculatedAxis[0].normalize();
-	m_calculatedAxis[1].normalize();
-	m_calculatedAxis[2].normalize();
+    	for (int ii=0; ii<3; ++ii) {
+        	// This is to prevent triggering btAssert in zero length normalization
+        	// in debug build
+        	if (!m_calculatedAxis[ii].fuzzyZero()) {
+            		m_calculatedAxis[ii].normalize();
+        	}
+    	}
 }
 
 void btGeneric6DofSpring2Constraint::calculateTransforms()


### PR DESCRIPTION
This problem was preventing our code to work in debug build due to the btAssert check here (https://github.com/bulletphysics/bullet3/blob/master/src/LinearMath/btVector3.h#L305). I am aware of the `safeNormalize` function (https://github.com/bulletphysics/bullet3/blob/master/src/LinearMath/btVector3.h#L286), however, it does not seem to have the vectorization capability as the regular `normalization` and thus the proposed change.