### PR TITLE
Made raycast vehicle work with collision groups

### DIFF
--- a/src/BulletDynamics/Vehicle/btRaycastVehicle.cpp
+++ b/src/BulletDynamics/Vehicle/btRaycastVehicle.cpp
@@ -690,6 +690,9 @@ void* btDefaultVehicleRaycaster::castRay(const btVector3& from, const btVector3&
 
 	btCollisionWorld::ClosestRayResultCallback rayCallback(from, to);
 
+	rayCallback.m_collisionFilterMask = m_collisionFilterMask;
+	rayCallback.m_collisionFilterGroup = m_collisionFilterGroup;
+
 	m_dynamicsWorld->rayTest(from, to, rayCallback);
 
 	if (rayCallback.hasHit())

--- a/src/BulletDynamics/Vehicle/btVehicleRaycaster.h
+++ b/src/BulletDynamics/Vehicle/btVehicleRaycaster.h
@@ -16,6 +16,8 @@
 /// btVehicleRaycaster is provides interface for between vehicle simulation and raycasting
 struct btVehicleRaycaster
 {
+	int m_collisionFilterMask;
+	int m_collisionFilterGroup;
 	virtual ~btVehicleRaycaster()
 	{
 	}


### PR DESCRIPTION
A simple non-breakable change, which allows to use collision filters in the vehicle raycaster