### PR TITLE
Increase MAX_DEGREE_OF_FREEDOM to 256

### DIFF
--- a/examples/SharedMemory/SharedMemoryCommands.h
+++ b/examples/SharedMemory/SharedMemoryCommands.h
@@ -30,7 +30,7 @@ typedef unsigned long long int smUint64_t;
 #endif
 
 #define SHARED_MEMORY_SERVER_TEST_C
-#define MAX_DEGREE_OF_FREEDOM 128
+#define MAX_DEGREE_OF_FREEDOM 256
 #define MAX_NUM_SENSORS 256
 #define MAX_URDF_FILENAME_LENGTH 1024
 #define MAX_SDF_FILENAME_LENGTH 1024


### PR DESCRIPTION
This PR addresses #4621 by increasing the variable MAX_DEGREE_OF_FREEDOM from 128 to 256. 
I tested this locally with a larger URDF and PyBullet and did not have any problems.