### PR TITLE
replace deprecated pkg_resources with stdlib version tuple comparison

### DIFF
--- a/examples/pybullet/gym/pybullet_envs/bullet/cartpole_bullet.py
+++ b/examples/pybullet/gym/pybullet_envs/bullet/cartpole_bullet.py
@@ -18,7 +18,7 @@ import subprocess
 import pybullet as p2
 import pybullet_data
 from pybullet_utils import bullet_client as bc
-from pkg_resources import parse_version
+
 
 logger = logging.getLogger(__name__)
 

--- a/examples/pybullet/gym/pybullet_envs/bullet/kukaCamGymEnv.py
+++ b/examples/pybullet/gym/pybullet_envs/bullet/kukaCamGymEnv.py
@@ -13,7 +13,6 @@ import pybullet as p
 from . import kuka
 import random
 import pybullet_data
-from pkg_resources import parse_version
 
 maxSteps = 1000
 
@@ -252,7 +251,7 @@ class KukaCamGymEnv(gym.Env):
     #print(reward)
     return reward
 
-  if parse_version(gym.__version__) < parse_version('0.9.6'):
+  if tuple(int(x) for x in gym.__version__.split('.')) < (0, 9, 6):
     _render = render
     _reset = reset
     _seed = seed

--- a/examples/pybullet/gym/pybullet_envs/bullet/kukaGymEnv.py
+++ b/examples/pybullet/gym/pybullet_envs/bullet/kukaGymEnv.py
@@ -13,7 +13,6 @@ import pybullet as p
 from . import kuka
 import random
 import pybullet_data
-from pkg_resources import parse_version
 
 largeValObservation = 100
 
@@ -286,7 +285,7 @@ class KukaGymEnv(gym.Env):
     #print(reward)
     return reward
 
-  if parse_version(gym.__version__) < parse_version('0.9.6'):
+  if tuple(int(x) for x in gym.__version__.split('.')) < (0, 9, 6):
     _render = render
     _reset = reset
     _seed = seed

--- a/examples/pybullet/gym/pybullet_envs/bullet/kuka_diverse_object_gym_env.py
+++ b/examples/pybullet/gym/pybullet_envs/bullet/kuka_diverse_object_gym_env.py
@@ -10,7 +10,6 @@ import pybullet_data
 import pdb
 import distutils.dir_util
 import glob
-from pkg_resources import parse_version
 import gym
 
 
@@ -319,6 +318,6 @@ class KukaDiverseObjectEnv(KukaGymEnv):
       selected_objects_filenames += [found_object_directories[object_index]]
     return selected_objects_filenames
 
-  if parse_version(gym.__version__) < parse_version('0.9.6'):
+  if tuple(int(x) for x in gym.__version__.split('.')) < (0, 9, 6):
     _reset = reset
     _step = step

--- a/examples/pybullet/gym/pybullet_envs/bullet/minitaur_duck_gym_env.py
+++ b/examples/pybullet/gym/pybullet_envs/bullet/minitaur_duck_gym_env.py
@@ -10,7 +10,6 @@ os.sys.path.insert(0, parentdir)
 
 import math
 import time
-from pkg_resources import parse_version
 
 import gym
 from gym import spaces
@@ -383,7 +382,7 @@ class MinitaurBulletDuckEnv(gym.Env):
           self.minitaur.GetObservationUpperBound())
     return observation
 
-  if parse_version(gym.__version__) < parse_version('0.9.6'):
+  if tuple(int(x) for x in gym.__version__.split('.')) < (0, 9, 6):
     _render = render
     _reset = reset
     _seed = seed

--- a/examples/pybullet/gym/pybullet_envs/bullet/minitaur_gym_env.py
+++ b/examples/pybullet/gym/pybullet_envs/bullet/minitaur_gym_env.py
@@ -19,7 +19,6 @@ from . import minitaur
 import os
 import pybullet_data
 from . import minitaur_env_randomizer
-from pkg_resources import parse_version
 
 NUM_SUBSTEPS = 5
 NUM_MOTORS = 8
@@ -383,7 +382,7 @@ class MinitaurBulletEnv(gym.Env):
           self.minitaur.GetObservationUpperBound())
     return observation
 
-  if parse_version(gym.__version__) < parse_version('0.9.6'):
+  if tuple(int(x) for x in gym.__version__.split('.')) < (0, 9, 6):
     _render = render
     _reset = reset
     _seed = seed

--- a/examples/pybullet/gym/pybullet_envs/bullet/racecarGymEnv.py
+++ b/examples/pybullet/gym/pybullet_envs/bullet/racecarGymEnv.py
@@ -14,7 +14,6 @@ from . import racecar
 import random
 from pybullet_utils import bullet_client as bc
 import pybullet_data
-from pkg_resources import parse_version
 
 RENDER_HEIGHT = 720
 RENDER_WIDTH = 960
