### PR TITLE
Fix issue with Raycast Vehicle (btRaycastVehicle) wheel transforms behaving strangely

### DIFF
--- a/src/BulletDynamics/Vehicle/btRaycastVehicle.cpp
+++ b/src/BulletDynamics/Vehicle/btRaycastVehicle.cpp
@@ -110,9 +110,9 @@ void btRaycastVehicle::updateWheelTransform(int wheelIndex, bool interpolatedTra
 	btMatrix3x3 rotatingMat(rotatingOrn);
 
 	btMatrix3x3 basis2;
-	basis2[0][m_indexRightAxis] = -right[0];
-	basis2[1][m_indexRightAxis] = -right[1];
-	basis2[2][m_indexRightAxis] = -right[2];
+	basis2[0][m_indexRightAxis] = right[0];
+	basis2[1][m_indexRightAxis] = right[1];
+	basis2[2][m_indexRightAxis] = right[2];
 
 	basis2[0][m_indexUpAxis] = up[0];
 	basis2[1][m_indexUpAxis] = up[1];
@@ -522,7 +522,7 @@ void btRaycastVehicle::updateFriction(btScalar timeStep)
 				const btTransform& wheelTrans = getWheelTransformWS(i);
 
 				btMatrix3x3 wheelBasis0 = wheelTrans.getBasis();
-				m_axle[i] = -btVector3(
+				m_axle[i] = btVector3(
 					wheelBasis0[0][m_indexRightAxis],
 					wheelBasis0[1][m_indexRightAxis],
 					wheelBasis0[2][m_indexRightAxis]);


### PR DESCRIPTION
I've spent many hours trying to figure out why my vehicle was behaving oddly, and this PR solves the problem. Even if for some reason this PR gets closed, I wanted to at least have a record of it sitting against bullet3 so other people won't have to spend as much time as I did trying to figure this out and can try out the solution for themselves!

Note that it seems to "undo" some work from [this previous PR](https://github.com/bulletphysics/bullet3/pull/1622), so maybe I'm doing something wrong here, but I'll give a backstory.

I have a little driving game I was working on and I decided to base the vehicle on the Raycast Vehicle. In my game world, I have +X to the right, +Y forward, and +Z up. It is a right-handed coordinate system.

From what I could tell, this matched the setup of btRaycastVehicle. In the constructor for it, I found the following code:

```
	m_indexRightAxis = 0;
	m_indexUpAxis = 2;
	m_indexForwardAxis = 1;
```

To me, that implied a perfect match. Although the ordering is a bit bizarre, the axis meanings are the same as my game world, so I thought this would work very well.

I interpreted that the intended direction of `wheelDirectionWS` should be "down" based on the following line of code:

`btVector3 up = -wheel.m_raycastInfo.m_wheelDirectionWS`

I also interpreted that the intended direction of `wheelAxleWS` should be "right" based on the following line of code:

`const btVector3& right = wheel.m_raycastInfo.m_wheelAxleWS`

With everything set up like that I ran my code and found that although the vehicle behaved properly (positive engine force moved it forward, negative moved it backward, steering left and right worked properly), when I would try to draw the wheels in my game based on the returned values of `getWheelTransformWS`, they would behave very erratically (sometimes not rotating at all, sometimes seemingly rotating properly, sometimes twisting off of their axes depending on the direction of travel).

It seems the code is internally inconsistent about which way the axle is supposed to face. I found that if I switched the axle direction to "left" in my game code, the engine force and steering got reversed. Once I removed these two negations in the code, everything seemed to work correctly. The wheel rotation rendered correctly, and engine and steering forces remained correct also.

Please let me know if this PR misunderstands something, but if so, please let me know how I might set up the vehicle correctly in this world space and what I might have been doing wrong. I'd also be willing to file a PR against the docs to be more clear about what the expectations are for raycast vehicles if that's the case.

I have [filed an issue](https://github.com/bulletphysics/bullet3/issues/3281) that is solved by this PR.

Thanks for the hard work on Bullet!