### PR TITLE
Ensure rounding errors don't make unquantized values too big

### DIFF
--- a/src/BulletCollision/BroadphaseCollision/btQuantizedBvh.h
+++ b/src/BulletCollision/BroadphaseCollision/btQuantizedBvh.h
@@ -408,6 +408,7 @@ public:
 			(btScalar)(vecIn[1]) / (m_bvhQuantization.getY()),
 			(btScalar)(vecIn[2]) / (m_bvhQuantization.getZ()));
 		vecOut += m_bvhAabbMin;
+		vecOut.setMax(m_bvhAabbMax);
 		return vecOut;
 	}
 


### PR DESCRIPTION
Potential fix for https://github.com/bulletphysics/bullet3/issues/4768

Floating point maths doesn't guarantee that quantizing and dequantizing a value will give the same value, even when it started as the extreme of the quantization range and therefore doesn't lose any precision from the quantization itself. Despite that, there are assertions in Bullet that fail when it doesn't happen.

Example values that demonstrate this are given in the linked issue.

This doesn't appear to be quite the same problem as `DEBUG_CHECK_DEQUANTIZATION` checks for.