### PR TITLE
heightfield: improve `processAllTriangles` performance

### DIFF
--- a/src/BulletCollision/CollisionShapes/btHeightfieldTerrainShape.cpp
+++ b/src/BulletCollision/CollisionShapes/btHeightfieldTerrainShape.cpp
@@ -349,27 +349,32 @@ void btHeightfieldTerrainShape::processAllTriangles(btTriangleCallback* callback
 
 			if (m_flipQuadEdges || (m_useDiamondSubdivision && !((j + x) & 1)) || (m_useZigzagSubdivision && !(j & 1)))
 			{
-				//first triangle
 				getVertex(x, j, vertices[indices[0]]);
 				getVertex(x, j + 1, vertices[indices[1]]);
 				getVertex(x + 1, j + 1, vertices[indices[2]]);
 				callback->processTriangle(vertices, 2 * x, j);
-				//second triangle
-				//  getVertex(x,j,vertices[0]);//already got this vertex before, thanks to Danny Chapman
-				getVertex(x + 1, j + 1, vertices[indices[1]]);
+			
+				// already set: getVertex(x, j, vertices[indices[0]])
+
+				// equivalent to: getVertex(x + 1, j + 1, vertices[indices[1]]);
+				vertices[indices[1]] = vertices[indices[2]];
+
 				getVertex(x + 1, j, vertices[indices[2]]);
+				
 				callback->processTriangle(vertices, 2 * x+1, j);
 			}
 			else
 			{
-				//first triangle
 				getVertex(x, j, vertices[indices[0]]);
 				getVertex(x, j + 1, vertices[indices[1]]);
 				getVertex(x + 1, j, vertices[indices[2]]);
 				callback->processTriangle(vertices, 2 * x, j);
-				//second triangle
-				getVertex(x + 1, j, vertices[indices[0]]);
-				//getVertex(x,j+1,vertices[1]);
+
+				// already set: getVertex(x, j + 1, vertices[indices[1]]);
+
+				// equivalent to: getVertex(x + 1, j, vertices[indices[0]]);
+				vertices[indices[0]] = vertices[indices[2]];
+
 				getVertex(x + 1, j + 1, vertices[indices[2]]);
 				callback->processTriangle(vertices, 2 * x+1, j);
 			}

--- a/src/BulletCollision/CollisionShapes/btHeightfieldTerrainShape.cpp
+++ b/src/BulletCollision/CollisionShapes/btHeightfieldTerrainShape.cpp
@@ -352,7 +352,13 @@ void btHeightfieldTerrainShape::processAllTriangles(btTriangleCallback* callback
 				getVertex(x, j, vertices[indices[0]]);
 				getVertex(x, j + 1, vertices[indices[1]]);
 				getVertex(x + 1, j + 1, vertices[indices[2]]);
-				callback->processTriangle(vertices, 2 * x, j);
+
+				// Skip triangle processing if the triangle is out-of-AABB.
+				btScalar minUp = btMin(vertices[0][m_upAxis], btMin(vertices[1][m_upAxis], vertices[2][m_upAxis]));
+				btScalar maxUp = btMax(vertices[0][m_upAxis], btMax(vertices[1][m_upAxis], vertices[2][m_upAxis]));
+
+				if (!(minUp > aabbMax[m_upAxis] || maxUp < aabbMin[m_upAxis]))
+					callback->processTriangle(vertices, 2 * x, j);
 			
 				// already set: getVertex(x, j, vertices[indices[0]])
 
@@ -360,15 +366,24 @@ void btHeightfieldTerrainShape::processAllTriangles(btTriangleCallback* callback
 				vertices[indices[1]] = vertices[indices[2]];
 
 				getVertex(x + 1, j, vertices[indices[2]]);
-				
-				callback->processTriangle(vertices, 2 * x+1, j);
+				minUp = btMin(minUp, vertices[indices[2]][m_upAxis]);
+				maxUp = btMax(maxUp, vertices[indices[2]][m_upAxis]);
+
+				if (!(minUp > aabbMax[m_upAxis] || maxUp < aabbMin[m_upAxis]))
+					callback->processTriangle(vertices, 2 * x+1, j);
 			}
 			else
 			{
 				getVertex(x, j, vertices[indices[0]]);
 				getVertex(x, j + 1, vertices[indices[1]]);
 				getVertex(x + 1, j, vertices[indices[2]]);
-				callback->processTriangle(vertices, 2 * x, j);
+
+				// Skip triangle processing if the triangle is out-of-AABB.
+				btScalar minUp = btMin(vertices[0][m_upAxis], btMin(vertices[1][m_upAxis], vertices[2][m_upAxis]));
+				btScalar maxUp = btMax(vertices[0][m_upAxis], btMax(vertices[1][m_upAxis], vertices[2][m_upAxis]));
+
+				if (!(minUp > aabbMax[m_upAxis] || maxUp < aabbMin[m_upAxis]))
+					callback->processTriangle(vertices, 2 * x, j);
 
 				// already set: getVertex(x, j + 1, vertices[indices[1]]);
 
@@ -376,7 +391,11 @@ void btHeightfieldTerrainShape::processAllTriangles(btTriangleCallback* callback
 				vertices[indices[0]] = vertices[indices[2]];
 
 				getVertex(x + 1, j + 1, vertices[indices[2]]);
-				callback->processTriangle(vertices, 2 * x+1, j);
+				minUp = btMin(minUp, vertices[indices[2]][m_upAxis]);
+				maxUp = btMax(maxUp, vertices[indices[2]][m_upAxis]);
+
+				if (!(minUp > aabbMax[m_upAxis] || maxUp < aabbMin[m_upAxis]))
+					callback->processTriangle(vertices, 2 * x+1, j);
 			}
 		}
 	}

--- a/src/BulletCollision/CollisionShapes/btHeightfieldTerrainShape.cpp
+++ b/src/BulletCollision/CollisionShapes/btHeightfieldTerrainShape.cpp
@@ -232,6 +232,43 @@ getQuantized(
 	return (int)(x + 0.5);
 }
 
+static btHeightfieldTerrainShape::Range makeRange(btScalar min, btScalar max)
+{
+	btHeightfieldTerrainShape::Range result;
+	result.min = min;
+	result.max = max;
+	return result;
+}
+
+static bool rangesHaveOverlap(const btHeightfieldTerrainShape::Range& a, const btHeightfieldTerrainShape::Range& b)
+{
+	return !(a.min > b.max || a.max < b.min);
+}
+
+// Equivalent to std::minmax({a, b, c}).
+// Performs at most 3 comparisons.
+static btHeightfieldTerrainShape::Range minmaxRange(btScalar a, btScalar b, btScalar c)
+{
+	if (a > b)
+	{
+		if (b > c)
+			return makeRange(c, a);
+		else if (a > c)
+			return makeRange(b, a);
+		else
+			return makeRange(b, c);
+	}
+	else
+	{
+		if (a > c)
+			return makeRange(c, b);
+		else if (b > c)
+			return makeRange(a, b);
+		else
+			return makeRange(a, c);
+	}
+}
+
 /// given input vector, return quantized version
 /**
   This routine is basically determining the gridpoint indices for a given
@@ -334,7 +371,8 @@ void btHeightfieldTerrainShape::processAllTriangles(btTriangleCallback* callback
 	}
 
 	// TODO If m_vboundsGrid is available, use it to determine if we really need to process this area
-
+	
+	const Range aabbUpRange = makeRange(aabbMin[m_upAxis], aabbMax[m_upAxis]);
 	for (int j = startJ; j < endJ; j++)
 	{
 		for (int x = startX; x < endX; x++)
@@ -354,10 +392,9 @@ void btHeightfieldTerrainShape::processAllTriangles(btTriangleCallback* callback
 				getVertex(x + 1, j + 1, vertices[indices[2]]);
 
 				// Skip triangle processing if the triangle is out-of-AABB.
-				btScalar minUp = btMin(vertices[0][m_upAxis], btMin(vertices[1][m_upAxis], vertices[2][m_upAxis]));
-				btScalar maxUp = btMax(vertices[0][m_upAxis], btMax(vertices[1][m_upAxis], vertices[2][m_upAxis]));
+				Range upRange = minmaxRange(vertices[0][m_upAxis], vertices[1][m_upAxis], vertices[2][m_upAxis]);
 
-				if (!(minUp > aabbMax[m_upAxis] || maxUp < aabbMin[m_upAxis]))
+				if (rangesHaveOverlap(upRange, aabbUpRange))
 					callback->processTriangle(vertices, 2 * x, j);
 			
 				// already set: getVertex(x, j, vertices[indices[0]])
@@ -366,11 +403,11 @@ void btHeightfieldTerrainShape::processAllTriangles(btTriangleCallback* callback
 				vertices[indices[1]] = vertices[indices[2]];
 
 				getVertex(x + 1, j, vertices[indices[2]]);
-				minUp = btMin(minUp, vertices[indices[2]][m_upAxis]);
-				maxUp = btMax(maxUp, vertices[indices[2]][m_upAxis]);
+				upRange.min = btMin(upRange.min, vertices[indices[2]][m_upAxis]);
+				upRange.max = btMax(upRange.max, vertices[indices[2]][m_upAxis]);
 
-				if (!(minUp > aabbMax[m_upAxis] || maxUp < aabbMin[m_upAxis]))
-					callback->processTriangle(vertices, 2 * x+1, j);
+				if (rangesHaveOverlap(upRange, aabbUpRange))
+					callback->processTriangle(vertices, 2 * x + 1, j);
 			}
 			else
 			{
@@ -379,10 +416,9 @@ void btHeightfieldTerrainShape::processAllTriangles(btTriangleCallback* callback
 				getVertex(x + 1, j, vertices[indices[2]]);
 
 				// Skip triangle processing if the triangle is out-of-AABB.
-				btScalar minUp = btMin(vertices[0][m_upAxis], btMin(vertices[1][m_upAxis], vertices[2][m_upAxis]));
-				btScalar maxUp = btMax(vertices[0][m_upAxis], btMax(vertices[1][m_upAxis], vertices[2][m_upAxis]));
+				Range upRange = minmaxRange(vertices[0][m_upAxis], vertices[1][m_upAxis], vertices[2][m_upAxis]);
 
-				if (!(minUp > aabbMax[m_upAxis] || maxUp < aabbMin[m_upAxis]))
+				if (rangesHaveOverlap(upRange, aabbUpRange))
 					callback->processTriangle(vertices, 2 * x, j);
 
 				// already set: getVertex(x, j + 1, vertices[indices[1]]);
@@ -391,11 +427,11 @@ void btHeightfieldTerrainShape::processAllTriangles(btTriangleCallback* callback
 				vertices[indices[0]] = vertices[indices[2]];
 
 				getVertex(x + 1, j + 1, vertices[indices[2]]);
-				minUp = btMin(minUp, vertices[indices[2]][m_upAxis]);
-				maxUp = btMax(maxUp, vertices[indices[2]][m_upAxis]);
+				upRange.min = btMin(upRange.min, vertices[indices[2]][m_upAxis]);
+				upRange.max = btMax(upRange.max, vertices[indices[2]][m_upAxis]);
 
-				if (!(minUp > aabbMax[m_upAxis] || maxUp < aabbMin[m_upAxis]))
-					callback->processTriangle(vertices, 2 * x+1, j);
+				if (rangesHaveOverlap(upRange, aabbUpRange))
+					callback->processTriangle(vertices, 2 * x + 1, j);
 			}
 		}
 	}

--- a/src/BulletCollision/CollisionShapes/btHeightfieldTerrainShape.cpp
+++ b/src/BulletCollision/CollisionShapes/btHeightfieldTerrainShape.cpp
@@ -232,19 +232,6 @@ getQuantized(
 	return (int)(x + 0.5);
 }
 
-static btHeightfieldTerrainShape::Range makeRange(btScalar min, btScalar max)
-{
-	btHeightfieldTerrainShape::Range result;
-	result.min = min;
-	result.max = max;
-	return result;
-}
-
-static bool rangesHaveOverlap(const btHeightfieldTerrainShape::Range& a, const btHeightfieldTerrainShape::Range& b)
-{
-	return !(a.min > b.max || a.max < b.min);
-}
-
 // Equivalent to std::minmax({a, b, c}).
 // Performs at most 3 comparisons.
 static btHeightfieldTerrainShape::Range minmaxRange(btScalar a, btScalar b, btScalar c)
@@ -252,20 +239,20 @@ static btHeightfieldTerrainShape::Range minmaxRange(btScalar a, btScalar b, btSc
 	if (a > b)
 	{
 		if (b > c)
-			return makeRange(c, a);
+			return btHeightfieldTerrainShape::Range(c, a);
 		else if (a > c)
-			return makeRange(b, a);
+			return btHeightfieldTerrainShape::Range(b, a);
 		else
-			return makeRange(b, c);
+			return btHeightfieldTerrainShape::Range(b, c);
 	}
 	else
 	{
 		if (a > c)
-			return makeRange(c, b);
+			return btHeightfieldTerrainShape::Range(c, b);
 		else if (b > c)
-			return makeRange(a, b);
+			return btHeightfieldTerrainShape::Range(a, b);
 		else
-			return makeRange(a, c);
+			return btHeightfieldTerrainShape::Range(a, c);
 	}
 }
 
@@ -372,7 +359,7 @@ void btHeightfieldTerrainShape::processAllTriangles(btTriangleCallback* callback
 
 	// TODO If m_vboundsGrid is available, use it to determine if we really need to process this area
 	
-	const Range aabbUpRange = makeRange(aabbMin[m_upAxis], aabbMax[m_upAxis]);
+	const Range aabbUpRange(aabbMin[m_upAxis], aabbMax[m_upAxis]);
 	for (int j = startJ; j < endJ; j++)
 	{
 		for (int x = startX; x < endX; x++)
@@ -394,7 +381,7 @@ void btHeightfieldTerrainShape::processAllTriangles(btTriangleCallback* callback
 				// Skip triangle processing if the triangle is out-of-AABB.
 				Range upRange = minmaxRange(vertices[0][m_upAxis], vertices[1][m_upAxis], vertices[2][m_upAxis]);
 
-				if (rangesHaveOverlap(upRange, aabbUpRange))
+				if (upRange.overlaps(aabbUpRange))
 					callback->processTriangle(vertices, 2 * x, j);
 			
 				// already set: getVertex(x, j, vertices[indices[0]])
@@ -406,7 +393,7 @@ void btHeightfieldTerrainShape::processAllTriangles(btTriangleCallback* callback
 				upRange.min = btMin(upRange.min, vertices[indices[2]][m_upAxis]);
 				upRange.max = btMax(upRange.max, vertices[indices[2]][m_upAxis]);
 
-				if (rangesHaveOverlap(upRange, aabbUpRange))
+				if (upRange.overlaps(aabbUpRange))
 					callback->processTriangle(vertices, 2 * x + 1, j);
 			}
 			else
@@ -418,7 +405,7 @@ void btHeightfieldTerrainShape::processAllTriangles(btTriangleCallback* callback
 				// Skip triangle processing if the triangle is out-of-AABB.
 				Range upRange = minmaxRange(vertices[0][m_upAxis], vertices[1][m_upAxis], vertices[2][m_upAxis]);
 
-				if (rangesHaveOverlap(upRange, aabbUpRange))
+				if (upRange.overlaps(aabbUpRange))
 					callback->processTriangle(vertices, 2 * x, j);
 
 				// already set: getVertex(x, j + 1, vertices[indices[1]]);
@@ -430,7 +417,7 @@ void btHeightfieldTerrainShape::processAllTriangles(btTriangleCallback* callback
 				upRange.min = btMin(upRange.min, vertices[indices[2]][m_upAxis]);
 				upRange.max = btMax(upRange.max, vertices[indices[2]][m_upAxis]);
 
-				if (rangesHaveOverlap(upRange, aabbUpRange))
+				if (upRange.overlaps(aabbUpRange))
 					callback->processTriangle(vertices, 2 * x + 1, j);
 			}
 		}

--- a/src/BulletCollision/CollisionShapes/btHeightfieldTerrainShape.h
+++ b/src/BulletCollision/CollisionShapes/btHeightfieldTerrainShape.h
@@ -75,6 +75,14 @@ btHeightfieldTerrainShape : public btConcaveShape
 public:
 	struct Range
 	{
+		Range() {}
+		Range(btScalar min, btScalar max) : min(min), max(max) {}
+
+		bool overlaps(const Range& other) const
+		{
+			return !(min > other.max || max < other.min);
+		}
+
 		btScalar min;
 		btScalar max;
 	};

--- a/test/collision/CMakeLists.txt
+++ b/test/collision/CMakeLists.txt
@@ -24,10 +24,13 @@ ENDIF()
 		../../src/BulletCollision/CollisionShapes/btSphereShape.cpp
 		../../src/BulletCollision/CollisionShapes/btMultiSphereShape.cpp
 		../../src/BulletCollision/CollisionShapes/btPolyhedralConvexShape.cpp
+		../../src/BulletCollision/CollisionShapes/btConcaveShape.cpp
 		../../src/BulletCollision/CollisionShapes/btConvexShape.cpp
 		../../src/BulletCollision/CollisionShapes/btConvexInternalShape.cpp
 		../../src/BulletCollision/CollisionShapes/btCollisionShape.cpp
 		../../src/BulletCollision/CollisionShapes/btConvexPolyhedron.cpp
+		../../src/BulletCollision/CollisionShapes/btHeightfieldTerrainShape.cpp
+		../../src/BulletCollision/CollisionShapes/btTriangleCallback.cpp
 	)
 
 ADD_TEST(Test_Collision_PASS Test_Collision)


### PR DESCRIPTION
1. Skips triangle processing if the triangle is out-of-AABB on the up axis.
2. Fewer calls to `getVertex`: The 2 triangles of a heightfield quad share 2 vertices.

This massively improves OpenMW performance on my machine (in some areas, 20 FPS -> 60 FPS)

Refs #3276. Even though it does not use the accelerator structure, `processAllTriangles` is no longer a bottle-neck.

/cc @Zylann @psi29a @ddrone @erwincoumans 