### PR TITLE
feat: Add replace item unique ID functionality to user debug functions

### DIFF
--- a/examples/SharedMemory/b3RobotSimulatorClientAPI_NoDirect.cpp
+++ b/examples/SharedMemory/b3RobotSimulatorClientAPI_NoDirect.cpp
@@ -1638,6 +1638,9 @@ int b3RobotSimulatorClientAPI_NoDirect::addUserDebugText(const char* text, doubl
 	{
 		b3UserDebugTextSetOrientation(commandHandle, &args.m_textOrientation[0]);
 	}
+	if (args.m_replaceItemUniqueId >=0){
+		b3UserDebugItemSetReplaceItemUniqueId( commandHandle, args.m_replaceItemUniqueId);
+	}
 
 	statusHandle = b3SubmitClientCommandAndWaitStatus(sm, commandHandle);
 	statusType = b3GetStatusType(statusHandle);
@@ -1678,6 +1681,9 @@ int b3RobotSimulatorClientAPI_NoDirect::addUserDebugLine(double* fromXYZ, double
 	if (args.m_parentObjectUniqueId >= 0)
 	{
 		b3UserDebugItemSetParentObject(commandHandle, args.m_parentObjectUniqueId, args.m_parentLinkIndex);
+	}
+	if (args.m_replaceItemUniqueId >=0){
+		b3UserDebugItemSetReplaceItemUniqueId( commandHandle, args.m_replaceItemUniqueId);
 	}
 
 	statusHandle = b3SubmitClientCommandAndWaitStatus(sm, commandHandle);

--- a/examples/SharedMemory/b3RobotSimulatorClientAPI_NoDirect.h
+++ b/examples/SharedMemory/b3RobotSimulatorClientAPI_NoDirect.h
@@ -399,7 +399,7 @@ struct b3RobotSimulatorAddUserDebugLineArgs
 	double m_lifeTime;
 	int m_parentObjectUniqueId;
 	int m_parentLinkIndex;
-
+	int m_replaceItemUniqueId;
 	b3RobotSimulatorAddUserDebugLineArgs()
 		: m_lineWidth(1),
 		  m_lifeTime(0),
@@ -426,6 +426,7 @@ struct b3RobotSimulatorAddUserDebugTextArgs
 	int m_parentObjectUniqueId;
 	int m_parentLinkIndex;
 	int m_flags;
+	int m_replaceItemUniqueId;
 
 	b3RobotSimulatorAddUserDebugTextArgs()
 		: m_size(1),


### PR DESCRIPTION
- Added support for replacing existing debug items by setting `m_replaceItemUniqueId` in `addUserDebugText`
- Added support for replacing existing debug items by setting `m_replaceItemUniqueId` in `addUserDebugLine`
