### PR TITLE
Fix memory leak in BulletSoftBody.

### DIFF
--- a/src/BulletSoftBody/btDeformableBodySolver.cpp
+++ b/src/BulletSoftBody/btDeformableBodySolver.cpp
@@ -405,6 +405,10 @@ void btDeformableBodySolver::predictMotion(btScalar solverdt)
 	for (int i = 0; i < m_softBodies.size(); ++i)
 	{
 		btSoftBody* psb = m_softBodies[i];
+		/* Clear contacts */
+		psb->m_nodeRigidContacts.resize(0);
+		psb->m_faceRigidContacts.resize(0);
+		psb->m_faceNodeContacts.resize(0);
 
 		if (psb->isActive())
 		{
@@ -472,10 +476,6 @@ void btDeformableBodySolver::predictDeformableMotion(btSoftBody* psb, btScalar d
 	{
 		psb->updateFaceTree(true, true);
 	}
-	/* Clear contacts */
-	psb->m_nodeRigidContacts.resize(0);
-	psb->m_faceRigidContacts.resize(0);
-	psb->m_faceNodeContacts.resize(0);
 	/* Optimize dbvt's        */
 	//    psb->m_ndbvt.optimizeIncremental(1);
 	//    psb->m_fdbvt.optimizeIncremental(1);


### PR DESCRIPTION
BulletSoftBody contact info would not be cleared between steps if the body was not active