### PR TITLE
Implement saveState/restoreState for deformable objects

### DIFF
--- a/Extras/Serialize/BulletWorldImporter/btMultiBodyWorldImporter.cpp
+++ b/Extras/Serialize/BulletWorldImporter/btMultiBodyWorldImporter.cpp
@@ -285,12 +285,6 @@ bool btMultiBodyWorldImporter::convertAllObjects(bParse::btBulletFile* bulletFil
 		//convert all multibodies
 		if (bulletFile2->getFlags() & bParse::FD_DOUBLE_PRECISION)
 		{
-			printf("DAN: Using double precision\n"); 
-			printf("DAN: Number of multibodies: %d\n", bulletFile2->m_multiBodies.size()); 
-			printf("DAN: Number of softbodies: %d\n", bulletFile2->m_softBodies.size()); 
-			printf("DAN: Number of rigid bodies: %d\n", bulletFile2->m_rigidBodies.size()); 
-			printf("DAN: Number of contact manifolds: %d\n", bulletFile2->m_contactManifolds.size()); 
-			printf("DAN: Number of collision objects: %d\n", bulletFile2->m_collisionObjects.size()); 
 			//for (int i = 0; i < bulletFile2->m_multiBodies.size(); i++)
 			for (int i = bulletFile2->m_multiBodies.size() - 1; i >= 0; i--)
 			{
@@ -373,80 +367,11 @@ bool btMultiBodyWorldImporter::convertAllObjects(bParse::btBulletFile* bulletFil
 				syncContactManifolds((btPersistentManifoldDoubleData**)&bulletFile2->m_contactManifolds[0], bulletFile2->m_contactManifolds.size(), m_data);
 			}
 
-
-			// Deserialize and update the softbody
-			// TODO figure out how to distinguish between double and float precision
-			for (int i = bulletFile2->m_softBodies.size() - 1; i >= 0; i--)
-			{
-				btSoftBodyData* sbd = (btSoftBodyData*)bulletFile2->m_softBodies[i];
-				int foundSb = -1;
-				int uid = sbd->m_collisionObjectData.m_uniqueId;
-				printf("DAN: sbd uid: %i\n", uid);
-				printf("DAN: Number of collision objects: %d\n", m_data->m_mbDynamicsWorld->getNumCollisionObjects());
-				printf("DAN: Number of multibodies: %d\n", m_data->m_mbDynamicsWorld->getNumMultibodies());
-				printf("DAN: Number of collision objects (non-mb world): %d\n", m_dynamicsWorld->getNumCollisionObjects());
-			
-				for (int i = 0; i < m_data->m_mbDynamicsWorld->getNumCollisionObjects(); i++)
-				{
-					printf("DAN: i = %i, broadphase = %i\n", i, m_data->m_mbDynamicsWorld->getCollisionObjectArray()[i]->getBroadphaseHandle()->m_uniqueId);
-					if (uid == m_data->m_mbDynamicsWorld->getCollisionObjectArray()[i]->getBroadphaseHandle()->m_uniqueId)
-					{
-						foundSb = i;
-						break;
-					}
-				}
-				printf("DAN: foundSb: %i\n", foundSb);
-
-				// HARDCODING THIS. TODO REMOVE THIS!! Just to see if finding the softbody is the issue
-				// foundSb = i+1; // (commented out for now)
-
-
-				if (foundSb >= 0)
-				{
-					btSoftBody* sb = btSoftBody::upcast(m_data->m_mbDynamicsWorld->getCollisionObjectArray()[foundSb]);
-					if (sb)
-					{
-						// Deserialize data for each node and update the softbody's nodes with the saved info
-						for (int i = 0; i < sbd->m_numNodes; i++){
-							btVector3 pos, prev_pos, vel, force, normal; 
-							pos.deSerializeFloat(sbd->m_nodes[i].m_position);
-							prev_pos.deSerializeFloat(sbd->m_nodes[i].m_previousPosition);
-							vel.deSerializeFloat(sbd->m_nodes[i].m_velocity);
-							force.deSerializeFloat(sbd->m_nodes[i].m_accumulatedForce);
-							normal.deSerializeFloat(sbd->m_nodes[i].m_normal);
-							// TODO: see if the other serialized attributes for the nodes need to be reset. i.e.
-							// m_pad, m_material, m_inverseMass, m_area, m_attach
-							sb->m_nodes[i].m_x = pos; 
-							sb->m_nodes[i].m_q = prev_pos;
-							sb->m_nodes[i].m_v = vel; 
-							sb->m_nodes[i].m_f = force;
-							sb->m_nodes[i].m_n = normal; 
-
-						}
-						// TODO: see if other attributes of the softbody data needs updating other than nodes. i.e.
-						// anchors, clusters, collisionObjectData, config, faces, joints, links, materials, nodes, 
-						// numJoints, numAnchors, numClusters, numFaces, numJoints, numLinks, numMaterials, numNodes, 
-						// numTetrahedra, pose, tetrahedra				
-					}
-					else
-					{
-						printf("btMultiBodyWorldImporter::convertAllObjects error: cannot find btSoftBody with bodyUniqueId %d\n", uid);
-						result = false;
-					}
-				}
-				else
-				{
-					printf("Error in btMultiBodyWorldImporter::convertAllObjects: didn't find bodyUniqueId: %d\n", uid);
-					result = false;
-				}
-			}
-
 		}
 		else
 		{
 			//single precision version
 			//for (int i = 0; i < bulletFile2->m_multiBodies.size(); i++)
-			printf("DAN: Using single precision\n"); 
 			for (int i = bulletFile2->m_multiBodies.size() - 1; i >= 0; i--)
 			{
 				btMultiBodyFloatData* mbd = (btMultiBodyFloatData*)bulletFile2->m_multiBodies[i];
@@ -527,6 +452,57 @@ bool btMultiBodyWorldImporter::convertAllObjects(bParse::btBulletFile* bulletFil
 				syncContactManifolds((btPersistentManifoldFloatData**)&bulletFile2->m_contactManifolds[0], bulletFile2->m_contactManifolds.size(), m_data);
 			}
 		}
+
+		// Deserialize and update the softbody. Note: This is outside of the check for float/double precision 
+		// since currently the softbody implementation is only configured for float serialization
+		for (int i = bulletFile2->m_softBodies.size() - 1; i >= 0; i--)
+		{
+			btSoftBodyData* sbd = (btSoftBodyData*)bulletFile2->m_softBodies[i];
+			int foundSb = -1;
+			int uid = sbd->m_collisionObjectData.m_uniqueId;
+			for (int i = 0; i < m_data->m_mbDynamicsWorld->getNumCollisionObjects(); i++)
+			{
+				if (uid == m_data->m_mbDynamicsWorld->getCollisionObjectArray()[i]->getBroadphaseHandle()->m_uniqueId)
+				{
+					foundSb = i;
+					break;
+				}
+			}
+			if (foundSb >= 0)
+			{
+				btSoftBody* sb = btSoftBody::upcast(m_data->m_mbDynamicsWorld->getCollisionObjectArray()[foundSb]);
+				if (sb)
+				{
+					// Deserialize data for each node and update the softbody's nodes with the saved info
+					for (int i = 0; i < sbd->m_numNodes; i++){
+						btVector3 pos, prev_pos, vel, force, normal; 
+						pos.deSerializeFloat(sbd->m_nodes[i].m_position);
+						prev_pos.deSerializeFloat(sbd->m_nodes[i].m_previousPosition);
+						vel.deSerializeFloat(sbd->m_nodes[i].m_velocity);
+						force.deSerializeFloat(sbd->m_nodes[i].m_accumulatedForce);
+						normal.deSerializeFloat(sbd->m_nodes[i].m_normal);
+						// TODO: see if the other serialized attributes for the nodes need to be reset. i.e.
+						// m_pad, m_material, m_inverseMass, m_area, m_attach
+						sb->m_nodes[i].m_x = pos; 
+						sb->m_nodes[i].m_q = prev_pos;
+						sb->m_nodes[i].m_v = vel; 
+						sb->m_nodes[i].m_f = force;
+						sb->m_nodes[i].m_n = normal; 
+					}		
+				}
+				else
+				{
+					printf("btMultiBodyWorldImporter::convertAllObjects error: cannot find btSoftBody with bodyUniqueId %d\n", uid);
+					result = false;
+				}
+			}
+			else
+			{
+				printf("Error in btMultiBodyWorldImporter::convertAllObjects: didn't find bodyUniqueId: %d\n", uid);
+				result = false;
+			}
+		}
+
 	}
 	else
 	{

--- a/examples/SharedMemory/PhysicsServerCommandProcessor.cpp
+++ b/examples/SharedMemory/PhysicsServerCommandProcessor.cpp
@@ -14854,6 +14854,7 @@ bool PhysicsServerCommandProcessor::processRestoreStateCommand(const struct Shar
 			bParse::btBulletFile* bulletFile = m_data->m_savedStates[clientCmd.m_loadStateArguments.m_stateId].m_bulletFile;
 			if (bulletFile)
 			{
+				std::cout << "DAN: Restoring objects" << std::endl; 
 				ok = importer->convertAllObjects(bulletFile);
 			}
 		}

--- a/examples/SharedMemory/PhysicsServerCommandProcessor.cpp
+++ b/examples/SharedMemory/PhysicsServerCommandProcessor.cpp
@@ -14854,7 +14854,6 @@ bool PhysicsServerCommandProcessor::processRestoreStateCommand(const struct Shar
 			bParse::btBulletFile* bulletFile = m_data->m_savedStates[clientCmd.m_loadStateArguments.m_stateId].m_bulletFile;
 			if (bulletFile)
 			{
-				std::cout << "DAN: Restoring objects" << std::endl; 
 				ok = importer->convertAllObjects(bulletFile);
 			}
 		}

--- a/src/BulletSoftBody/btDeformableMultiBodyDynamicsWorld.cpp
+++ b/src/BulletSoftBody/btDeformableMultiBodyDynamicsWorld.cpp
@@ -743,3 +743,40 @@ int btDeformableMultiBodyDynamicsWorld::stepSimulation(btScalar timeStep, int ma
 
 	return numSimulationSubSteps;
 }
+
+
+void btDeformableMultiBodyDynamicsWorld::serializeSoftBodies(btSerializer* serializer)
+{
+	int i;
+	//serialize all collision objects
+	for (i = 0; i < m_collisionObjects.size(); i++)
+	{
+		btCollisionObject* colObj = m_collisionObjects[i];
+		if (colObj->getInternalType() & btCollisionObject::CO_SOFT_BODY)
+		{
+			int len = colObj->calculateSerializeBufferSize();
+			btChunk* chunk = serializer->allocate(len, 1);
+			const char* structType = colObj->serialize(chunk->m_oldPtr, serializer);
+			serializer->finalizeChunk(chunk, structType, BT_SOFTBODY_CODE, colObj);
+		}
+	}
+}
+
+void btDeformableMultiBodyDynamicsWorld::serialize(btSerializer* serializer)
+{
+	serializer->startSerialization();
+
+	serializeDynamicsWorldInfo(serializer);
+
+	serializeSoftBodies(serializer);
+
+	serializeMultiBodies(serializer);
+
+	serializeRigidBodies(serializer);
+
+	serializeCollisionObjects(serializer);
+
+	serializeContactManifolds(serializer);
+
+	serializer->finishSerialization();
+}

--- a/src/BulletSoftBody/btDeformableMultiBodyDynamicsWorld.cpp
+++ b/src/BulletSoftBody/btDeformableMultiBodyDynamicsWorld.cpp
@@ -747,18 +747,17 @@ int btDeformableMultiBodyDynamicsWorld::stepSimulation(btScalar timeStep, int ma
 
 void btDeformableMultiBodyDynamicsWorld::serializeSoftBodies(btSerializer* serializer)
 {
+	printf("DAN: Number of softbodies in deformable world: %d\n", m_softBodies.size());
 	int i;
 	//serialize all collision objects
-	for (i = 0; i < m_collisionObjects.size(); i++)
+	for (i = 0; i < m_softBodies.size(); i++)
 	{
-		btCollisionObject* colObj = m_collisionObjects[i];
-		if (colObj->getInternalType() & btCollisionObject::CO_SOFT_BODY)
-		{
-			int len = colObj->calculateSerializeBufferSize();
-			btChunk* chunk = serializer->allocate(len, 1);
-			const char* structType = colObj->serialize(chunk->m_oldPtr, serializer);
-			serializer->finalizeChunk(chunk, structType, BT_SOFTBODY_CODE, colObj);
-		}
+		btSoftBody* psb = m_softBodies[i];
+		std::cout << "DAN: Serializing soft body object" << std::endl; 
+		int len = psb->calculateSerializeBufferSize();
+		btChunk* chunk = serializer->allocate(len, 1);
+		const char* structType = psb->serialize(chunk->m_oldPtr, serializer);
+		serializer->finalizeChunk(chunk, structType, BT_SOFTBODY_CODE, psb);
 	}
 }
 

--- a/src/BulletSoftBody/btDeformableMultiBodyDynamicsWorld.cpp
+++ b/src/BulletSoftBody/btDeformableMultiBodyDynamicsWorld.cpp
@@ -747,13 +747,11 @@ int btDeformableMultiBodyDynamicsWorld::stepSimulation(btScalar timeStep, int ma
 
 void btDeformableMultiBodyDynamicsWorld::serializeSoftBodies(btSerializer* serializer)
 {
-	printf("DAN: Number of softbodies in deformable world: %d\n", m_softBodies.size());
 	int i;
 	//serialize all collision objects
 	for (i = 0; i < m_softBodies.size(); i++)
 	{
 		btSoftBody* psb = m_softBodies[i];
-		std::cout << "DAN: Serializing soft body object" << std::endl; 
 		int len = psb->calculateSerializeBufferSize();
 		btChunk* chunk = serializer->allocate(len, 1);
 		const char* structType = psb->serialize(chunk->m_oldPtr, serializer);

--- a/src/BulletSoftBody/btDeformableMultiBodyDynamicsWorld.h
+++ b/src/BulletSoftBody/btDeformableMultiBodyDynamicsWorld.h
@@ -175,6 +175,10 @@ public:
 
 	void performGeometricCollisions(btScalar timeStep);
 
+	void serializeSoftBodies(btSerializer* serializer); 
+
+	void serialize(btSerializer* serializer);
+
 	struct btDeformableSingleRayCallback : public btBroadphaseRayCallback
 	{
 		btVector3 m_rayFromWorld;

--- a/src/BulletSoftBody/btSoftBody.cpp
+++ b/src/BulletSoftBody/btSoftBody.cpp
@@ -4337,12 +4337,9 @@ const char* btSoftBody::serialize(void* dataBuffer, class btSerializer* serializ
 {
 	btSoftBodyData* sbd = (btSoftBodyData*)dataBuffer;
 
-	// TODO: figure out if this is needed. 
-	// Seems like this did not solve the issue when this was included
-	// sbd->m_collisionObjectData.m_uniqueId = m_broadphaseHandle->m_uniqueId;
-	// printf("Serializing softbody: ID = %i", m_broadphaseHandle->m_uniqueId);
-
 	btCollisionObject::serialize(&sbd->m_collisionObjectData, serializer);
+
+	sbd->m_collisionObjectData.m_uniqueId = m_broadphaseHandle->m_uniqueId;
 
 	btHashMap<btHashPtr, int> m_nodeIndexMap;
 

--- a/src/BulletSoftBody/btSoftBody.cpp
+++ b/src/BulletSoftBody/btSoftBody.cpp
@@ -4337,6 +4337,11 @@ const char* btSoftBody::serialize(void* dataBuffer, class btSerializer* serializ
 {
 	btSoftBodyData* sbd = (btSoftBodyData*)dataBuffer;
 
+	// TODO: figure out if this is needed. 
+	// Seems like this did not solve the issue when this was included
+	// sbd->m_collisionObjectData.m_uniqueId = m_broadphaseHandle->m_uniqueId;
+	// printf("Serializing softbody: ID = %i", m_broadphaseHandle->m_uniqueId);
+
 	btCollisionObject::serialize(&sbd->m_collisionObjectData, serializer);
 
 	btHashMap<btHashPtr, int> m_nodeIndexMap;


### PR DESCRIPTION
This will serialize the deformable object upon a call to saveState, and then deserialize the deformable object's node properties upon a call to restoreState. Previously, every object except for deformables would be saved/reset, when using RESET_USE_DEFORMABLE_WORLD

The code style here is based on what I've seen in the repo already. I can make more changes as needed too