### PR TITLE
Use drawTriangle instead of drawing three lines

### DIFF
--- a/src/BulletCollision/CollisionDispatch/btCollisionWorld.cpp
+++ b/src/BulletCollision/CollisionDispatch/btCollisionWorld.cpp
@@ -1294,9 +1294,7 @@ public:
 			btVector3 normalColor(1, 1, 0);
 			m_debugDrawer->drawLine(center, center + normal, normalColor);
 		}
-		m_debugDrawer->drawLine(wv0, wv1, m_color);
-		m_debugDrawer->drawLine(wv1, wv2, m_color);
-		m_debugDrawer->drawLine(wv2, wv0, m_color);
+		m_debugDrawer->drawTriangle(wv0, wv1, wv2, m_color, 1.0);
 	}
 };
 


### PR DESCRIPTION
tl;dr: a trivial change making it easier to customise debug drawing. Just swaps three `drawLine` calls for one `drawTriangle` call.

In my application, we'd like to use `glPolygonOffset` so drawing Bullet's debug wireframes over geometry with matching shapes shows the physics wireframe on top of the rendered scene instead of depth fighting. This requires drawing it as triangles with the mode set to just draw the edges instead of directly as lines, so in our `btIDebugDraw` subclass, we've made it do that for `drawTriangle`. That doesn't work, though, as Bullet doesn't use `drawTriangle` even when drawing things made of triangles, so I've changed the function responsible.

For any applications *not* providing a custom `drawTriangle` override, the new and old behaviour will be indistinguishable as the default implementation in `btIDebugDraw` just draws three lines.