### PR TITLE
replace logging.warn with logging.warning

### DIFF
--- a/examples/pybullet/examples/rendertest_sync.py
+++ b/examples/pybullet/examples/rendertest_sync.py
@@ -115,7 +115,7 @@ def train(env_id, num_timesteps=300, seed=0, num_env=2, renderer='tiny'):
         env = gym.make(env_id)
       env.seed(seed + rank)
       env = bench.Monitor(env, logger.get_dir() and os.path.join(logger.get_dir(), str(rank)))
-      gym.logger.setLevel(logging.WARN)
+      gym.logger.setLevel(logging.WARNING)
       # only clip rewards when not evaluating
       return env
 

--- a/examples/pybullet/gym/pybullet_envs/minitaur/robots/minitaur_v2.py
+++ b/examples/pybullet/gym/pybullet_envs/minitaur/robots/minitaur_v2.py
@@ -23,7 +23,7 @@ class Minitaur(quadruped_base.QuadrupedBase):
     except ValueError:
       use_constrained_base = False
     if use_constrained_base:
-      logging.warn(
+      logging.warning(
           "use_constrained_base is currently not compatible with Minitaur's "
           "leg constraints."
       )


### PR DESCRIPTION
logging.warn is an alias to logging.warning since Python 3.3 and will be removed in Python 3.13.