### PR TITLE
Fix crash when btSoftBody collides with btCompoundShape

### DIFF
--- a/src/BulletSoftBody/btSoftBodyConcaveCollisionAlgorithm.cpp
+++ b/src/BulletSoftBody/btSoftBodyConcaveCollisionAlgorithm.cpp
@@ -195,8 +195,7 @@ void btSoftBodyConcaveCollisionAlgorithm::processCollision(const btCollisionObje
 
 	if (triBody->getCollisionShape()->isConcave())
 	{
-		const btCollisionObject* triOb = triBody->getCollisionObject();
-		const btConcaveShape* concaveShape = static_cast<const btConcaveShape*>(triOb->getCollisionShape());
+		const btConcaveShape* concaveShape = static_cast<const btConcaveShape*>(triBody->getCollisionShape());
 
 		//	if (convexBody->getCollisionShape()->isConvex())
 		{


### PR DESCRIPTION
Fix crash when `btSoftBody` collides with a `btBvhTriangleMeshShape` inside a `btCompoundShape`

- `triBody->getCollisionObject()` returns the `btCompoundShape` in that situation, which does not implement the `btConcaveShape` interface required for the `processAllTriangles()` call later
- `triBody->getCollisionShape()` already returns the shape to check, so it can be used instead

Reproduction of crash: 
1. Apply https://github.com/notrabs/bullet3/commit/0009830cf1be0440286ec320336f73836b1109d2 to SoftDemo.cpp
2. Start `SoftBody>Cluster Deform` Demo
3. The crash happens as soon as the torus gets close to the ground