### PR TITLE
Disable velocity calculation in kinematic multibody mode by default

### DIFF
--- a/examples/MultiBody/KinematicMultiBodyExample.cpp
+++ b/examples/MultiBody/KinematicMultiBodyExample.cpp
@@ -37,6 +37,8 @@ void kinematicPreTickCallback(btDynamicsWorld* world, btScalar deltaTime)
 	btVector3 angularVelocity(0, 0.1, 0);
 	btTransformUtil::integrateTransform(groundBody->getBaseWorldTransform(), linearVelocity, angularVelocity, deltaTime, predictedTrans);
 	groundBody->setBaseWorldTransform(predictedTrans);
+	groundBody->setBaseVel(linearVelocity);
+	groundBody->setBaseOmega(angularVelocity);
 
 	static float time = 0.0;
 	time += deltaTime;

--- a/src/BulletDynamics/Featherstone/btMultiBody.cpp
+++ b/src/BulletDynamics/Featherstone/btMultiBody.cpp
@@ -125,7 +125,8 @@ btMultiBody::btMultiBody(int n_links,
 	  m_posVarCnt(0),
 	  m_useRK4(false),
 	  m_useGlobalVelocities(false),
-	  m_internalNeedsJointFeedback(false)
+	  m_internalNeedsJointFeedback(false),
+		m_kinematic_calculate_velocity(false)
 {
 	m_cachedInertiaTopLeft.setValue(0, 0, 0, 0, 0, 0, 0, 0, 0);
 	m_cachedInertiaTopRight.setValue(0, 0, 0, 0, 0, 0, 0, 0, 0);
@@ -2381,7 +2382,7 @@ const char *btMultiBody::serialize(void *dataBuffer, class btSerializer *seriali
 void btMultiBody::saveKinematicState(btScalar timeStep)
 {
 	//todo: clamp to some (user definable) safe minimum timestep, to limit maximum angular/linear velocities
-	if (timeStep != btScalar(0.))
+	if (m_kinematic_calculate_velocity && timeStep != btScalar(0.))
 	{
 		btVector3 linearVelocity, angularVelocity;
 		btTransformUtil::calculateVelocity(getInterpolateBaseWorldTransform(), getBaseWorldTransform(), timeStep, linearVelocity, angularVelocity);

--- a/src/BulletDynamics/Featherstone/btMultiBody.h
+++ b/src/BulletDynamics/Featherstone/btMultiBody.h
@@ -823,6 +823,9 @@ private:
 
 	///the m_needsJointFeedback gets updated/computed during the stepVelocitiesMultiDof and it for internal usage only
 	bool m_internalNeedsJointFeedback;
+
+  //If enabled, calculate the velocity based on kinematic transform changes. Currently only implemented for the base.
+	bool m_kinematic_calculate_velocity;
 };
 
 struct btMultiBodyLinkDoubleData


### PR DESCRIPTION
We haven't implemented this for the multi body joints. To be consistent, let's disable it for the base as well, and let user to set the velocities.