### PR TITLE
Intermittent alignment issues fix

### DIFF
--- a/src/LinearMath/btTransform.h
+++ b/src/LinearMath/btTransform.h
@@ -34,6 +34,7 @@ btTransform
 	btVector3 m_origin;
 
 public:
+	BT_DECLARE_ALIGNED_ALLOCATOR();
 	/**@brief No initialization constructor */
 	btTransform() {}
 	/**@brief Constructor from btQuaternion (optional btVector3 )


### PR DESCRIPTION
Not sure if `BT_DECLARE_ALIGNED_ALLOCATOR` is omitted at purpose in this file, but adding it like in most aligned classes/structs fixes some intermittent problems with alignment when reassigning transforms with new values. This is happening when building with SIMD support in Emscripten. There's also one `BT_DECLARE_ALIGNED_ALLOCATOR` missing in `btMatrix3x3.h` but with the fix above it doesn't seem to be necessary.