### PR TITLE
fix soft body triangular area calculation

### DIFF
--- a/src/BulletSoftBody/btSoftBodyInternals.h
+++ b/src/BulletSoftBody/btSoftBodyInternals.h
@@ -1285,7 +1285,7 @@ static inline btScalar AreaOf(const btVector3& x0,
 	const btVector3 a = x1 - x0;
 	const btVector3 b = x2 - x0;
 	const btVector3 cr = btCross(a, b);
-	const btScalar area = cr.length();
+	const btScalar area = cr.length() / 2.;
 	return (area);
 }
 


### PR DESCRIPTION
I'm not sure if this was deliberate, but if `area` is supposed to be the area of a triangle with edges `x1 - x0` and `x2 - x0`, it's missing a factor of `0.5`.