### PR TITLE
Fix incorrect comments in the build batch script

### DIFF
--- a/build_visual_studio_vr_pybullet_double.bat
+++ b/build_visual_studio_vr_pybullet_double.bat
@@ -2,10 +2,10 @@ IF NOT EXIST bin mkdir bin
 IF NOT EXIST bin\openvr_api.dll  copy examples\ThirdPartyLibs\openvr\bin\win32\openvr_api.dll bin
 IF NOT EXIST bin\openvr64pi.dll  copy examples\ThirdPartyLibs\openvr\bin\win64\openvr_api.dll bin\openvr64pi.dll
 
-#aargh, see https://github.com/ValveSoftware/openvr/issues/412
+rem aargh, see https://github.com/ValveSoftware/openvr/issues/412
 
 
-#find a python version (hopefully just 1) and use this
+rem find a python version (hopefully just 1) and use this
 dir c:\python* /b /ad > tmp1234.txt
 
 set /p myvar1= < tmp1234.txt

--- a/build_visual_studio_vr_pybullet_double_dynamic.bat
+++ b/build_visual_studio_vr_pybullet_double_dynamic.bat
@@ -2,10 +2,10 @@ IF NOT EXIST bin mkdir bin
 IF NOT EXIST bin\openvr_api.dll  copy examples\ThirdPartyLibs\openvr\bin\win32\openvr_api.dll bin
 IF NOT EXIST bin\openvr64pi.dll  copy examples\ThirdPartyLibs\openvr\bin\win64\openvr_api.dll bin\openvr64pi.dll
 
-#aargh, see https://github.com/ValveSoftware/openvr/issues/412
+rem aargh, see https://github.com/ValveSoftware/openvr/issues/412
 
 
-#find a python version (hopefully just 1) and use this
+rem find a python version (hopefully just 1) and use this
 dir c:\python* /b /ad > tmp1234.txt
 
 set /p myvar1= < tmp1234.txt


### PR DESCRIPTION
comments in batch file should start with `::' or `rem'

Hi @erwincoumans , while the scripts are a bit dated, we should still clean them up and enhance them, right?