### PR TITLE
SoftBody: Fix local variable shadowing warning

### DIFF
--- a/src/BulletSoftBody/btSoftBody.h
+++ b/src/BulletSoftBody/btSoftBody.h
@@ -1317,8 +1317,8 @@ public:
 		}
 		for (int k = 0; k < m_faceNodeContacts.size(); ++k)
 		{
-			int i = indices[k];
-			btSoftBody::DeformableFaceNodeContact& c = m_faceNodeContacts[i];
+			int idx = indices[k];
+			btSoftBody::DeformableFaceNodeContact& c = m_faceNodeContacts[idx];
 			btSoftBody::Node* node = c.m_node;
 			btSoftBody::Face* face = c.m_face;
 			const btVector3& w = c.m_bary;


### PR DESCRIPTION
Solves the following warning seen in Godot compiling with `-Wextra -Wshadow-local`.

```
thirdparty/bullet/BulletSoftBody/btSoftBody.h: In member function 'void btSoftBody::applyRepulsionForce(btScalar, bool)':
thirdparty/bullet/BulletSoftBody/btSoftBody.h:1344:34: warning: declaration of 'i' shadows a previous local [-Wshadow=compatible-local]
 1344 |                         for (int i = 0; i < 3; ++i)
      |                                  ^
thirdparty/bullet/BulletSoftBody/btSoftBody.h:1320:29: note: shadowed declaration is here
 1320 |                         int i = indices[k];
      |                             ^
```