### PR TITLE
Fix: Potential Vulnerability in Cloned Function

### DIFF
--- a/examples/ThirdPartyLibs/lua-5.2.3/src/ldo.c
+++ b/examples/ThirdPartyLibs/lua-5.2.3/src/ldo.c
@@ -225,7 +225,7 @@ static int stackinuse(lua_State *L)
 void luaD_shrinkstack(lua_State *L)
 {
 	int inuse = stackinuse(L);
-	int goodsize = inuse + (inuse / 8) + 2 * EXTRA_STACK;
+	int goodsize = inuse + BASIC_STACK_SIZE;
 	if (goodsize > LUAI_MAXSTACK) goodsize = LUAI_MAXSTACK;
 	if (inuse > LUAI_MAXSTACK ||  /* handling stack overflow? */
 		goodsize >= L->stacksize) /* would grow instead of shrink? */


### PR DESCRIPTION
**Description**
This PR fixes a security vulnerability in luaD_shrinkstack() that was cloned from lua but did not receive the security patch. The original issue was reported and fixed under https://github.com/lua/lua/commit/6298903e35217ab69c279056f925fb72900ce0b7.
This PR applies the same patch to eliminate the vulnerability.

**References**
https://nvd.nist.gov/vuln/detail/CVE-2020-15888
https://github.com/lua/lua/commit/6298903e35217ab69c279056f925fb72900ce0b7
