### PR TITLE
Add b3RobotSimulatorClientAPI to BulletRoboticsGUI

### DIFF
--- a/Extras/BulletRoboticsGUI/CMakeLists.txt
+++ b/Extras/BulletRoboticsGUI/CMakeLists.txt
@@ -91,6 +91,8 @@ SET(BulletRoboticsGUI_INCLUDES
   ../../examples/MultiThreading/b3PosixThreadSupport.h
   ../../examples/MultiThreading/b3Win32ThreadSupport.h
   ../../examples/MultiThreading/b3ThreadSupportInterface.h
+
+  ../../examples/RobotSimulator/b3RobotSimulatorClientAPI.h
 )
 
 SET(BulletRoboticsGUI_SRCS ${BulletRoboticsGUI_INCLUDES}
@@ -107,6 +109,7 @@ SET(BulletRoboticsGUI_SRCS ${BulletRoboticsGUI_INCLUDES}
 	../../examples/SharedMemory/PhysicsServerExample.cpp
 	../../examples/SharedMemory/PhysicsServerExampleBullet2.cpp
 	../../examples/SharedMemory/SharedMemoryInProcessPhysicsC_API.cpp		
+    ../../examples/RobotSimulator/b3RobotSimulatorClientAPI.cpp
 )
 
 IF(BUILD_CLSOCKET)


### PR DESCRIPTION
The RobotSimulatorClientAPI is great and the closest thing to PyBullet when switching to C++.

I could not include/link `b3RobotSimulatorClientAPI` from any of the pkg-config files installed by CMake/make (`bullet.pc`, `bullet_robotics.pc`, `bullet_robotics_gui.pc`) so the proposal here is to add it to `BulletRoboticsGUI`.

The client code can then happily include:

```c++
#include "RobotSimulator/b3RobotSimulatorClientAPI.h"
```