### PR TITLE
Add deformable contact forces info

### DIFF
--- a/src/BulletSoftBody/btDeformableContactConstraint.cpp
+++ b/src/BulletSoftBody/btDeformableContactConstraint.cpp
@@ -268,7 +268,7 @@ btScalar btDeformableRigidContactConstraint::solveConstraint(const btContactSolv
 	{
 		dn += m_penetration * infoGlobal.m_deformable_erp / infoGlobal.m_timeStep;
 	}
-	// dn is the normal component of velocity diffrerence. Approximates the residual. // todo xuchenhan@: this prob needs to be scaled by dt
+	// dn is the normal component of velocity difference. Approximates the residual. // todo xuchenhan@: this prob needs to be scaled by dt
 	btVector3 impulse = m_contact->m_c0 * (vr + m_total_normal_dv * infoGlobal.m_deformable_cfm + ((m_penetration > 0) ? m_penetration / infoGlobal.m_timeStep * cti.m_normal : btVector3(0, 0, 0)));
 	if (!infoGlobal.m_splitImpulse)
 	{
@@ -486,6 +486,9 @@ void btDeformableFaceRigidContactConstraint::applyImpulse(const btVector3& impul
 	const btSoftBody::DeformableFaceRigidContact* contact = getContact();
 	btVector3 dv = impulse * contact->m_c2;
 	btSoftBody::Face* face = contact->m_face;
+
+	// save applied impulse
+	contact->m_cti.m_impulse = impulse;
 
 	btVector3& v0 = face->m_n[0]->m_v;
 	btVector3& v1 = face->m_n[1]->m_v;

--- a/src/BulletSoftBody/btSoftBody.h
+++ b/src/BulletSoftBody/btSoftBody.h
@@ -223,10 +223,12 @@ public:
 	/* sCti is Softbody contact info	*/
 	struct sCti
 	{
-		const btCollisionObject* m_colObj; /* Rigid body			*/
-		btVector3 m_normal;                /* Outward normal		*/
-		btScalar m_offset;                 /* Offset from origin	*/
+		const btCollisionObject* m_colObj; /* Rigid body			        */
+		btVector3 m_normal;                /* Outward normal		        */
+		mutable btVector3 m_impulse;	   /* Applied impulse        	    */
+		btScalar m_offset;                 /* Offset from origin	        */
 		btVector3 m_bary;                  /* Barycentric weights for faces */
+		sCti() : m_impulse(0, 0, 0) {}
 	};
 
 	/* sMedium		*/
@@ -892,7 +894,7 @@ public:
 				   int node1) const;
 	bool checkLink(const Node* node0,
 				   const Node* node1) const;
-	/* Check for existring face												*/
+	/* Check for existing face												*/
 	bool checkFace(int node0,
 				   int node1,
 				   int node2) const;


### PR DESCRIPTION
- add contact information for collisions between rigid and soft bodies
- collisions between different soft bodies are not supported
- uses impulse acting on tetrahedral nodes for calculation of forces
- contact points are approximated by node positions
- multiple forces acting on identical nodes are accumulated