### PR TITLE
Extras/VHACD/inc/vhacdMutex.h: fix musl build

### DIFF
--- a/Extras/VHACD/inc/vhacdMutex.h
+++ b/Extras/VHACD/inc/vhacdMutex.h
@@ -69,7 +69,7 @@
 #include <pthread.h>
 #endif
 
-#if defined(__APPLE__)
+#if defined(__APPLE__) || !defined(__GLIBC__)
 #define PTHREAD_MUTEX_RECURSIVE_NP PTHREAD_MUTEX_RECURSIVE
 #endif
 


### PR DESCRIPTION
Fix the following build failure on musl (which does not provide `PTHREAD_MUTEX_RECURSIVE_NP`):

```
In file included from /tmp/instance-5/output-1/build/bullet-3.09/src/LinearMath/btScalar.h:289,
                 from /tmp/instance-5/output-1/build/bullet-3.09/src/LinearMath/btVector3.h:19,
                 from /tmp/instance-5/output-1/build/bullet-3.09/src/LinearMath/btConvexHullComputer.h:18,
                 from /tmp/instance-5/output-1/build/bullet-3.09/Extras/VHACD/src/VHACD.cpp:28:
/tmp/instance-5/output-1/build/bullet-3.09/Extras/BulletRobotics/../../Extras/VHACD/inc/vhacdMutex.h: In constructor 'VHACD::Mutex::Mutex()':
/tmp/instance-5/output-1/build/bullet-3.09/Extras/BulletRobotics/../../Extras/VHACD/inc/vhacdMutex.h:97:54: error: 'PTHREAD_MUTEX_RECURSIVE_NP' was not declared in this scope; did you mean 'PTHREAD_MUTEX_RECURSIVE'?
   97 |   VHACD_VERIFY(pthread_mutexattr_settype(&mutexAttr, PTHREAD_MUTEX_RECURSIVE_NP) == 0);
      |                                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~
```

Fixes:
 - http://autobuild.buildroot.org/results/79cd2024b3dfc8d3e896cdacf67fb891df81ca6e

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>