### PR TITLE
Expose activationState to pybullet

### DIFF
--- a/examples/SharedMemory/SharedMemoryPublic.h
+++ b/examples/SharedMemory/SharedMemoryPublic.h
@@ -368,6 +368,15 @@ enum DynamicsActivationState
 	eActivationStateDisableWakeup = 32,
 };
 
+enum DynamicsActivationStateInternal
+{
+	eActiveTag = 1,
+	eIslandSleeping = 2,
+	eWantsDeactivation = 3,
+	eDisableDeactivation = 4,
+	eDisableSimulation = 5,
+};
+
 enum b3BodyType
 {
 	BT_RIGID_BODY = 1,

--- a/examples/pybullet/pybullet.c
+++ b/examples/pybullet/pybullet.c
@@ -1541,7 +1541,7 @@ static PyObject* pybullet_getDynamicsInfo(PyObject* self, PyObject* args, PyObje
 
 			if (b3GetDynamicsInfo(status_handle, &info))
 			{
-				int numFields = 12;
+				int numFields = 13;
 				PyObject* pyDynamicsInfo = PyTuple_New(numFields);
 				PyTuple_SetItem(pyDynamicsInfo, 0, PyFloat_FromDouble(info.m_mass));
 				PyTuple_SetItem(pyDynamicsInfo, 1, PyFloat_FromDouble(info.m_lateralFrictionCoeff));
@@ -1575,6 +1575,8 @@ static PyObject* pybullet_getDynamicsInfo(PyObject* self, PyObject* args, PyObje
 				PyTuple_SetItem(pyDynamicsInfo, 9, PyFloat_FromDouble(info.m_contactStiffness));
 				PyTuple_SetItem(pyDynamicsInfo, 10, PyInt_FromLong(info.m_bodyType));
 				PyTuple_SetItem(pyDynamicsInfo, 11, PyFloat_FromDouble(info.m_collisionMargin));
+				PyTuple_SetItem(pyDynamicsInfo, 12, PyInt_FromLong(info.m_activationState));
+
 				return pyDynamicsInfo;
 			}
 		}

--- a/examples/pybullet/pybullet.c
+++ b/examples/pybullet/pybullet.c
@@ -12997,6 +12997,12 @@ initpybullet(void)
 	PyModule_AddIntConstant(m, "ACTIVATION_STATE_ENABLE_WAKEUP", eActivationStateEnableWakeup);
 	PyModule_AddIntConstant(m, "ACTIVATION_STATE_DISABLE_WAKEUP", eActivationStateDisableWakeup);
 
+	PyModule_AddIntConstant(m, "ACTIVATION_STATE_INTERNAL_IS_ACTIVE", eActiveTag);
+	PyModule_AddIntConstant(m, "ACTIVATION_STATE_INTERNAL_ISLAND_SLEEPING", eIslandSleeping);
+	PyModule_AddIntConstant(m, "ACTIVATION_STATE_INTERNAL_WANTS_DEACTIVATION", eWantsDeactivation);
+	PyModule_AddIntConstant(m, "ACTIVATION_STATE_INTERNAL_DISABLE_DEACTIVATION", eDisableDeactivation);
+	PyModule_AddIntConstant(m, "ACTIVATION_STATE_INTERNAL_DISABLE_SIMULATION", eDisableSimulation);
+
 	PyModule_AddIntConstant(m, "URDF_USE_SELF_COLLISION", URDF_USE_SELF_COLLISION);
 	PyModule_AddIntConstant(m, "URDF_USE_SELF_COLLISION_EXCLUDE_PARENT", URDF_USE_SELF_COLLISION_EXCLUDE_PARENT);
 	PyModule_AddIntConstant(m, "URDF_USE_SELF_COLLISION_INCLUDE_PARENT", URDF_USE_SELF_COLLISION_INCLUDE_PARENT);


### PR DESCRIPTION
Hi Erwin,

I am wondering would it be good to expose the `activationState` to pybullet? The main use case is when there are many object in the scene and if one needs to iterative over them, we can query the `activationState` and skip some expensive operations on an object if it is sleeping.

Also I find the variable activationState is slightly overloaded, there is one to control if an object can go into sleep when changing dynamics. And there is one accounting for internal activationState which is defined here as `m_activationState1`: 

https://github.com/bulletphysics/bullet3/blob/2a0f811c3bb3c65810eb2c095724b20b2f8b8dd4/src/BulletCollision/CollisionDispatch/btCollisionObject.h#L22-L26
