### PR TITLE
Fix `-Wunused-but-set-variable` in debug code

### DIFF
--- a/src/BulletSoftBody/btSparseSDF.h
+++ b/src/BulletSoftBody/btSparseSDF.h
@@ -233,9 +233,9 @@ struct btSparseSdf
 			//int sz = sizeof(Cell);
 			if (ncells > m_clampCells)
 			{
-				static int numResets = 0;
-				numResets++;
-				//				printf("numResets=%d\n",numResets);
+				//static int numResets = 0;
+				//numResets++;
+				//printf("numResets=%d\n",numResets);
 				Reset();
 			}
 


### PR DESCRIPTION
Another option is to delete this debug code, I can amend the PR if that's what you prefer.

Warning raised by Clang in optimized builds (actually Emscripten which is based on LLVM).