### PR TITLE
Fix GImpact algo registration issue

### DIFF
--- a/src/BulletCollision/Gimpact/btGImpactCollisionAlgorithm.cpp
+++ b/src/BulletCollision/Gimpact/btGImpactCollisionAlgorithm.cpp
@@ -856,11 +856,13 @@ void btGImpactCollisionAlgorithm::registerAlgorithm(btCollisionDispatcher* dispa
 
 	for (i = 0; i < MAX_BROADPHASE_COLLISION_TYPES; i++)
 	{
+		dispatcher->registerClosestPointsCreateFunc(GIMPACT_SHAPE_PROXYTYPE, i, &s_gimpact_cf);
 		dispatcher->registerCollisionCreateFunc(GIMPACT_SHAPE_PROXYTYPE, i, &s_gimpact_cf);
 	}
 
 	for (i = 0; i < MAX_BROADPHASE_COLLISION_TYPES; i++)
 	{
+		dispatcher->registerClosestPointsCreateFunc(i, GIMPACT_SHAPE_PROXYTYPE, &s_gimpact_cf);
 		dispatcher->registerCollisionCreateFunc(i, GIMPACT_SHAPE_PROXYTYPE, &s_gimpact_cf);
 	}
 }


### PR DESCRIPTION
After I updated the version of Bullet to the latest one, I noticed that GImpact collision functionality, namely `contactPairTest` doesn't work anymore. So after some time, I found out this discussion - https://github.com/bulletphysics/bullet3/discussions/3747 with a reference to this commit https://github.com/bulletphysics/bullet3/commit/9ee1c4ec245ff0fc860fc56c78910d4ab0dd0579. I noticed that with that commit were introduced two "kinds" of algos:
```
enum ebtDispatcherQueryType
{
	BT_CONTACT_POINT_ALGORITHMS = 1,
	BT_CLOSEST_POINT_ALGORITHMS = 2
};
```
and by default, we use  `BT_CLOSEST_POINT_ALGORITHMS`. But in the `registerAlgorithm` method in `btGImpactCollisionAlgorithm.cpp`, the GImpact algorithm is registered only as `BT_CONTACT_POINT_ALGORITHMS`, so if you call `contactPairTest`, it doesn't work.

I am not sure whether my fix is correct, but it works for me, so to fix it, I added registration for `BT_CLOSEST_POINT_ALGORITHMS` as well.