### PR TITLE
Expose linear and angular velocity for softbodies

### DIFF
--- a/examples/SharedMemory/PhysicsServerCommandProcessor.cpp
+++ b/examples/SharedMemory/PhysicsServerCommandProcessor.cpp
@@ -8215,6 +8215,16 @@ bool PhysicsServerCommandProcessor::processRequestActualStateCommand(const struc
 		stateDetails->m_actualStateQ[5] = tr.getRotation()[2];
 		stateDetails->m_actualStateQ[6] = tr.getRotation()[3];
 
+		//base linear velocity (in world space, cartesian)
+		stateDetails->m_actualStateQdot[0] = sb->getLinearVelocity()[0];
+		stateDetails->m_actualStateQdot[1] = sb->getLinearVelocity()[1];
+		stateDetails->m_actualStateQdot[2] = sb->getLinearVelocity()[2];
+
+		//base angular velocity (in world space, cartesian)
+		stateDetails->m_actualStateQdot[3] = sb->getAngularVelocity()[0];
+		stateDetails->m_actualStateQdot[4] = sb->getAngularVelocity()[1];
+		stateDetails->m_actualStateQdot[5] = sb->getAngularVelocity()[2];
+
 		int totalDegreeOfFreedomQ = 7;  //pos + quaternion
 		int totalDegreeOfFreedomU = 6;  //3 linear and 3 angular DOF
 

--- a/src/BulletSoftBody/btSoftBody.cpp
+++ b/src/BulletSoftBody/btSoftBody.cpp
@@ -1043,6 +1043,20 @@ btVector3 btSoftBody::getLinearVelocity()
 	return total_mass == 0 ? total_momentum : total_momentum / total_mass;
 }
 
+btVector3 btSoftBody::getAngularVelocity()
+{
+	btVector3 total_momentum = btVector3(0, 0, 0);
+	btVector3 com = getCenterOfMass();
+	for (int i = 0; i < m_nodes.size(); ++i)
+	{
+		btScalar mass = m_nodes[i].m_im == 0 ? 0 : 1.0 / m_nodes[i].m_im;
+		btVector3 r = m_nodes[i].m_x - com; 
+		total_momentum += mass * r.cross(m_nodes[i].m_v);
+	}
+	btScalar total_mass = getTotalMass();
+	return total_mass == 0 ? total_momentum : total_momentum / total_mass;
+}
+
 //
 void btSoftBody::setLinearVelocity(const btVector3& linVel)
 {

--- a/src/BulletSoftBody/btSoftBody.h
+++ b/src/BulletSoftBody/btSoftBody.h
@@ -1001,6 +1001,8 @@ public:
 	void setVolumeDensity(btScalar density);
 	/* Get the linear velocity of the center of mass                        */
 	btVector3 getLinearVelocity();
+	/* Get the angular velocity about the center of mass                    */
+	btVector3 getAngularVelocity();
 	/* Set the linear velocity of the center of mass                        */
 	void setLinearVelocity(const btVector3& linVel);
 	/* Set the angular velocity of the center of mass                       */


### PR DESCRIPTION
This adds the ability to call `getBaseVelocity` on a softbody in bullet/pybullet - see https://github.com/bulletphysics/bullet3/issues/4445 for more info