### PR TITLE
Fix sign in contact distance 

### DIFF
--- a/examples/SharedMemory/PhysicsServerCommandProcessor.cpp
+++ b/examples/SharedMemory/PhysicsServerCommandProcessor.cpp
@@ -8450,7 +8450,7 @@ bool PhysicsServerCommandProcessor::processRequestDeformableContactpointHelper(c
 				b3ContactPointData pt;
 				pt.m_bodyUniqueIdA = objectIndexA;
 				pt.m_bodyUniqueIdB = objectIndexB;
-				pt.m_contactDistance = -contact->m_cti.m_offset;
+				pt.m_contactDistance = contact->m_cti.m_offset;
 				pt.m_contactFlags = 0;
 				pt.m_linkIndexA = linkIndexA;
 				pt.m_linkIndexB = linkIndexB;
@@ -8459,7 +8459,7 @@ bool PhysicsServerCommandProcessor::processRequestDeformableContactpointHelper(c
 					if (swap)
 					{
 						pt.m_contactNormalOnBInWS[j] = -contact->m_cti.m_normal[j];
-						pt.m_positionOnAInWS[j] = node->m_x[j] - pt.m_contactDistance * pt.m_contactNormalOnBInWS[j]; // not really precise because of margins in btSoftBody.cpp:line 2912
+						pt.m_positionOnAInWS[j] = node->m_x[j] + pt.m_contactDistance * pt.m_contactNormalOnBInWS[j]; // not really precise because of margins in btSoftBody.cpp:line 2912
 						// node is force application point, therefore node position is contact point (not contact->m_contactPoint, because not equal to node)
 						pt.m_positionOnBInWS[j] = node->m_x[j];
 					}

--- a/examples/SharedMemory/PhysicsServerCommandProcessor.cpp
+++ b/examples/SharedMemory/PhysicsServerCommandProcessor.cpp
@@ -8461,6 +8461,7 @@ bool PhysicsServerCommandProcessor::processRequestDeformableContactpointHelper(c
 						pt.m_contactNormalOnBInWS[j] = -contact->m_cti.m_normal[j];
 						pt.m_positionOnAInWS[j] = node->m_x[j] + pt.m_contactDistance * pt.m_contactNormalOnBInWS[j]; // not really precise because of margins in btSoftBody.cpp:line 2912
 						// node is force application point, therefore node position is contact point (not contact->m_contactPoint, because not equal to node)
+						// pt.m_contactNormalOnBInWS[j] points away from B.
 						pt.m_positionOnBInWS[j] = node->m_x[j];
 					}
 					else
@@ -8469,6 +8470,7 @@ bool PhysicsServerCommandProcessor::processRequestDeformableContactpointHelper(c
 						// node is force application point, therefore node position is contact point (not contact->m_contactPoint, because not equal to node)
 						pt.m_positionOnAInWS[j] = node->m_x[j];
 						pt.m_positionOnBInWS[j] = node->m_x[j] - pt.m_contactDistance * pt.m_contactNormalOnBInWS[j]; // not really precise because of margins in btSoftBody.cpp:line 2912
+						// pt.m_contactNormalOnBInWS[j] points away from B, so need to flip the sign to point to B.
 					}
 				}
 				pt.m_normalForce = (impulseNormal / m_data->m_physicsDeltaTime).norm();


### PR DESCRIPTION
contact->m_cti.m_offset is contact distance, not the negative of it. For example: https://github.com/bulletphysics/bullet3/blob/39b8de74df93721add193e5b3d9ebee579faebf8/src/BulletSoftBody/btSoftBody.cpp#L549