### PR TITLE
Make sure MJCFBaseBulletEnv.render returns a uint8 array

### DIFF
--- a/examples/pybullet/gym/pybullet_envs/env_bases.py
+++ b/examples/pybullet/gym/pybullet_envs/env_bases.py
@@ -127,7 +127,7 @@ class MJCFBaseBulletEnv(gym.Env):
     else:
       px = np.array([[[255,255,255,255]]*self._render_width]*self._render_height, dtype=np.uint8)
     rgb_array = np.array(px, dtype=np.uint8)
-    rgb_array = np.reshape(np.array(px), (self._render_height, self._render_width, -1))
+    rgb_array = np.reshape(rgb_array, (self._render_height, self._render_width, -1))
     rgb_array = rgb_array[:, :, :3]
     return rgb_array
 


### PR DESCRIPTION
The issue is `MJCFBaseBulletEnv.render` returns an `int64` array.

Here is how to reproduce the issue.
```python
import gym
import pybullet_envs

env = gym.make("AntBulletEnv-v0")
env.reset()
array = env.render(mode="rgb_array")
print(array.dtype)
```
What I get with the latest master (https://github.com/bulletphysics/bullet3/commit/abea1a848411cf53385fb8288c89db05e5751ef7): `int64`.

This is not great since `gym`'s video recorder expects `uint8`: https://github.com/openai/gym/blob/8a721ace460cbaf8c3e6c03c12d06c616fd6e1e8/gym/wrappers/monitoring/video_recorder.py#L300

The current code of `MJCFBaseBulletEnv.render` seems to try to cast the array to `uint8` at L129. However, it does not work since it is ignored by L130.
https://github.com/bulletphysics/bullet3/blob/abea1a848411cf53385fb8288c89db05e5751ef7/examples/pybullet/gym/pybullet_envs/env_bases.py#L129-L130

This PR resolves the issue so that the code snippet above prints `uint8`.