### PR TITLE
Add missing ".h" to file pointer

### DIFF
--- a/examples/ExampleBrowser/CMakeLists.txt
+++ b/examples/ExampleBrowser/CMakeLists.txt
@@ -284,7 +284,7 @@ SET(BulletExampleBrowser_SRCS
 	../Benchmarks/BenchmarkDemo.cpp
 	../Benchmarks/BenchmarkDemo.h
 	../Benchmarks/landscapeData.h
-	../Benchmarks/TaruData
+	../Benchmarks/TaruData.h
 	../Raycast/RaytestDemo.cpp
 		../Importers/ImportBsp/BspConverter.h
  	../Importers/ImportBullet/SerializeSetup.cpp


### PR DESCRIPTION
Quick patch to fix a build warning.

When building from source with CMake, this warning showed up:

```bash
CMake Warning (dev) at examples/ExampleBrowser/CMakeLists.txt:433 (ADD_EXECUTABLE):
  Policy CMP0115 is not set: Source file extensions must be explicit.  Run 
  "cmake --help-policy CMP0115" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.                     
                                                                           
  File:                                                                    
                                                                           
    examples/Benchmarks/TaruData.h

This warning is for project developers.  Use -Wno-dev to suppress it.      
```

Adding the .h to the reference mitigated this warning.