### PR TITLE
fix gmake configuration to fix undefined btTriangleCallback

### DIFF
--- a/test/collision/premake4.lua
+++ b/test/collision/premake4.lua
@@ -1,4 +1,3 @@
-
 	project "Test_BulletCollision"
 		
 	kind "ConsoleApp"
@@ -37,10 +36,12 @@
 		"../../src/BulletCollision/CollisionShapes/btConvexInternalShape.cpp",
 		"../../src/BulletCollision/CollisionShapes/btCollisionShape.cpp",
 		"../../src/BulletCollision/CollisionShapes/btConvexPolyhedron.cpp",
+		"../../src/BulletCollision/CollisionShapes/btConcaveShape.cpp",
+		"../../src/BulletCollision/CollisionShapes/btHeightfieldTerrainShape.cpp",
+		"../../src/BulletCollision/CollisionShapes/btTriangleCallback.cpp",
 
 	}
 
 	if os.is("Linux") then
                 links {"pthread"}
         end
-


### PR DESCRIPTION
This addresses #4291, and results in a successful gmake build. Tested on ubuntu with premake4_linux64.