### PR TITLE
Couple lateral friction constraint magnitudes.

### DIFF
--- a/src/BulletDynamics/Featherstone/btMultiBodyConstraintSolver.cpp
+++ b/src/BulletDynamics/Featherstone/btMultiBodyConstraintSolver.cpp
@@ -1380,13 +1380,32 @@ void btMultiBodyConstraintSolver::convertMultiBodyContact(btPersistentManifold* 
 				{
 					applyAnisotropicFriction(colObj0, cp.m_lateralFrictionDir1, btCollisionObject::CF_ANISOTROPIC_FRICTION);
 					applyAnisotropicFriction(colObj1, cp.m_lateralFrictionDir1, btCollisionObject::CF_ANISOTROPIC_FRICTION);
-					addMultiBodyFrictionConstraint(cp.m_lateralFrictionDir1, cp.m_appliedImpulseLateral1, manifold, frictionIndex, cp, colObj0, colObj1, relaxation, infoGlobal);
+					btMultiBodySolverConstraint& frictionConstraint = addMultiBodyFrictionConstraint(cp.m_lateralFrictionDir1, cp.m_appliedImpulseLateral1, manifold, frictionIndex, cp, colObj0, colObj1, relaxation, infoGlobal);
 
 					if ((infoGlobal.m_solverMode & SOLVER_USE_2_FRICTION_DIRECTIONS))
 					{
 						applyAnisotropicFriction(colObj0, cp.m_lateralFrictionDir2, btCollisionObject::CF_ANISOTROPIC_FRICTION);
 						applyAnisotropicFriction(colObj1, cp.m_lateralFrictionDir2, btCollisionObject::CF_ANISOTROPIC_FRICTION);
-					  addMultiBodyFrictionConstraint(cp.m_lateralFrictionDir2, cp.m_appliedImpulseLateral2, manifold, frictionIndex, cp, colObj0, colObj1, relaxation, infoGlobal);
+					  btMultiBodySolverConstraint& frictionConstraintB = addMultiBodyFrictionConstraint(cp.m_lateralFrictionDir2, cp.m_appliedImpulseLateral2, manifold, frictionIndex, cp, colObj0, colObj1, relaxation, infoGlobal);
+
+
+                        btScalar m1 = frictionConstraint.m_jacDiagABInv;
+                        btScalar m2 = frictionConstraintB.m_jacDiagABInv;
+                        btScalar v1 = frictionConstraint.m_rhs / m1;
+                        btScalar v2 = frictionConstraintB.m_rhs / m2;
+
+                        btScalar vSq = v1 * v1 + v2 * v2;
+
+                        if (vSq > SIMD_EPSILON)
+                        {
+                            // Compute effective mass so that kinetic energy is the
+                            // same as the sum of the original two constraints
+                            btScalar m = (m1 * v1 * v1 + m2 * v2 * v2) / vSq;
+                            frictionConstraint.m_rhs = v1 * m;
+                            frictionConstraintB.m_rhs = v2 * m;
+                            frictionConstraint.m_jacDiagABInv = m;
+                            frictionConstraintB.m_jacDiagABInv = m;
+                        }
 					}
 
 					if ((infoGlobal.m_solverMode & SOLVER_USE_2_FRICTION_DIRECTIONS) && (infoGlobal.m_solverMode & SOLVER_DISABLE_VELOCITY_DEPENDENT_FRICTION_DIRECTION))


### PR DESCRIPTION
As has been noted [before](https://pybullet.org/Bullet/phpBB3/viewtopic.php?t=12847), PyBullet has an odd behavior where the friction force exerted on an object depends on its orientation. For a small self-contained example, see [this gist](https://gist.github.com/adamheins/b64651ab072ca2f1f7b44ed7bacea71d), in which a box is pushed on the ground plane by an applied force. When the box is pushed along either the x- or y-axis, the resulting friction force is correct. However, when it is oriented and pushed along a 45 deg angle to the axes, we get a lower, incorrect friction force.

It seems to me that the reason for this is that the two friction constraints for each contact point are decoupled (until clipped to the implicit friction cone). This means that they have different effective masses (because effective mass depends on orientation through the constraint Jacobian), such that the resulting impulse is not aligned with the velocity at the contact point. But this doesn't make physical sense: when the contact point is sliding, the friction force should act in the opposite direction to oppose the motion.

This PR is an initial attempt to fix this behavior, by making the effective mass of each pair friction constraints the same. In particular, I compute an effective mass that keeps the kinetic energy the same as when the constraints are decoupled. If one compiles PyBullet with this change and then runs the gist example linked above, one sees that the friction forces are now correct regardless of the orientation. However, I'm not sure if there are other aspects of this problem that I haven't thought about.

Fixing this behavior would be very desirable for facilitating research on planar pushing, so I'm very interested to hear what others think about it