### PR TITLE
Fix early exit in heightfield raycast

### DIFF
--- a/src/BulletCollision/CollisionShapes/btHeightfieldTerrainShape.cpp
+++ b/src/BulletCollision/CollisionShapes/btHeightfieldTerrainShape.cpp
@@ -828,6 +828,7 @@ void btHeightfieldTerrainShape::performRaycast(btTriangleCallback* callback, con
 		{
 			// Don't use chunks, the ray is too short in the plane
 			gridRaycast(processTriangles, beginPos, endPos, &indices[0]);
+			return;
 		}
 
 		ProcessVBoundsAction processVBounds(m_vboundsGrid, &indices[0]);


### PR DESCRIPTION
When deciding the ray is too short to use the accelerated structure and a simple raycast is performed, the method now returns to avoid processing it a second time using the accelerated structure.