### PR TITLE
Fix a null dereference in UrdfParser

### DIFF
--- a/examples/Importers/ImportURDFDemo/UrdfParser.cpp
+++ b/examples/Importers/ImportURDFDemo/UrdfParser.cpp
@@ -1132,6 +1132,7 @@ bool UrdfParser::parseDeformable(UrdfModel& model, tinyxml2::XMLElement* config,
 	if (!i)
 	{
 		logger->reportError("expected an inertial element");
+		return false;
 	}
 	UrdfInertia inertia;
 	if (!parseInertia(inertia, i, logger))


### PR DESCRIPTION
When the parser sees no <inertial> tag inside a <deformable>, it logs an error but does not return false. So in the next step, a null pointer is dereferenced.

This can be tested with loading the following URDF:
```
<?xml version="1.0"?>
<robot name="rhythm_carrot_sticks">
  <deformable name="bag">
  </deformable>
</robot>
```