### PR TITLE
Added fix for deleting debug points with life time.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ p.connect(p.SHARED_MEMORY) #or (p.TCP, "localhost", 6667) or (p.UDP, "192.168.86
 
 **Linux and Mac OSX gnu make**
 
-Make sure cmake is installed (sudo apt-get install cmake, brew install cmake, or https://cmake.org)
+Make sure gcc and cmake is installed (`sudo apt-get install build-essential` and `sudo apt-get install cmake` for Linux, `brew install cmake` for Mac, or https://cmake.org)
 
 In a terminal type:
 ```

--- a/examples/SharedMemory/PhysicsServerExample.cpp
+++ b/examples/SharedMemory/PhysicsServerExample.cpp
@@ -2799,6 +2799,20 @@ void PhysicsServerExample::stepSimulation(float deltaTime)
 			}
 		}
 	}
+
+	for (int i = m_multiThreadedHelper->m_userDebugPoints.size() - 1; i >= 0; i--)
+	{
+		if (m_multiThreadedHelper->m_userDebugPoints[i].m_lifeTime)
+		{
+			m_multiThreadedHelper->m_userDebugPoints[i].m_lifeTime -= deltaTime;
+			if (m_multiThreadedHelper->m_userDebugPoints[i].m_lifeTime <= 0)
+			{
+				m_multiThreadedHelper->m_userDebugPoints.swap(i, m_multiThreadedHelper->m_userDebugPoints.size() - 1);
+				m_multiThreadedHelper->m_userDebugPoints.pop_back();
+			}
+		}
+	}
+
 	updateGraphics();
 
 


### PR DESCRIPTION
Debug points weren't deleted with having life time.

The issue was shown in the following issue, providing a video and an example.
https://github.com/bulletphysics/bullet3/issues/4372

The problem is solved with this pull request.