### PR TITLE
BulletRoboticsGUI: do not link to shared BulletExampleBrowserLib

### DIFF
--- a/Extras/BulletRoboticsGUI/CMakeLists.txt
+++ b/Extras/BulletRoboticsGUI/CMakeLists.txt
@@ -180,7 +180,7 @@ SET_TARGET_PROPERTIES(BulletRoboticsGUI PROPERTIES VERSION ${BULLET_VERSION})
 SET_TARGET_PROPERTIES(BulletRoboticsGUI PROPERTIES SOVERSION ${BULLET_VERSION})
 
 IF (BUILD_SHARED_LIBS)
-	TARGET_LINK_LIBRARIES(BulletRoboticsGUI  BulletExampleBrowserLib BulletRobotics  BulletInverseDynamicsUtils BulletWorldImporter BulletFileLoader BulletSoftBody BulletDynamics BulletCollision BulletInverseDynamics LinearMath Bullet3Common)
+	TARGET_LINK_LIBRARIES(BulletRoboticsGUI  BulletRobotics  BulletInverseDynamicsUtils BulletWorldImporter BulletFileLoader BulletSoftBody BulletDynamics BulletCollision BulletInverseDynamics LinearMath Bullet3Common)
 ENDIF (BUILD_SHARED_LIBS)
 
   


### PR DESCRIPTION
This fixes

```
ld: error: unable to find library -lBulletExampleBrowserLib
```

with BUILD_BULLET2_DEMOS=OFF.

This linking should not be required, IIUC the required parts of that lib are built as the sources of BulletRoboticsGUI itself.