### PR TITLE
Create explicit copy constructor for btVector4

### DIFF
--- a/src/LinearMath/btVector3.h
+++ b/src/LinearMath/btVector3.h
@@ -1092,6 +1092,11 @@ public:
 		mVec128 = rhs.mVec128;
 	}
 
+	SIMD_FORCE_INLINE btVector4(const btVector4& rhs)
+	{
+		mVec128 = rhs.mVec128;
+	}
+
 	SIMD_FORCE_INLINE btVector4&
 	operator=(const btVector4& v)
 	{


### PR DESCRIPTION
Currently, when compiling on macOS 15 with Clang 17, I get the following warning:
```
  src/LinearMath/btVector3.h:1096:2: warning: definition of implicit copy constructor for 'btVector4' is deprecated because it has a user-provided copy assignment operator [-Wdeprecated-copy-with-user-provided-copy]
   1096 |         operator=(const btVector4& v)
        |         ^
  src/LinearMath/btVector3.h:1106:10: note: in implicit copy constructor for 'btVector4' first required here
   1106 |                 return btVector4(_mm_and_ps(mVec128, btvAbsfMask));
        |                        ^
```
This PR creates an explicit copy constructor for `btVector4`.