### PR TITLE
Create single const get128() method in btSimdScalar

### DIFF
--- a/src/BulletDynamics/ConstraintSolver/btSolverBody.h
+++ b/src/BulletDynamics/ConstraintSolver/btSolverBody.h
@@ -51,12 +51,7 @@ struct btSimdScalar
 		int m_ints[4];
 		btScalar m_unusedPadding;
 	};
-	SIMD_FORCE_INLINE __m128 get128()
-	{
-		return m_vec128;
-	}
-
-	SIMD_FORCE_INLINE const __m128 get128() const
+	SIMD_FORCE_INLINE __m128 get128() const
 	{
 		return m_vec128;
 	}


### PR DESCRIPTION
Currently, when compiling on macOS 15 with Clang 17, I get the following warning:
```
  src/BulletDynamics/ConstraintSolver/btSolverBody.h:59:20: warning: 'const' type qualifier on return type has no effect [-Wignored-qualifiers]
     59 |         SIMD_FORCE_INLINE const __m128 get128() const
        |   
```
There is also a non-`const` `get128()` method.

This PR combines the two and creates a single `__m128 get128() const` method for `btSimdScalar`.