### PR TITLE
Update btSoftBody to handle close to degenerate triangles.

### DIFF
--- a/src/BulletSoftBody/btSoftBody.cpp
+++ b/src/BulletSoftBody/btSoftBody.cpp
@@ -2827,8 +2827,6 @@ static void getBarycentric(const btVector3& p, const btVector3& a, const btVecto
 		bary.setY((d11 * d20 - d01 * d21) / denom);
 		bary.setZ((d00 * d21 - d01 * d20) / denom);
   	}
-	bary.setY((d11 * d20 - d01 * d21) / denom);
-	bary.setZ((d00 * d21 - d01 * d20) / denom);
 	bary.setX(btScalar(1) - bary.getY() - bary.getZ());
 }
 

--- a/src/BulletSoftBody/btSoftBody.cpp
+++ b/src/BulletSoftBody/btSoftBody.cpp
@@ -2807,7 +2807,7 @@ bool btSoftBody::checkDeformableContact(const btCollisionObjectWrapper* colObjWr
 //
 // Compute barycentric coordinates (u, v, w) for
 // point p with respect to triangle (a, b, c)
-static void getBarycentric(const btVector3& p, btVector3& a, btVector3& b, btVector3& c, btVector3& bary)
+static void getBarycentric(const btVector3& p, const btVector3& a, const btVector3& b, const btVector3& c, btVector3& bary)
 {
 	btVector3 v0 = b - a, v1 = c - a, v2 = p - a;
 	btScalar d00 = v0.dot(v0);
@@ -2816,6 +2816,7 @@ static void getBarycentric(const btVector3& p, btVector3& a, btVector3& b, btVec
 	btScalar d20 = v2.dot(v0);
 	btScalar d21 = v2.dot(v1);
 	btScalar denom = d00 * d11 - d01 * d01;
+	// In the case of a degenerate triangle, pick a vertex.
 	if (denom == btScalar(0.0)) 
 	{
 		bary.setY(btScalar(0.0));

--- a/src/BulletSoftBody/btSoftBody.cpp
+++ b/src/BulletSoftBody/btSoftBody.cpp
@@ -2817,7 +2817,7 @@ static void getBarycentric(const btVector3& p, const btVector3& a, const btVecto
 	btScalar d21 = v2.dot(v1);
 	btScalar denom = d00 * d11 - d01 * d01;
 	// In the case of a degenerate triangle, pick a vertex.
-	if (denom == btScalar(0.0)) 
+	if (btFabs(denom) < SIMD_EPSILON) 
 	{
 		bary.setY(btScalar(0.0));
 		bary.setZ(btScalar(0.0));

--- a/src/BulletSoftBody/btSoftBody.cpp
+++ b/src/BulletSoftBody/btSoftBody.cpp
@@ -2816,6 +2816,16 @@ static void getBarycentric(const btVector3& p, btVector3& a, btVector3& b, btVec
 	btScalar d20 = v2.dot(v0);
 	btScalar d21 = v2.dot(v1);
 	btScalar denom = d00 * d11 - d01 * d01;
+	if (denom == btScalar(0.0)) 
+	{
+		bary.setY(btScalar(0.0));
+		bary.setZ(btScalar(0.0));
+	} 
+	else 
+	{
+		bary.setY((d11 * d20 - d01 * d21) / denom);
+		bary.setZ((d00 * d21 - d01 * d20) / denom);
+  	}
 	bary.setY((d11 * d20 - d01 * d21) / denom);
 	bary.setZ((d00 * d21 - d01 * d20) / denom);
 	bary.setX(btScalar(1) - bary.getY() - bary.getZ());


### PR DESCRIPTION
In the case of deformable objects, the triangles in the mesh can get very close to degenerate, which can lead to division by zero and NaN propagating through the system. In this case if it's close to degenerate and going to result in NaN, it uses a vertex. 