### PR TITLE
performance update for direct and egl plugin

### DIFF
--- a/examples/SharedMemory/PhysicsDirect.cpp
+++ b/examples/SharedMemory/PhysicsDirect.cpp
@@ -569,6 +569,7 @@ bool PhysicsDirect::processCamera(const struct SharedMemoryCommand& orgCommand)
 
 			//  printf("pixel = %d\n", rgbaPixelsReceived[0]);
 
+#if 0
 			for (int i = 0; i < serverCmd.m_sendPixelDataArguments.m_numPixelsCopied; i++)
 			{
 				m_data->m_cachedCameraDepthBuffer[i + serverCmd.m_sendPixelDataArguments.m_startingPixelIndex] = depthBuffer[i];
@@ -581,7 +582,11 @@ bool PhysicsDirect::processCamera(const struct SharedMemoryCommand& orgCommand)
 			{
 				m_data->m_cachedCameraPixelsRGBA[i + serverCmd.m_sendPixelDataArguments.m_startingPixelIndex * numBytesPerPixel] = rgbaPixelsReceived[i];
 			}
-
+#else
+ 			memcpy(&m_data->m_cachedCameraDepthBuffer[serverCmd.m_sendPixelDataArguments.m_startingPixelIndex],depthBuffer,serverCmd.m_sendPixelDataArguments.m_numPixelsCopied*sizeof(float));
+			memcpy(&m_data->m_cachedSegmentationMask[serverCmd.m_sendPixelDataArguments.m_startingPixelIndex],segmentationMaskBuffer,serverCmd.m_sendPixelDataArguments.m_numPixelsCopied*sizeof(int));
+			memcpy(&m_data->m_cachedCameraPixelsRGBA[serverCmd.m_sendPixelDataArguments.m_startingPixelIndex * numBytesPerPixel],rgbaPixelsReceived,serverCmd.m_sendPixelDataArguments.m_numPixelsCopied * numBytesPerPixel);
+#endif
 			if (serverCmd.m_sendPixelDataArguments.m_numRemainingPixels > 0 && serverCmd.m_sendPixelDataArguments.m_numPixelsCopied)
 			{
 				m_data->m_hasStatus = false;

--- a/examples/SharedMemory/plugins/eglPlugin/eglRendererVisualShapeConverter.cpp
+++ b/examples/SharedMemory/plugins/eglPlugin/eglRendererVisualShapeConverter.cpp
@@ -1617,12 +1617,12 @@ void EGLRendererVisualShapeConverter::copyCameraImageDataGL(
 					BT_PROFILE("resize and flip");
 					for (int j = 0; j < *heightPtr; j++)
 					{
+						int yIndex = int(float(*heightPtr - 1 - j) * (float(sourceHeight) / float(*heightPtr)));
+						btClamp(yIndex, 0, sourceHeight);
 						for (int i = 0; i < *widthPtr; i++)
 						{
 							int xIndex = int(float(i) * (float(sourceWidth) / float(*widthPtr)));
-							int yIndex = int(float(*heightPtr - 1 - j) * (float(sourceHeight) / float(*heightPtr)));
 							btClamp(xIndex, 0, sourceWidth);
-							btClamp(yIndex, 0, sourceHeight);
 							int bytesPerPixel = 4;  //RGBA
 
 							int sourcePixelIndex = (xIndex + yIndex * sourceWidth) * bytesPerPixel;
@@ -1686,12 +1686,12 @@ void EGLRendererVisualShapeConverter::copyCameraImageDataGL(
 					BT_PROFILE("resize and flip");
 					for (int j = 0; j < destinationHeight; j++)
 					{
+						int yIndex = int(float(destinationHeight - 1 - j) * (float(sourceHeight) / float(destinationHeight)));
+						btClamp(yIndex, 0, sourceHeight);
 						for (int i = 0; i < destinationWidth; i++)
 						{
 							int xIndex = int(float(i) * (float(sourceWidth) / float(destinationWidth)));
-							int yIndex = int(float(destinationHeight - 1 - j) * (float(sourceHeight) / float(destinationHeight)));
 							btClamp(xIndex, 0, sourceWidth);
-							btClamp(yIndex, 0, sourceHeight);
 							int bytesPerPixel = 4;  //RGBA
 							int sourcePixelIndex = (xIndex + yIndex * sourceWidth) * bytesPerPixel;
 							int sourceDepthIndex = xIndex + yIndex * sourceWidth;


### PR DESCRIPTION
I added some small changes to increase performance.
It is most significant when using relatively large images.
On my machine rendering 12M pixels images (by modifying  eglRenderTest.py example image size) I was able to reduce run time from 200 msec per frame to ~140msec per frame.