### PR TITLE
heightfield: Fix PHY_FLOAT data handling in double-precision mode

### DIFF
--- a/src/BulletCollision/CollisionShapes/btHeightfieldTerrainShape.h
+++ b/src/BulletCollision/CollisionShapes/btHeightfieldTerrainShape.h
@@ -50,17 +50,15 @@ subject to the following restrictions:
   The heightfield heights are determined from the data type used for the
   heightfieldData array.  
 
-   - PHY_UCHAR: height at a point is the uchar value at the
+   - unsigned char: height at a point is the uchar value at the
        grid point, multipled by heightScale.  uchar isn't recommended
        because of its inability to deal with negative values, and
        low resolution (8-bit).
 
-   - PHY_SHORT: height at a point is the short int value at that grid
+   - short: height at a point is the short int value at that grid
        point, multipled by heightScale.
 
-   - PHY_FLOAT: height at a point is the float value at that grid
-       point.  heightScale is ignored when using the float heightfield
-       data type.
+   - float or dobule: height at a point is the value at that grid point.
 
   Whatever the caller specifies as minHeight and maxHeight will be honored.
   The class will not inspect the heightfield to discover the actual minimum
@@ -95,7 +93,8 @@ protected:
 	union {
 		const unsigned char* m_heightfieldDataUnsignedChar;
 		const short* m_heightfieldDataShort;
-		const btScalar* m_heightfieldDataFloat;
+		const float* m_heightfieldDataFloat;
+		const double* m_heightfieldDataDouble;
 		const void* m_heightfieldDataUnknown;
 	};
 
@@ -135,11 +134,33 @@ protected:
 public:
 	BT_DECLARE_ALIGNED_ALLOCATOR();
 
-	/// preferred constructor
+	/// preferred constructors
+	btHeightfieldTerrainShape(
+		int heightStickWidth, int heightStickLength,
+		const float* heightfieldData, btScalar minHeight, btScalar maxHeight,
+		int upAxis, bool flipQuadEdges);
+	btHeightfieldTerrainShape(
+		int heightStickWidth, int heightStickLength,
+		const double* heightfieldData, btScalar minHeight, btScalar maxHeight,
+		int upAxis, bool flipQuadEdges);
+	btHeightfieldTerrainShape(
+		int heightStickWidth, int heightStickLength,
+		const short* heightfieldData, btScalar heightScale, btScalar minHeight, btScalar maxHeight,
+		int upAxis, bool flipQuadEdges);
+	btHeightfieldTerrainShape(
+		int heightStickWidth, int heightStickLength,
+		const unsigned char* heightfieldData, btScalar heightScale, btScalar minHeight, btScalar maxHeight,
+		int upAxis, bool flipQuadEdges);
+
+	/// legacy constructor
 	/**
 	  This constructor supports a range of heightfield
 	  data types, and allows for a non-zero minimum height value.
 	  heightScale is needed for any integer-based heightfield data types.
+
+	  This legacy constructor considers `PHY_FLOAT` to mean `btScalar`.
+	  With `BT_USE_DOUBLE_PRECISION`, it will expect `heightfieldData`
+	  to be double-precision.
 	 */
 	btHeightfieldTerrainShape(int heightStickWidth, int heightStickLength,
 							  const void* heightfieldData, btScalar heightScale,
@@ -150,7 +171,7 @@ public:
 	/// legacy constructor
 	/**
 	  The legacy constructor assumes the heightfield has a minimum height
-	  of zero.  Only unsigned char or floats are supported.  For legacy
+	  of zero.  Only unsigned char or btScalar data are supported.  For legacy
 	  compatibility reasons, heightScale is calculated as maxHeight / 65535 
 	  (and is only used when useFloatData = false).
  	 */


### PR DESCRIPTION
Previously, the heightfield constructor always assumed `PHY_FLOAT` meant `btScalar`, contrary to the documentation and inconsistent with other usages of `PHY_FLOAT`.

Adds new constructors that distinguish between `float` and `double`. The legacy constructor is still there for backwards compatibility.

This allows the client to use `float` or `double` heightfield data regardless of `BT_USE_DOUBLE_PRECISION`.

Example use-case is to avoid data conversion when the source data is `float` but `btScalar` is `double`: https://gitlab.com/OpenMW/openmw/-/merge_requests/647/diffs

/cc @Zylann @psi29a @ddrone @erwincoumans