### PR TITLE
fix(ppc64): don't include altivec headers on ppc64

### DIFF
--- a/src/clew/clew.h
+++ b/src/clew/clew.h
@@ -319,14 +319,24 @@ float nanf(const char *);
 
 /* Define basic vector types */
 #if defined(__VEC__)
-#include <altivec.h> /* may be omitted depending on compiler. AltiVec spec provides no way to detect whether the header is required. */
-	typedef vector unsigned char __cl_uchar16;
-	typedef vector signed char __cl_char16;
-	typedef vector unsigned short __cl_ushort8;
-	typedef vector signed short __cl_short8;
-	typedef vector unsigned int __cl_uint4;
-	typedef vector signed int __cl_int4;
-	typedef vector float __cl_float4;
+   #if defined(__powerpc__)
+       typedef __vector unsigned char     __cl_uchar16;
+       typedef __vector signed char       __cl_char16;
+       typedef __vector unsigned short    __cl_ushort8;
+       typedef __vector signed short      __cl_short8;
+       typedef __vector unsigned int      __cl_uint4;
+       typedef __vector signed int        __cl_int4;
+       typedef __vector float             __cl_float4;
+   #else
+       #include <altivec.h>   /* may be omitted depending on compiler. AltiVec spec provides no way to detect whether the header is required. */
+       typedef vector unsigned char     __cl_uchar16;
+       typedef vector signed char       __cl_char16;
+       typedef vector unsigned short    __cl_ushort8;
+       typedef vector signed short      __cl_short8;
+       typedef vector unsigned int      __cl_uint4;
+       typedef vector signed int        __cl_int4;
+       typedef vector float             __cl_float4;
+   #endif
 #define __CL_UCHAR16__ 1
 #define __CL_CHAR16__ 1
 #define __CL_USHORT8__ 1


### PR DESCRIPTION
I've crafted a small patch which I carry in my portage tree since several releases in order to make bullet compile on ppc64le.

I'd like to get it merged.