### PR TITLE
Issues with GImpact contact test

### DIFF
--- a/src/BulletCollision/Gimpact/btClipPolygon.h
+++ b/src/BulletCollision/Gimpact/btClipPolygon.h
@@ -111,6 +111,40 @@ SIMD_FORCE_INLINE int bt_plane_clip_polygon(
 	return clipped_count;
 }
 
+//! Check if plane does cut/touch polygon
+/*!
+*\param points must at least have one entry
+*\return if plane does cut plane
+*/
+SIMD_FORCE_INLINE bool bt_plane_cuts_polygone(
+	const btVector4 &plane,
+	btScalar margin,
+	int point_count,
+	const btVector3 *points)
+{ 
+	btScalar lastDist = bt_distance_point_plane(plane, points[0]);
+	//touch the plane
+	if (lastDist < margin + SIMD_EPSILON && -margin - SIMD_EPSILON < lastDist)
+		return true;
+
+	for (int _k = 1; _k < point_count; ++_k)
+	{
+		btScalar dist = bt_distance_point_plane(plane, points[_k]);
+		
+		//touch the plane
+		if (dist < margin + SIMD_EPSILON && -margin - SIMD_EPSILON < dist)
+			return true;
+
+		// different sign
+		if (dist * lastDist < 0)
+			return true;
+
+		lastDist = dist;
+	}
+
+	return false;
+}
+
 //! Clips a polygon by a plane
 /*!
 *\param clipped must be an array of 16 points.

--- a/src/BulletCollision/Gimpact/btTriangleShapeEx.cpp
+++ b/src/BulletCollision/Gimpact/btTriangleShapeEx.cpp
@@ -80,7 +80,6 @@ bool btPrimitiveTriangle::overlap_test_conservative(const btPrimitiveTriangle& o
 	dis2 = bt_distance_point_plane(other.m_plane, m_vertices[2]) - total_margin;
 
 	if (dis0 > 0.0f && dis1 > 0.0f && dis2 > 0.0f) return false;
-
 	return true;
 }
 
@@ -137,6 +136,11 @@ bool btPrimitiveTriangle::find_triangle_collision_clip_method(btPrimitiveTriangl
 		return false;  //Reject
 	}
 
+	if (!bt_plane_cuts_polygone(m_plane, margin, clipped_count, clipped_points))
+	{
+		return false; //Reject
+	}
+
 	//find most deep interval face1
 	contacts1.merge_points(contacts1.m_separating_normal, margin, clipped_points, clipped_count);
 	if (contacts1.m_point_count == 0) return false;  // too far
@@ -152,6 +156,11 @@ bool btPrimitiveTriangle::find_triangle_collision_clip_method(btPrimitiveTriangl
 	if (clipped_count == 0)
 	{
 		return false;  //Reject
+	}
+
+	if (!bt_plane_cuts_polygone(m_plane, margin, clipped_count, clipped_points))
+	{
+		return false; //Reject
 	}
 
 	//find most deep interval face1


### PR DESCRIPTION
Hi,

this is a fix for the [issue](https://github.com/bulletphysics/bullet3/issues/4318).
It fix wrongly reported contact for gimpact vs gimpact collision if triangles lay behind each other and within their aabb.

It ensures that only triangle that intersect are reported as contact points.