### PR TITLE
Added warning Buffer Limit

### DIFF
--- a/examples/OpenGLWindow/GLInstancingRenderer.cpp
+++ b/examples/OpenGLWindow/GLInstancingRenderer.cpp
@@ -1192,6 +1192,7 @@ int GLInstancingRenderer::registerShape(const float* vertices, int numvertices, 
 	b3Assert(totalUsed < m_data->m_maxShapeCapacityInBytes);
 	if (totalUsed >= m_data->m_maxShapeCapacityInBytes)
 	{
+		b3Warning("Can't register shape, Buffer Limit Exceeded");
 		return -1;
 	}
 


### PR DESCRIPTION
For addressing situations like [Issue #4386](https://github.com/bulletphysics/bullet3/issues/4386).

I am working on a fix in removeGraphicsInstance behaviour but I think I should modify OpenGL buffers also for not producing breaking changes, I can commit the solution I have until now and have some feedback from @erwincoumans 