### PR TITLE
Add explicit int cast to avoid conversion warning

### DIFF
--- a/src/LinearMath/btSerializer.h
+++ b/src/LinearMath/btSerializer.h
@@ -512,7 +512,7 @@ public:
 			currentPtr += BT_HEADER_LENGTH;
 			for (int i = 0; i < m_chunkPtrs.size(); i++)
 			{
-				int curLength = sizeof(btChunk) + m_chunkPtrs[i]->m_length;
+				int curLength = (int)sizeof(btChunk) + m_chunkPtrs[i]->m_length;
 				memcpy(currentPtr, m_chunkPtrs[i], curLength);
 				btAlignedFree(m_chunkPtrs[i]);
 				currentPtr += curLength;


### PR DESCRIPTION
On some platforms (e.g. e2k) size_t is declared as unsigned long, and this triggers spurious
Wconversion warnings in expressions using sizeof operator.
To supress this warning, add explicit cast of sizeof output to int. This is safe, since 
sizeof(btChunk) is very small compared to max value of int.