@@ -176,7 +175,7 @@ class RacecarGymEnv(gym.Env):
       #print(reward)
     return reward
 
-  if parse_version(gym.__version__) < parse_version('0.9.6'):
+  if tuple(int(x) for x in gym.__version__.split('.')) < (0, 9, 6):
     _render = render
     _reset = reset
     _seed = seed

--- a/examples/pybullet/gym/pybullet_envs/bullet/racecarZEDGymEnv.py
+++ b/examples/pybullet/gym/pybullet_envs/bullet/racecarZEDGymEnv.py
@@ -14,7 +14,6 @@ from pybullet_utils import bullet_client as bc
 from . import racecar
 import random
 import pybullet_data
-from pkg_resources import parse_version
 
 RENDER_HEIGHT = 720
 RENDER_WIDTH = 960
@@ -206,7 +205,7 @@ class RacecarZEDGymEnv(gym.Env):
       #print(reward)
     return reward
 
-  if parse_version(gym.__version__) < parse_version('0.9.6'):
+  if tuple(int(x) for x in gym.__version__.split('.')) < (0, 9, 6):
     _render = render
     _reset = reset
     _seed = seed

--- a/examples/pybullet/gym/pybullet_envs/deep_mimic/gym_env/deep_mimic_env.py
+++ b/examples/pybullet/gym/pybullet_envs/deep_mimic/gym_env/deep_mimic_env.py
@@ -18,7 +18,7 @@ import subprocess
 import pybullet as p2
 import pybullet_data
 from pybullet_utils import bullet_client as bc
-from pkg_resources import parse_version
+
 from pybullet_envs.deep_mimic.env.pybullet_deep_mimic_env import PyBulletDeepMimicEnv, InitializationStrategy
 from pybullet_utils.arg_parser import ArgParser
 from pybullet_utils.logger import Logger

--- a/examples/pybullet/gym/pybullet_envs/env_bases.py
+++ b/examples/pybullet/gym/pybullet_envs/env_bases.py
@@ -5,7 +5,7 @@ import os
 
 from pybullet_utils import bullet_client
 
-from pkg_resources import parse_version
+
 
 try:
   if os.environ["PYBULLET_EGL"]:
@@ -152,7 +152,7 @@ class MJCFBaseBulletEnv(gym.Env):
   #
   #
   # 	return self.step(*args, **kwargs)
-  if parse_version(gym.__version__) < parse_version('0.9.6'):
+  if tuple(int(x) for x in gym.__version__.split('.')) < (0, 9, 6):
     _render = render
     _reset = reset
     _seed = seed

--- a/examples/pybullet/gym/pybullet_envs/minitaur/envs/minitaur_gym_env.py
+++ b/examples/pybullet/gym/pybullet_envs/minitaur/envs/minitaur_gym_env.py
@@ -22,7 +22,6 @@ from pybullet_envs.minitaur.envs import minitaur_logging
 from pybullet_envs.minitaur.envs import minitaur_logging_pb2
 from pybullet_envs.minitaur.envs import minitaur_rainbow_dash
 from pybullet_envs.minitaur.envs import motor
-from pkg_resources import parse_version
 
 NUM_MOTORS = 8
 MOTOR_ANGLE_OBSERVATION_INDEX = 0
@@ -548,7 +547,7 @@ class MinitaurGymEnv(gym.Env):
     """
     return len(self._get_observation())
 
-  if parse_version(gym.__version__) < parse_version('0.9.6'):
+  if tuple(int(x) for x in gym.__version__.split('.')) < (0, 9, 6):
     _render = render
     _reset = reset
     _seed = seed

--- a/examples/pybullet/gym/pybullet_envs/prediction/pybullet_sim_gym_env.py
+++ b/examples/pybullet/gym/pybullet_envs/prediction/pybullet_sim_gym_env.py
@@ -21,7 +21,6 @@ from pybullet_envs.prediction import boxstack_pybullet_sim
 import os
 import pybullet_data
 
-from pkg_resources import parse_version
 
 
 class PyBulletSimGymEnv(gym.Env):
@@ -209,7 +208,7 @@ class PyBulletSimGymEnv(gym.Env):
     self._observation = self._example_sim.GetObservation()
     return self._observation
 
-  if parse_version(gym.__version__) < parse_version('0.9.6'):
+  if tuple(int(x) for x in gym.__version__.split('.')) < (0, 9, 6):
     _render = render
     _reset = reset
     _seed = seed


### PR DESCRIPTION
## Summary
- removes all `pkg_resources` imports from pybullet example files, fixing breakage with setuptools >= 82 where `pkg_resources` was removed
- replaces `parse_version()` calls with simple tuple comparison using the stdlib, no new dependencies needed
- `cartpole_bullet.py` and `deep_mimic_env.py` had unused imports which were just deleted

fixes #4779