### PR TITLE
Fix registration of gym envs

### DIFF
--- a/examples/pybullet/gym/pybullet_envs/__init__.py
+++ b/examples/pybullet/gym/pybullet_envs/__init__.py
@@ -1,13 +1,5 @@
 import gym
-from gym.envs.registration import registry, make, spec
-
-
-def register(id, *args, **kvargs):
-  if id in registry.env_specs:
-    return
-  else:
-    return gym.envs.registration.register(id, *args, **kvargs)
-
+from gym.envs.registration import registry, make, spec, register
 
 # ------------bullet-------------
 


### PR DESCRIPTION
The piece of code that checks for name collisions is redundant, as this logic is already present in gym. Fixing this will make it possible to use pybullet with the upcoming 0.26 release of gym as well as previous versions.