### PR TITLE
Fix calculateInverseDynamics losing one joint DOF for floating bodies

### DIFF
--- a/examples/SharedMemory/PhysicsServerCommandProcessor.cpp
+++ b/examples/SharedMemory/PhysicsServerCommandProcessor.cpp
@@ -12360,9 +12360,10 @@ bool PhysicsServerCommandProcessor::processInverseDynamicsCommand(const struct S
 					q[4] = pos[1];
 					q[5] = pos[2];
 				}
+				int quatToEulerCorrection =  baseDofQ ? -1 : 0; // The conversion to Euler angles drops the DOF by one
 				for (int i = 0; i < num_dofs; i++)
 				{
-					q[i + baseDofQ] = clientCmd.m_calculateInverseDynamicsArguments.m_jointPositionsQ[i + baseDofQ];
+					q[i + baseDofQ + quatToEulerCorrection] = clientCmd.m_calculateInverseDynamicsArguments.m_jointPositionsQ[i + baseDofQ];
 				}
 				for (int i = 0; i < num_dofs + baseDofQdot; i++)
 				{


### PR DESCRIPTION
resolves #4578

The issue here is that the last positional degree of freedom of floating bodies is ignored in calculateInverseDynamics. 
This is because the indexing of q does not account for the drop in degree of freedom when converting from a quaternion angle (4 DOF) to an Euler angle (3 DOF).

https://github.com/bulletphysics/bullet3/blob/6bb8d1123d8a55d407b19fd3357c724d0f5c9d3c/examples/SharedMemory/PhysicsServerCommandProcessor.cpp#L12333
With a floating body, baseDofQ is set to be 7.


https://github.com/bulletphysics/bullet3/blob/6bb8d1123d8a55d407b19fd3357c724d0f5c9d3c/examples/SharedMemory/PhysicsServerCommandProcessor.cpp#L12344-L12366
q[0] through q[5] are set in the if statement. However the for loop starts at q[7], meaning that q[6] is never set and the last joint position is excluded from the array. 

This can be fixed by subtracting 1 from the indexing of q (not clientCmd.m_calculateInverseDynamicsArguments.m_jointPositionsQ as this uses a quaternion) in the case of a floating body.