### PR TITLE
Fix Soft Body conversion to a smaller type warning

### DIFF
--- a/src/BulletSoftBody/btSoftBody.h
+++ b/src/BulletSoftBody/btSoftBody.h
@@ -35,7 +35,7 @@ subject to the following restrictions:
 //#else
 #define btSoftBodyData btSoftBodyFloatData
 #define btSoftBodyDataName "btSoftBodyFloatData"
-static const btScalar OVERLAP_REDUCTION_FACTOR = 0.1;
+static const btScalar OVERLAP_REDUCTION_FACTOR = 0.1f;
 static unsigned long seed = 243703;
 //#endif //BT_USE_DOUBLE_PRECISION
 


### PR DESCRIPTION
Currently, when compiling with MSVC 19, I get a C4305 level 1 warning:
```
src\BulletSoftBody\btSoftBody.h(38): warning C4305: 'initializing': truncation from 'double' to 'btScalar'
```
This PR fixes the issue by using a float literal.