### PR TITLE
Initialize user_ptr in function CreateMultiBodyTree.

### DIFF
--- a/Extras/InverseDynamics/MultiBodyTreeCreator.cpp
+++ b/Extras/InverseDynamics/MultiBodyTreeCreator.cpp
@@ -14,7 +14,7 @@ MultiBodyTree* CreateMultiBodyTree(const MultiBodyTreeCreator& creator)
 	vec3 body_r_body_com;
 	mat33 body_I_body;
 	int user_int;
-	void* user_ptr;
+	void* user_ptr = nullptr;
 
 	MultiBodyTree* tree = new MultiBodyTree();
 	if (0x0 == tree)


### PR DESCRIPTION
When this method is overloaded, some implementors forget to initialize user_ptr and it is used in this uninitialized state.  This was found using clang memory sanitizer.