### PR TITLE
Fix text artifacts in example browser

### DIFF
--- a/examples/OpenGLWindow/GLInstancingRenderer.cpp
+++ b/examples/OpenGLWindow/GLInstancingRenderer.cpp
@@ -311,7 +311,7 @@ static GLint points_colourIn = 0;
 static GLint points_colour = 0;
 GLuint pointsVertexBufferObject = 0;
 GLuint pointsVertexArrayObject = 0;
-GLuint pointsIndexVbo = 0;
+GLuint pointsColourBufferObject = 0;
 
 static GLint lines_ModelViewMatrix = 0;
 static GLint lines_ProjectionMatrix = 0;
@@ -1279,14 +1279,14 @@ void GLInstancingRenderer::InitShaders()
 			glBindVertexArray(pointsVertexArrayObject);
 
 			glGenBuffers(1, &pointsVertexBufferObject);
-			glGenBuffers(1, &pointsIndexVbo);
+			glGenBuffers(1, &pointsColourBufferObject);
 
 			int sz = MAX_POINTS_IN_BATCH * sizeof(b3Vector3);
 			int sz1 = MAX_POINTS_IN_BATCH * sizeof(b3Vector4);
 			glBindVertexArray(pointsVertexArrayObject);
 			glBindBuffer(GL_ARRAY_BUFFER, pointsVertexBufferObject);
 			glBufferData(GL_ARRAY_BUFFER, sz, 0, GL_DYNAMIC_DRAW);
-			glBindBuffer(GL_ARRAY_BUFFER, pointsIndexVbo);
+			glBindBuffer(GL_ARRAY_BUFFER, pointsColourBufferObject);
 			glBufferData(GL_ARRAY_BUFFER, sz1, 0, GL_DYNAMIC_DRAW);
 
 			glBindVertexArray(0);
@@ -1971,7 +1971,7 @@ void GLInstancingRenderer::drawPoints(const float* positions, const float* color
 			glEnableVertexAttribArray(points_position);
 			glVertexAttribPointer(points_position, 3, GL_FLOAT, GL_FALSE, pointStrideInBytes, 0);
 
-			glBindBuffer(GL_ARRAY_BUFFER, pointsIndexVbo);
+			glBindBuffer(GL_ARRAY_BUFFER, pointsColourBufferObject);
 			glBufferSubData(GL_ARRAY_BUFFER, 0, curPointsInBatch * 4 * sizeof(float), colors + offsetNumPoints * 4);
 			glEnableVertexAttribArray(points_colourIn);
 			glVertexAttribPointer(points_colourIn, 4, GL_FLOAT, GL_FALSE, 4 * sizeof(float), 0);

--- a/examples/OpenGLWindow/GLInstancingRenderer.cpp
+++ b/examples/OpenGLWindow/GLInstancingRenderer.cpp
@@ -1968,7 +1968,7 @@ void GLInstancingRenderer::drawPoints(const float* positions, const float* color
 			glEnableVertexAttribArray(points_position);
 			glVertexAttribPointer(points_position, 3, GL_FLOAT, GL_FALSE, pointStrideInBytes, 0);
 
-			glBindBuffer(GL_ARRAY_BUFFER, pointsVertexArrayObject);
+			glBindBuffer(GL_ARRAY_BUFFER, pointsIndexVbo);
 			glBufferSubData(GL_ARRAY_BUFFER, 0, curPointsInBatch * 4 * sizeof(float), colors + offsetNumPoints * 4);
 			glEnableVertexAttribArray(points_colourIn);
 			glVertexAttribPointer(points_colourIn, 4, GL_FLOAT, GL_FALSE, 4 * sizeof(float), 0);

--- a/examples/OpenGLWindow/GLInstancingRenderer.cpp
+++ b/examples/OpenGLWindow/GLInstancingRenderer.cpp
@@ -1282,9 +1282,12 @@ void GLInstancingRenderer::InitShaders()
 			glGenBuffers(1, &pointsIndexVbo);
 
 			int sz = MAX_POINTS_IN_BATCH * sizeof(b3Vector3);
+			int sz1 = MAX_POINTS_IN_BATCH * sizeof(b3Vector4);
 			glBindVertexArray(pointsVertexArrayObject);
 			glBindBuffer(GL_ARRAY_BUFFER, pointsVertexBufferObject);
 			glBufferData(GL_ARRAY_BUFFER, sz, 0, GL_DYNAMIC_DRAW);
+			glBindBuffer(GL_ARRAY_BUFFER, pointsIndexVbo);
+			glBufferData(GL_ARRAY_BUFFER, sz1, 0, GL_DYNAMIC_DRAW);
 
 			glBindVertexArray(0);
 		}


### PR DESCRIPTION
Fixes #4493

Thanks to @DaveH355 it was easy to `git-bisect` where the issue was introduced (31b9be8).

The diff is very short so it was quick to see the misuse of the VAO in `glBindBuffer()`. The first commit is sufficient for GLX, but testing on Windows showed a need to allocate the buffer space like the position VBO (I guess WGL is more faithful to the spec. in this regard?).

I also renamed the misleading variable to its supposed intended use.