### PR TITLE
Remove duplicate AccessModifierOffset in clang-format file

### DIFF
--- a/_clang-format
+++ b/_clang-format
@@ -1,7 +1,6 @@
 ---
 Language:        Cpp
 # BasedOnStyle:  Google
-AccessModifierOffset: -1
 AlignAfterOpenBracket: Align
 AlignConsecutiveAssignments: false
 AlignConsecutiveDeclarations: false


### PR DESCRIPTION
The key AccessModifierOffset was duplicated in the _clang-format file. This leads to errors.