### PR TITLE
Add flag to disable parent collisions over multiple generations.

### DIFF
--- a/src/BulletDynamics/Featherstone/btMultiBodyLink.h
+++ b/src/BulletDynamics/Featherstone/btMultiBodyLink.h
@@ -24,6 +24,7 @@ enum btMultiBodyLinkFlags
 {
 	BT_MULTIBODYLINKFLAGS_DISABLE_PARENT_COLLISION = 1,
 	BT_MULTIBODYLINKFLAGS_DISABLE_ALL_PARENT_COLLISION = 2,
+	BT_MULTIBODYLINKFLAGS_DISABLE_CUSTOM_NUMBER_PARENT_COLLISION = 4  //use this flag in combination with m_customNrDisabledParentCol
 };
 
 //both defines are now permanently enabled
@@ -131,6 +132,7 @@ struct btMultibodyLink
 
 	class btMultiBodyLinkCollider *m_collider;
 	int m_flags;
+	int m_customNrDisabledParentCol = 0;  //only being used if the BT_MULTIBODYLINKFLAGS_DISABLE_CUSTOM_NUMBER_PARENT_COLLISION flag is set. 
 
 	int m_dofCount, m_posVarCount;  //redundant but handy
 

--- a/src/BulletDynamics/Featherstone/btMultiBodyLinkCollider.h
+++ b/src/BulletDynamics/Featherstone/btMultiBodyLinkCollider.h
@@ -104,6 +104,20 @@ public:
 				if (link.m_parent == other->m_link)
 					return false;
 			}
+			else if (link.m_flags & BT_MULTIBODYLINKFLAGS_DISABLE_CUSTOM_NUMBER_PARENT_COLLISION)
+			{
+				int parent_of_this = m_link;
+				for (int i = 0; i < link.m_customNrDisabledParentCol; ++i)
+				{
+					if (parent_of_this == -1)
+						break;
+					parent_of_this = m_multiBody->getLink(parent_of_this).m_parent;
+					if (parent_of_this == other->m_link)
+					{
+						return false;
+					}
+				}
+			}
 		}
 
 		if (other->m_link >= 0)
@@ -125,6 +139,20 @@ public:
 			{
 				if (otherLink.m_parent == this->m_link)
 					return false;
+			}
+			else if (otherLink.m_flags & BT_MULTIBODYLINKFLAGS_DISABLE_CUSTOM_NUMBER_PARENT_COLLISION)
+			{
+				int parent_of_other = other->m_link;
+				for (int i = 0; i < otherLink.m_customNrDisabledParentCol; ++i)
+				{
+					if (parent_of_other == -1)
+						break;
+					parent_of_other = m_multiBody->getLink(parent_of_other).m_parent;
+					if (parent_of_other == this->m_link)
+					{
+						return false;
+					}
+				}
 			}
 		}
 		return true;


### PR DESCRIPTION
This is useful for example in wheeled robots to ignore collisions of the wheels with the suspension and the chassis. In this case set the flag and set m_customNrDisabledParentCol to 2 to ignore the parent and grandparent collisions.