### PR TITLE
Fix a bug related to the law of action and reaction in btGeneric6DofSpring2Constraint.

### DIFF
--- a/src/BulletDynamics/ConstraintSolver/btGeneric6DofSpring2Constraint.cpp
+++ b/src/BulletDynamics/ConstraintSolver/btGeneric6DofSpring2Constraint.cpp
@@ -653,7 +653,7 @@ void btGeneric6DofSpring2Constraint::calculateJacobi(btRotationalLimitMotor2* li
 		// get vector from bodyB to frameB in WCS
 		relB = m_calculatedTransformB.getOrigin() - transB.getOrigin();
 		// same for bodyA
-		relA = m_calculatedTransformA.getOrigin() - transA.getOrigin();
+		relA = m_calculatedTransformB.getOrigin() - transA.getOrigin();
 		tmpA = relA.cross(ax1);
 		tmpB = relB.cross(ax1);
 		if (m_hasStaticBody && (!rotAllowed))


### PR DESCRIPTION
The relA and relB in calculateJacobi() are vectors used to calculate the torque that the linearAxis applies to the bodies.
Therefore, relA and relB should point to the same coordinate, but they were pointing to the connection points of bodyA and bodyB respectively.
This caused a bug where the positions where the action and reaction forces were applied were shifted when the relative positions of the bodies changed.

To fix this, relA was corrected to point to the connection point of bodyB.