### PR TITLE
Fix unused example

### DIFF
--- a/examples/ExampleBrowser/ExampleEntries.cpp
+++ b/examples/ExampleBrowser/ExampleEntries.cpp
@@ -208,7 +208,7 @@ static ExampleEntry gDefaultExamples[] =
 		ExampleEntry(1, "Spheres & Plane C-API (Bullet2)", "Collision C-API using Bullet 2.x backend", CollisionTutorialBullet2CreateFunc, TUT_SPHERE_PLANE_BULLET2),
 //ExampleEntry(1, "Spheres & Plane C-API (Bullet3)", "Collision C-API using Bullet 3.x backend", CollisionTutorialBullet2CreateFunc,TUT_SPHERE_PLANE_RTB3),
 
-        ExampleEntry(0, "Deformabe Body"),
+        ExampleEntry(0, "Deformable Body"),
         ExampleEntry(1, "Deformable Self Collision", "Deformable Self Collision", DeformableSelfCollisionCreateFunc),
         ExampleEntry(1, "Deformable-Deformable Contact", "Deformable contact", DeformableContactCreateFunc),
         ExampleEntry(1, "Cloth Friction", "Cloth friction contact", ClothFrictionCreateFunc),
@@ -226,7 +226,7 @@ static ExampleEntry gDefaultExamples[] =
         ExampleEntry(1, "Deformable-MultiBody Contact", "MultiBody and Deformable contact", DeformableMultibodyCreateFunc),
         // ExampleEntry(1, "MultiBody Baseline", "MultiBody Baseline", MultiBodyBaselineCreateFunc),
 		
-		ExampleEntry(0, "Reduced Deformabe Body"),
+		ExampleEntry(0, "Reduced Deformable Body"),
 		ExampleEntry(1, "Mode Visualizer", "Visualizer the modes for reduced deformable objects", ReducedModeVisualizerCreateFunc),
 		ExampleEntry(1, "Reduced Conservation Test", "Momentum conservation test for the reduced deformable objects", ReducedConservationTestCreateFunc),
 		ExampleEntry(1, "Reduced Springboard", "Moving rigid object colliding with a fixed reduced deformable objects", ReducedSpringboardCreateFunc),

--- a/examples/MultiBodyBaseline/MultiBodyBaseline.cpp
+++ b/examples/MultiBodyBaseline/MultiBodyBaseline.cpp
@@ -30,7 +30,6 @@ subject to the following restrictions:
 #include "MultiBodyBaseline.h"
 ///btBulletDynamicsCommon.h is the main Bullet include file, contains most common include files.
 #include "btBulletDynamicsCommon.h"
-#include "BulletSoftBody/btDeformableRigidDynamicsWorld.h"
 #include "BulletSoftBody/btSoftBody.h"
 #include "BulletSoftBody/btSoftBodyHelpers.h"
 #include "BulletSoftBody/btDeformableBodySolver.h"


### PR DESCRIPTION
`examples/MultiBodyBaseline` is commented out in the example browser, which might explain why it was missed in bf215a3c.
https://github.com/bulletphysics/bullet3/blob/e9c461b0ace140d5c73972760781d94b7b5eee53/examples/ExampleBrowser/ExampleEntries.cpp#L227

The included file is not actually used in that example. It looks like a prototype for some of the other examples (e.g., /Deformabe Body/Deformable-MultiBody Contact), so I left it commented out in the browser but fixed the typo.