### PR TITLE
fix(ppc): rename altivec vector keywords

### DIFF
--- a/src/clew/clew.h
+++ b/src/clew/clew.h
@@ -320,13 +320,13 @@ float nanf(const char *);
 /* Define basic vector types */
 #if defined(__VEC__)
 #include <altivec.h> /* may be omitted depending on compiler. AltiVec spec provides no way to detect whether the header is required. */
-	typedef vector unsigned char __cl_uchar16;
-	typedef vector signed char __cl_char16;
-	typedef vector unsigned short __cl_ushort8;
-	typedef vector signed short __cl_short8;
-	typedef vector unsigned int __cl_uint4;
-	typedef vector signed int __cl_int4;
-	typedef vector float __cl_float4;
+       typedef __vector unsigned char     __cl_uchar16;
+       typedef __vector signed char       __cl_char16;
+       typedef __vector unsigned short    __cl_ushort8;
+       typedef __vector signed short      __cl_short8;
+       typedef __vector unsigned int      __cl_uint4;
+       typedef __vector signed int        __cl_int4;
+       typedef __vector float             __cl_float4;
 #define __CL_UCHAR16__ 1
 #define __CL_CHAR16__ 1
 #define __CL_USHORT8__ 1


### PR DESCRIPTION
Altivec vectors can be defined with either the "vector" keyword or the "__vector" type. In general "__vector" should be prefered for include files, as otherwise it might conflicts with other type define in the source code (define a vector class in C++ is quite common). This causes bullet to fail to build on powerpc if the code is compiled with -maltivec, or by default on ppc64el which always has altivec enabled.
See also: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=760310