### PR TITLE
Explicitly state the datatypes in creating action/obs spaces

### DIFF
--- a/examples/pybullet/gym/pybullet_envs/robot_bases.py
+++ b/examples/pybullet/gym/pybullet_envs/robot_bases.py
@@ -22,10 +22,10 @@ class XmlBasedRobot:
     self.ordered_joints = None
     self.robot_body = None
 
-    high = np.ones([action_dim])
-    self.action_space = gym.spaces.Box(-high, high)
-    high = np.inf * np.ones([obs_dim])
-    self.observation_space = gym.spaces.Box(-high, high)
+    high = np.ones([action_dim], dtype=np.float32)
+    self.action_space = gym.spaces.Box(-high, high, dtype=np.float32)
+    high = np.inf * np.ones([obs_dim], dtype=np.float32)
+    self.observation_space = gym.spaces.Box(-high, high, dtype=np.float32)
 
     #self.model_xml = model_xml
     self.robot_name = robot_name


### PR DESCRIPTION
This should get rid of the annoying warnings that pop up whenever an environment is created. Numpy's default datatype is float64, gym's is float32, the env is actually float32, but the initialization doesn't make it explicit so it causes redundant warnings.
```
/path/lib/python3.9/site-packages/gym/logger.py:34: UserWarning: WARN: Box bound precision lowered by casting to float32 warnings.warn(colorize("%s: %s" % ("WARN", msg % args), "yellow"))
```