### PR TITLE
safely normalize in 6dof springs and small refactoring in vector3 class

### DIFF
--- a/src/BulletDynamics/ConstraintSolver/btGeneric6DofSpring2Constraint.cpp
+++ b/src/BulletDynamics/ConstraintSolver/btGeneric6DofSpring2Constraint.cpp
@@ -403,9 +403,9 @@ void btGeneric6DofSpring2Constraint::calculateAngleInfo()
 			btAssert(false);
 	}
 
-	m_calculatedAxis[0].normalize();
-	m_calculatedAxis[1].normalize();
-	m_calculatedAxis[2].normalize();
+	m_calculatedAxis[0].safeNormalize();
+	m_calculatedAxis[1].safeNormalize();
+	m_calculatedAxis[2].safeNormalize();
 }
 
 void btGeneric6DofSpring2Constraint::calculateTransforms()

--- a/src/LinearMath/btVector3.h
+++ b/src/LinearMath/btVector3.h
@@ -285,11 +285,9 @@ public:
 
 	SIMD_FORCE_INLINE btVector3& safeNormalize()
 	{
-		btScalar l2 = length2();
-		//triNormal.normalize();
-		if (l2 >= SIMD_EPSILON * SIMD_EPSILON)
+		if (!fuzzyZero())
 		{
-			(*this) /= btSqrt(l2);
+            return normalize();
 		}
 		else
 		{


### PR DESCRIPTION
This problem was preventing our code to work in debug build due to the btAssert check [here](https://github.com/bulletphysics/bullet3/blob/master/src/LinearMath/btVector3.h#L305).