### PR TITLE
 Fix crash due to wrong manifold being released in btCollisionDispatcherMt

### DIFF
--- a/src/BulletCollision/CollisionDispatch/btCollisionDispatcherMt.cpp
+++ b/src/BulletCollision/CollisionDispatch/btCollisionDispatcherMt.cpp
@@ -154,6 +154,7 @@ void btCollisionDispatcherMt::dispatchAllCollisionPairs(btOverlappingPairCache* 
 
 		for (int j = 0; j < batchManifoldsPtr.size(); ++j)
 		{
+			batchManifoldsPtr[j]->m_index1a = m_manifoldsPtr.size();
 			m_manifoldsPtr.push_back(batchManifoldsPtr[j]);
 		}
 


### PR DESCRIPTION
We need to set the correct value in index1a when adding manifolds from the batch. This must happen before we release manifolds because it relies on the value in index1a. Otherwise this can cause missing contacts or dangling manifold pointers which causes intermittent crashes

Re-created PR due to wrong branch being used