### PR TITLE
Fixing pybullet example on getting a point cloud

### DIFF
--- a/examples/pybullet/examples/getCameraImageTest.py
+++ b/examples/pybullet/examples/getCameraImageTest.py
@@ -31,6 +31,7 @@ images = p.getCameraImage(width,
                           projection_matrix,
                           shadow=True,
                           renderer=p.ER_BULLET_HARDWARE_OPENGL)
+# NOTE: the ordering of height and width change based on the conversion
 rgb_opengl = np.reshape(images[2], (height, width, 4)) * 1. / 255.
 depth_buffer_opengl = np.reshape(images[3], [width, height])
 depth_opengl = far * near / (far - (far - near) * depth_buffer_opengl)

--- a/examples/pybullet/examples/pointCloudFromCameraImage.py
+++ b/examples/pybullet/examples/pointCloudFromCameraImage.py
@@ -72,8 +72,8 @@ imgW = int(width / 10)
 imgH = int(height / 10)
 
 img = p.getCameraImage(imgW, imgH, renderer=p.ER_BULLET_HARDWARE_OPENGL)
-rgbBuffer = img[2]
-depthBuffer = img[3]
+rgbBuffer = np.reshape(img[2], (imgH, imgW, 4))
+depthBuffer = np.reshape(img[3], [imgW, imgH])
 print("rgbBuffer.shape=", rgbBuffer.shape)
 print("depthBuffer.shape=", depthBuffer.shape)
 

--- a/examples/pybullet/examples/pointCloudFromCameraImage.py
+++ b/examples/pybullet/examples/pointCloudFromCameraImage.py
@@ -73,7 +73,7 @@ imgH = int(height / 10)
 
 img = p.getCameraImage(imgW, imgH, renderer=p.ER_BULLET_HARDWARE_OPENGL)
 rgbBuffer = np.reshape(img[2], (imgH, imgW, 4))
-# Note: this depth buffer's reshaping does not match the [w, h] convention for
+# NOTE: this depth buffer's reshaping does not match the [w, h] convention for
 # OpenGL depth buffers.  See getCameraImageTest.py for an OpenGL depth buffer
 depthBuffer = np.reshape(img[3], [imgH, imgW])
 print("rgbBuffer.shape=", rgbBuffer.shape)

--- a/examples/pybullet/examples/pointCloudFromCameraImage.py
+++ b/examples/pybullet/examples/pointCloudFromCameraImage.py
@@ -73,7 +73,9 @@ imgH = int(height / 10)
 
 img = p.getCameraImage(imgW, imgH, renderer=p.ER_BULLET_HARDWARE_OPENGL)
 rgbBuffer = np.reshape(img[2], (imgH, imgW, 4))
-depthBuffer = np.reshape(img[3], [imgW, imgH])
+# Note: this depth buffer's reshaping does not match the [w, h] convention for
+# OpenGL depth buffers.  See getCameraImageTest.py for an OpenGL depth buffer
+depthBuffer = np.reshape(img[3], [imgH, imgW])
 print("rgbBuffer.shape=", rgbBuffer.shape)
 print("depthBuffer.shape=", depthBuffer.shape)
 


### PR DESCRIPTION
I am a newcomer to `bullet` and will be using it + Python to sample point clouds.

This PR resolves https://github.com/bulletphysics/bullet3/issues/4115.

After acquiring images via `getCameraImage`, sometimes the images are reshaped based on `w x h`, and other times based on `h x w`.  Understanding which to use, and when, is something I've found confusing.  So, I also added comments to two of the Python starter files, providing more information.