### PR TITLE
Fix for bullet_client to be used from a class instance during multiprocessing

### DIFF
--- a/examples/pybullet/gym/pybullet_utils/bullet_client.py
+++ b/examples/pybullet/gym/pybullet_utils/bullet_client.py
@@ -1,6 +1,7 @@
 """A wrapper for pybullet to manage different clients."""
 from __future__ import absolute_import
 from __future__ import division
+import os
 import functools
 import inspect
 import pybullet
@@ -21,6 +22,7 @@ class BulletClient(object):
         `pybullet.SHARED_MEMORY` connects to an existing simulation.
     """
     self._shapes = {}
+    self._pid = os.getpid()
     if connection_mode is None:
       self._client = pybullet.connect(pybullet.SHARED_MEMORY, options=options)
       if self._client >= 0:
@@ -34,7 +36,7 @@ class BulletClient(object):
 
   def __del__(self):
     """Clean up connection if not already done."""
-    if self._client>=0:
+    if self._client>=0 and self._pid == os.getpid():
       try:
         pybullet.disconnect(physicsClientId=self._client)
         self._client = -1


### PR DESCRIPTION
Based on the conversation in https://github.com/bulletphysics/bullet3/discussions/3810

This fix adds an internal variable to the `BulletClient()` to store the process id that was used to create it.  It then checks this id before cleanup and disconnecting (i.e. executing `__del__`).

In summary, a class instance with an internal client will be set to 0, when the class calls a subprocess using spawn, the instance (and its variables) are copied to the subprocess. When that subprocess makes its own bullet connection using the same variable name, python decrements that reference _within that subprocess_ and calls `__del__`, which then disconnects from the _just created_ bullet client, because the `_client` attribute is 0, and was copied over.  This then creates a `pybullet.error: Not connected to physics server.` error. So this fix just checks that it doesn't disconnect from a bullet client that wasn't created on its own process. 

psuedo-situation
```
pid 101: create self.my_bullet_client # id is 0
# spawn subprocess
pid 202: reassign self.my_bullet_client as a new connection # id is 0, because there is no connection on this process
pid 202: my_bullet_client is disconnected
pid 202: physics server error # we just disconnected _client 0

```

now the process using the pid check would be
```
pid 101: create self.my_bullet_client # id is 0
# spawn subprocess
pid 202: reassign self.my_bullet_client as a new connection # id is 0, because there is no connection on this process
pid 202: self.my_bullet_client __del__ is called, but 202 != 101 # since the __del__ was called on the old instance it won't be disconnected
pid 202: does its thing 
pid 202: closes
pid 202: self.my_bullet_client __del__ is called, and is disconnected # because this was created on pid 202
# ends subprocess
pid 101: ends doing its thing
pid 101: self.my_bullet_client __del__ is called, and is disconnected # because this process never lost reference to the original

```
