### PR TITLE
UWP: Fix potentially uninitialized local pointer variable error

### DIFF
--- a/src/BulletSoftBody/btSoftBody.cpp
+++ b/src/BulletSoftBody/btSoftBody.cpp
@@ -3897,7 +3897,7 @@ void btSoftBody::PSolve_RContacts(btSoftBody* psb, btScalar kst, btScalar ti)
 			btVector3 va(0, 0, 0);
 			btRigidBody* rigidCol = 0;
 			btMultiBodyLinkCollider* multibodyLinkCol = 0;
-			btScalar* deltaV;
+			btScalar* deltaV = NULL;
 
 			if (cti.m_colObj->getInternalType() == btCollisionObject::CO_RIGID_BODY)
 			{


### PR DESCRIPTION
When compiling uwp such as with vcpkg you get the following error:
```
     8>D:\buildtrees\bullet3\src\3.17-e90f5ef08b.clean\src\BulletSoftBody\btSoftBody.cpp(3933): error C4703: potentially uninitialized local pointer variable 'deltaV' used [D:\buildtrees\bullet3\arm-uwp-dbg\src\BulletSoftBody\BulletSoftBody.vcxproj]
```

Seems like the compiler is not resolving that both cases of the following are identical:
```
if (cti.m_colObj->getInternalType() == btCollisionObject::CO_FEATHERSTONE_LINK)
{
    if (multibodyLinkCol)
    {
    }
}
```