### PR TITLE
Added the eCONNECT_SHARED_MEMORY_SERVER_CASE

### DIFF
--- a/examples/RobotSimulator/b3RobotSimulatorClientAPI.cpp
+++ b/examples/RobotSimulator/b3RobotSimulatorClientAPI.cpp
@@ -102,6 +102,16 @@ bool b3RobotSimulatorClientAPI::connect(int mode, const std::string& hostName, i
 			sm = b3CreateInProcessPhysicsServerFromExistingExampleBrowserAndConnect(m_data->m_guiHelper);
 			break;
 		}
+        case eCONNECT_SHARED_MEMORY_SERVER:
+		{
+            if (portOrKey >= 0)
+			{
+				key = portOrKey;
+			}
+			sm = b3CreateInProcessPhysicsServerFromExistingExampleBrowserAndConnect3(0, key);
+			break;
+		}
+
 
 		case eCONNECT_GUI:
 		{


### PR DESCRIPTION
This case was missing, which made it impossible to launch a shared memory server from this, and only to connect to a previously existing one.