### PR TITLE
Fix crash due to stale manifolds when using multi-threaded dispatcher

### DIFF
--- a/src/BulletCollision/CollisionDispatch/btCollisionDispatcherMt.h
+++ b/src/BulletCollision/CollisionDispatch/btCollisionDispatcherMt.h
@@ -31,6 +31,8 @@ public:
 
 protected:
 	btAlignedObjectArray<btAlignedObjectArray<btPersistentManifold*> > m_batchManifoldsPtr;
+	btAlignedObjectArray<btAlignedObjectArray<btPersistentManifold*> > m_batchReleaseManifoldsPtr;
+
 	bool m_batchUpdating;
 	int m_grainSize;
 };


### PR DESCRIPTION
This fixes a crash in btSimulationIslandManagerMt::addManifoldsToIslands that was introduced in #2558. As manifolds aren't removed if a manifold is released while batch updating, this would cause stale entries if this happened. The following is what seems to lead to the crash:

1. A manifold is removed while batch updating is in progress (in my case this sometimes happened from btKinematicCharacterController::recoverFromPenetration)
2. A stale entry remains in the m_manifoldsPtr array
3. The pool allocator reuses the address for a new manifold
4. The m_manifoldsPtr array now has duplicate entries
5. A manifold gets removed because an object is removed from the world
6. The stale leftover entry still references this removed object
7. addManifoldsToIslands attempts to retrieve the island of this object
8. Crash as this island does not exist anymore

This commit fixes the crash by not destroying manifolds while batch updating, but postponing that until after the batch update.

If necessary I can attempt to reproduce the issue in an example.