### PR TITLE
Fix NaN due to division by zero

### DIFF
--- a/src/BulletDynamics/ConstraintSolver/btSequentialImpulseConstraintSolver.cpp
+++ b/src/BulletDynamics/ConstraintSolver/btSequentialImpulseConstraintSolver.cpp
@@ -658,7 +658,7 @@ void btSequentialImpulseConstraintSolver::setupTorsionalFrictionConstraint(btSol
 		btScalar sum = 0;
 		sum += iMJaA.dot(solverConstraint.m_relpos1CrossNormal);
 		sum += iMJaB.dot(solverConstraint.m_relpos2CrossNormal);
-		solverConstraint.m_jacDiagABInv = btScalar(1.) / sum;
+		solverConstraint.m_jacDiagABInv = btFuzzyZero(sum) ? btScalar(0.) : (btScalar(1.) / sum);
 	}
 
 	{


### PR DESCRIPTION
I encountered NaN when simulating with a kinematic rigid body, one dynamic rigid body, and one rope anchored between them.
It was solved by avoiding division-by-zero when computing `solverConstraint.m_jacDiagABInv`.