### PR TITLE
Add b3RobotSimulatorClientAPI to BulletRoboticsGUI

### DIFF
--- a/Extras/BulletRoboticsGUI/CMakeLists.txt
+++ b/Extras/BulletRoboticsGUI/CMakeLists.txt
@@ -91,11 +91,12 @@ SET(BulletRoboticsGUI_INCLUDES
   ../../examples/MultiThreading/b3PosixThreadSupport.h
   ../../examples/MultiThreading/b3Win32ThreadSupport.h
   ../../examples/MultiThreading/b3ThreadSupportInterface.h
+
+  ../../examples/RobotSimulator/b3RobotSimulatorClientAPI.h
 )
 
 SET(BulletRoboticsGUI_SRCS ${BulletRoboticsGUI_INCLUDES}
-
-	../../examples/SharedMemory/plugins/stablePDPlugin/SpAlg.cpp
+  ../../examples/SharedMemory/plugins/stablePDPlugin/SpAlg.cpp
   ../../examples/SharedMemory/plugins/stablePDPlugin/SpAlg.h
   ../../examples/SharedMemory/plugins/stablePDPlugin/Shape.cpp
   ../../examples/SharedMemory/plugins/stablePDPlugin/Shape.h
@@ -109,19 +110,20 @@ SET(BulletRoboticsGUI_SRCS ${BulletRoboticsGUI_INCLUDES}
   ../../examples/SharedMemory/plugins/stablePDPlugin/KinTree.h
   ../../examples/SharedMemory/plugins/stablePDPlugin/BulletConversion.cpp
   ../../examples/SharedMemory/plugins/stablePDPlugin/BulletConversion.h
-	../../examples/ExampleBrowser/InProcessExampleBrowser.cpp
-	../../examples/SharedMemory/GraphicsServerExample.cpp
-	../../examples/SharedMemory/GraphicsClientExample.cpp
-	../../examples/SharedMemory/RemoteGUIHelper.cpp
-	../../examples/SharedMemory/RemoteGUIHelperTCP.cpp
-	../../examples/SharedMemory/GraphicsServerExample.h
-	../../examples/SharedMemory/GraphicsClientExample.h
-	../../examples/SharedMemory/RemoteGUIHelper.h
-	../../examples/SharedMemory/GraphicsSharedMemoryCommands.h
-	../../examples/SharedMemory/GraphicsSharedMemoryPublic.h
-	../../examples/SharedMemory/PhysicsServerExample.cpp
-	../../examples/SharedMemory/PhysicsServerExampleBullet2.cpp
-	../../examples/SharedMemory/SharedMemoryInProcessPhysicsC_API.cpp		
+  ../../examples/ExampleBrowser/InProcessExampleBrowser.cpp
+  ../../examples/SharedMemory/GraphicsServerExample.cpp
+  ../../examples/SharedMemory/GraphicsClientExample.cpp
+  ../../examples/SharedMemory/RemoteGUIHelper.cpp
+  ../../examples/SharedMemory/RemoteGUIHelperTCP.cpp
+  ../../examples/SharedMemory/GraphicsServerExample.h
+  ../../examples/SharedMemory/GraphicsClientExample.h
+  ../../examples/SharedMemory/RemoteGUIHelper.h
+  ../../examples/SharedMemory/GraphicsSharedMemoryCommands.h
+  ../../examples/SharedMemory/GraphicsSharedMemoryPublic.h
+  ../../examples/SharedMemory/PhysicsServerExample.cpp
+  ../../examples/SharedMemory/PhysicsServerExampleBullet2.cpp
+  ../../examples/SharedMemory/SharedMemoryInProcessPhysicsC_API.cpp
+  ../../examples/RobotSimulator/b3RobotSimulatorClientAPI.cpp
 )
 
 IF(BUILD_CLSOCKET)


### PR DESCRIPTION
I added the b3RobotSimulatorClientAPI from the RobotSimulator example to the BulletRoboticsGUI library. This is so a user doesn't have to copy the API into their project. 