### PR TITLE
change AABB and textureScaling on heightfield replacement

### DIFF
--- a/examples/SharedMemory/PhysicsServerCommandProcessor.cpp
+++ b/examples/SharedMemory/PhysicsServerCommandProcessor.cpp
@@ -5010,6 +5010,8 @@ bool PhysicsServerCommandProcessor::processCreateCollisionShapeCommand(const str
 							{
 								heightfieldDest[i] = datafl[i];
 							}
+							terrainShape->reinitialize(width, height, minHeight, maxHeight);
+
 							//update graphics
 
 							btAlignedObjectArray<GLInstanceVertex> gfxVertices;
@@ -5023,6 +5025,8 @@ bool PhysicsServerCommandProcessor::processCreateCollisionShapeCommand(const str
 							MyTriangleCollector4 col(aabbMin, aabbMax);
 							col.m_pVerticesOut = &gfxVertices;
 							col.m_pIndicesOut = &indices;
+							double textureScaling = clientCmd.m_createUserShapeArgs.m_shapes[i].m_heightfieldTextureScaling;
+							col.m_textureScaling = textureScaling;
 							
 							terrainShape->processAllTriangles(&col, aabbMin, aabbMax);
 							if (gfxVertices.size() && indices.size())

--- a/src/BulletCollision/CollisionShapes/btHeightfieldTerrainShape.cpp
+++ b/src/BulletCollision/CollisionShapes/btHeightfieldTerrainShape.cpp
@@ -95,6 +95,46 @@ btHeightfieldTerrainShape::btHeightfieldTerrainShape(int heightStickWidth, int h
 			   flipQuadEdges);
 }
 
+void btHeightfieldTerrainShape::reinitialize(
+	int heightStickWidth, int heightStickLength,
+	btScalar minHeight, btScalar maxHeight)
+{
+	btScalar heightScale = maxHeight / 65535;
+	m_minHeight = minHeight;
+	m_maxHeight = maxHeight;
+	// determine min/max axis-aligned bounding box (aabb) values
+	switch (m_upAxis)
+	{
+		case 0:
+		{
+			m_localAabbMin.setValue(m_minHeight, 0, 0);
+			m_localAabbMax.setValue(m_maxHeight, m_width, m_length);
+			break;
+		}
+		case 1:
+		{
+			m_localAabbMin.setValue(0, m_minHeight, 0);
+			m_localAabbMax.setValue(m_width, m_maxHeight, m_length);
+			break;
+		};
+		case 2:
+		{
+			m_localAabbMin.setValue(0, 0, m_minHeight);
+			m_localAabbMax.setValue(m_width, m_length, m_maxHeight);
+			break;
+		}
+		default:
+		{
+			//need to get valid m_upAxis
+			btAssert(0);  // && "Bad m_upAxis");
+		}
+	}
+
+	// remember origin (defined as exact middle of aabb)
+	m_localOrigin = btScalar(0.5) * (m_localAabbMin + m_localAabbMax);
+}
+
+
 void btHeightfieldTerrainShape::initialize(
 	int heightStickWidth, int heightStickLength, const void* heightfieldData,
 	btScalar heightScale, btScalar minHeight, btScalar maxHeight, int upAxis,

--- a/src/BulletCollision/CollisionShapes/btHeightfieldTerrainShape.h
+++ b/src/BulletCollision/CollisionShapes/btHeightfieldTerrainShape.h
@@ -142,6 +142,10 @@ protected:
 public:
 	BT_DECLARE_ALIGNED_ALLOCATOR();
 
+	void reinitialize(
+		int heightStickWidth, int heightStickLength,
+		btScalar minHeight, btScalar maxHeight);
+
 	/// preferred constructors
 	btHeightfieldTerrainShape(
 		int heightStickWidth, int heightStickLength,


### PR DESCRIPTION
See [Heightfield replacement may cause wrong collision detection](https://github.com/bulletphysics/bullet3/issues/4236)
If the AABB of relative body is not changed during heightfield replacement, it will cause collision detection and rendering failure. 
Additionally, I changed the textureScaling of the replaced heightfield to the request input, instead of the default 1.