### PR TITLE
Optimize calls to find*() for a single char.

### DIFF
--- a/examples/ThirdPartyLibs/cpp_base64/base64.cpp
+++ b/examples/ThirdPartyLibs/cpp_base64/base64.cpp
@@ -136,7 +136,7 @@ std::string base64_decode(std::string const& encoded_string, bool remove_linebre
        std::string copy(encoded_string);
 
        size_t pos=0;
-       while ((pos = copy.find("\n", pos)) != std::string::npos) {
+       while ((pos = copy.find('\n', pos)) != std::string::npos) {
            copy.erase(pos, 1);
        }
 

--- a/examples/TinyRenderer/model.cpp
+++ b/examples/TinyRenderer/model.cpp
@@ -149,7 +149,7 @@ Vec3f Model::vert(int iface, int nthvert)
 void Model::load_texture(std::string filename, const char *suffix, TGAImage &img)
 {
 	std::string texfile(filename);
-	size_t dot = texfile.find_last_of(".");
+	size_t dot = texfile.find_last_of('.');
 	if (dot != std::string::npos)
 	{
 		texfile = texfile.substr(0, dot) + std::string(suffix);


### PR DESCRIPTION
The character literal overload is more efficient.