### PR TITLE
Fix compile on windows 64 bit arm architecture

### DIFF
--- a/src/LinearMath/btScalar.h
+++ b/src/LinearMath/btScalar.h
@@ -107,7 +107,7 @@ inline int btIsDoublePrecision()
  			#define btFsel(a,b,c) __fsel((a),(b),(c))
 		#else
 
-#if defined (_M_ARM)
+#if defined (_M_ARM) || defined (_M_ARM64)
             //Do not turn SSE on for ARM (may want to turn on BT_USE_NEON however)
 #elif (defined (_WIN32) && (_MSC_VER) && _MSC_VER >= 1400) && (!defined (BT_USE_DOUBLE_PRECISION))
 


### PR DESCRIPTION
When building 64 bit arm with visual studio, btScalar will try to include SSE headers meant for x86 and x64 architectures.
This gives the following error in many source files:
```
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.31.31103\include\emmintrin.h(20): fatal error C1189: #error:  This header is specific to X86 and X64 targets
```