### PR TITLE
Fix NumPy 2.0+ compatibility for pybullet

### DIFF
--- a/examples/pybullet/pybullet.c
+++ b/examples/pybullet/pybullet.c
@@ -54,6 +54,12 @@
 //#define PYBULLET_USE_NUMPY
 #ifdef PYBULLET_USE_NUMPY
 #include <numpy/arrayobject.h>
+/* For NumPy 2.0+ compatibility: PyArray_DATA became a function expecting PyArrayObject* */
+#if defined(NPY_VERSION) && NPY_VERSION >= 0x02000000
+#define B3_PyArray_DATA(arr) PyArray_DATA((PyArrayObject*)(arr))
+#else
+#define B3_PyArray_DATA(arr) PyArray_DATA(arr)
+#endif
 //#include "C:/Python37/Lib/site-packages/numpy/core/include/numpy/arrayobject.h"
 #endif
 
@@ -7022,7 +7028,7 @@ static PyObject* pybullet_rayTestBatch(PyObject* self, PyObject* args, PyObject*
 			int len = (PyArray_NDIM(rayFromPyArrayObj) == 2) ? PyArray_DIMS(rayFromPyArrayObj)[0] : 1;
 			if (len <= MAX_RAY_INTERSECTION_BATCH_SIZE_STREAMING)
 			{
-				b3RaycastBatchAddRays(sm, commandHandle, PyArray_DATA(rayFromPyArrayObj), PyArray_DATA(rayToPyArrayObj), len);
+				b3RaycastBatchAddRays(sm, commandHandle, B3_PyArray_DATA(rayFromPyArrayObj), B3_PyArray_DATA(rayToPyArrayObj), len);
 				raysAdded = 1;
 			}
 		}
@@ -10257,11 +10263,11 @@ static PyObject* pybullet_getCameraImage(PyObject* self, PyObject* args, PyObjec
 				pyDep = PyArray_SimpleNew(2, dep_dims, NPY_FLOAT32);
 				pySeg = PyArray_SimpleNew(2, seg_dims, NPY_INT32);
 
-				memcpy(PyArray_DATA(pyRGB), imageData.m_rgbColorData,
+				memcpy(B3_PyArray_DATA(pyRGB), imageData.m_rgbColorData,
 					   imageData.m_pixelHeight * imageData.m_pixelWidth * bytesPerPixel);
-				memcpy(PyArray_DATA(pyDep), imageData.m_depthValues,
+				memcpy(B3_PyArray_DATA(pyDep), imageData.m_depthValues,
 					   imageData.m_pixelHeight * imageData.m_pixelWidth * sizeof(float));
-				memcpy(PyArray_DATA(pySeg), imageData.m_segmentationMaskValues,
+				memcpy(B3_PyArray_DATA(pySeg), imageData.m_segmentationMaskValues,
 					   imageData.m_pixelHeight * imageData.m_pixelWidth * sizeof(int));
 
 				PyTuple_SetItem(pyResultList, 2, pyRGB);
@@ -10683,11 +10689,11 @@ static PyObject* pybullet_renderImageObsolete(PyObject* self, PyObject* args)
 				pyDep = PyArray_SimpleNew(2, dep_dims, NPY_FLOAT32);
 				pySeg = PyArray_SimpleNew(2, seg_dims, NPY_INT32);
 
-				memcpy(PyArray_DATA(pyRGB), imageData.m_rgbColorData,
+				memcpy(B3_PyArray_DATA(pyRGB), imageData.m_rgbColorData,
 					   imageData.m_pixelHeight * imageData.m_pixelWidth * bytesPerPixel);
-				memcpy(PyArray_DATA(pyDep), imageData.m_depthValues,
+				memcpy(B3_PyArray_DATA(pyDep), imageData.m_depthValues,
 					   imageData.m_pixelHeight * imageData.m_pixelWidth);
-				memcpy(PyArray_DATA(pySeg), imageData.m_segmentationMaskValues,
+				memcpy(B3_PyArray_DATA(pySeg), imageData.m_segmentationMaskValues,
 					   imageData.m_pixelHeight * imageData.m_pixelWidth);
 
 				PyTuple_SetItem(pyResultList, 2, pyRGB);


### PR DESCRIPTION
Add B3_PyArray_DATA macro that casts PyObject* to PyArrayObject* for NumPy 2.0+ where PyArray_DATA expects PyArrayObject*. Maintains backward compatibility with older NumPy versions.

Fixes build errors on Ubuntu Resolute with NumPy 2.x where PyArray_DATA calls had incompatible pointer types.