### PR TITLE
Allow delivered classes to access unscaled points

### DIFF
--- a/src/BulletCollision/CollisionShapes/btConvexHullShape.h
+++ b/src/BulletCollision/CollisionShapes/btConvexHullShape.h
@@ -25,6 +25,7 @@ subject to the following restrictions:
 ATTRIBUTE_ALIGNED16(class)
 btConvexHullShape : public btPolyhedralConvexAabbCachingShape
 {
+protected:
 	btAlignedObjectArray<btVector3> m_unscaledPoints;
 
 public:


### PR DESCRIPTION
As in title, someone might want to do custom actions on points what currently is not possible.