### PR TITLE
Fix compilation error: Compatibility with CMake < 3.5 Removed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -305,6 +305,11 @@ IF(COMMAND cmake_policy)
    cmake_policy(SET CMP0003 NEW)
 ENDIF(COMMAND cmake_policy)
 
+# Set preferred OpenGL implementation to the modern GLVND.
+# This ensures FindOpenGL will prefer GLVND (if available) over legacy GL libraries.
+IF (POLICY CMP0072)
+  cmake_policy(SET CMP0072 NEW)
+ENDIF ()
 
 # This is the shortcut to finding GLU, GLUT and OpenGL if they are properly installed on your system
 # This should be the case.


### PR DESCRIPTION
This update resolves compilation errors and warnings when building Bullet3 with `CMake 3.27`. The changes include:

1. **CMake Minimum Version Error Fix:**  
   Bullet3’s CMakeLists.txt now requires a minimum of CMake 3.5.  
   - **Change:** Bump the minimum required CMake version from `2.4.3` to `3.5`.  
   - **Reason:** Compatibility with versions older than 3.5 has been removed, resulting in compilation errors when using CMake 3.27 (see [cmake_minimum_required documentation](https://cmake.org/cmake/help/v4.0/command/cmake_minimum_required.html#command:cmake_minimum_required)).

   The error message encountered was:
   ```bash
    CMake Error at build/release/_deps/bullet3-src/CMakeLists.txt:1 (cmake_minimum_required):
    Compatibility with CMake < 3.5 has been removed from CMake.
  
    Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
    to tell CMake that the project requires at least <min> but has been updated
    to work with policies introduced by <max> or earlier.
  
    Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
   ```

2. **Find OpenGL Warning Fix:**  
   - **Change:** Set the CMake policy `CMP0072` to `NEW`.
   - **Reason:** This ensures that the modern GLVND libraries are preferred when available, eliminating warnings about ambiguous OpenGL library selection.  
     
   The related warning was:
   ```
    CMake Warning (dev) at /usr/share/cmake/Modules/FindOpenGL.cmake:415 (message):
    Policy CMP0072 is not set: FindOpenGL prefers GLVND by default when
    available.  Run "cmake --help-policy CMP0072" for policy details.  Use the
    cmake_policy command to set the policy and suppress this warning.
  
    FindOpenGL found both a legacy GL library:
  
      OPENGL_gl_LIBRARY: /usr/lib/libGL.so
  
    and GLVND libraries for OpenGL and GLX:
  
      OPENGL_opengl_LIBRARY: /usr/lib/libOpenGL.so
      OPENGL_glx_LIBRARY: /usr/lib/libGLX.so
  
    OpenGL_GL_PREFERENCE has not been set to "GLVND" or "LEGACY", so for
    compatibility with CMake 3.10 and below the legacy GL library will be used.
    Call Stack (most recent call first):
      CMakeLists.txt:317 (FIND_PACKAGE)
    This warning is for project developers.  Use -Wno-dev to suppress it.
   ```

These modifications resolve the current build issues and improve compatibility with the latest release of CMake.