### PR TITLE
Velocities synchronization fix in btDeformableMultiBodyConstraintSolver::writeToSolverBody

### DIFF
--- a/src/BulletDynamics/ConstraintSolver/btSolverBody.h
+++ b/src/BulletDynamics/ConstraintSolver/btSolverBody.h
@@ -45,7 +45,8 @@ struct btSimdScalar
 		: m_vec128(v128)
 	{
 	}
-	union {
+	union
+	{
 		__m128 m_vec128;
 		float m_floats[4];
 		int m_ints[4];

--- a/src/BulletSoftBody/btDeformableMultiBodyConstraintSolver.h
+++ b/src/BulletSoftBody/btDeformableMultiBodyConstraintSolver.h
@@ -40,11 +40,13 @@ protected:
 	// write the velocity of the the solver body to the underlying rigid body
 	void solverBodyWriteBack(const btContactSolverInfo& infoGlobal);
 
+	void synchronizeSolverBodyWithRigidBody(btSolverBody * solverBody, btRigidBody * rigidBody);
+
 	// write the velocity of the underlying rigid body to the the the solver body
 	void writeToSolverBody(btCollisionObject * *bodies, int numBodies, const btContactSolverInfo& infoGlobal);
 
 	// let each deformable body knows which solver body is in constact
-	void pairDeformableAndSolverBody(btCollisionObject** bodies, int numBodies, int numDeformableBodies, const btContactSolverInfo& infoGlobal);
+	void pairDeformableAndSolverBody(btCollisionObject * *bodies, int numBodies, int numDeformableBodies, const btContactSolverInfo& infoGlobal);
 
 	virtual void solveGroupCacheFriendlySplitImpulseIterations(btCollisionObject * *bodies, int numBodies, btCollisionObject** deformableBodies, int numDeformableBodies, btPersistentManifold** manifoldPtr, int numManifolds, btTypedConstraint** constraints, int numConstraints, const btContactSolverInfo& infoGlobal, btIDebugDraw* debugDrawer);
 


### PR DESCRIPTION
The synchronization of velocities into the solver body was not working as it should have. Consider the following scene: there is a rigid static obstacle (let's say a box) at x coordinate 0. There is a rigid dynamic box not far from the obstacle in positive x axis direction. To this rigid dynamic box is connected another box, which is a deformable soft body. They are connected by, say, 5 deformable anchors to the nodes of the soft body. The soft body is sufficiently rigid, which also helps to amplify the problem described. Now, when the rigid dynamic box is pushed in the negative x direction into the obstacle (for example by a gravity force), then as soon as it hits the obstacle, the soft body explodes. The problem is that in `btDeformableMultiBodyConstraintSolver::solveDeformableGroupIterations`, the resulting velocity always ends up with negative x component, which makes the body go though the obstacle. The proper result should be a slightly positive x velocity, because the obstacle is blocking that direction. The reason for this is wrong synchro of solver body velocities, which this PR fixes.

Sorry for the unrelated formatting changes. Probably caused by clang-format.