### PR TITLE
fix: disable Bullet rayTest stack temp memory on Apple Silicon (arm64)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,10 +54,11 @@ IF(NOT WIN32)
 			# Fix arm64 rayTest stack alignment:
 			# btDbvt::rayTest uses char tempmemory[] on the stack which may
 			# not be properly aligned for btDbvtNode* pointers on arm64.
-			# BT_DISABLE_STACK_TEMP_MEMORY uses heap-allocated
-			# btAlignedObjectArray::resize() instead.
+			# BT_DISABLE_STACK_TEMP_MEMORY disables use of that stack-backed
+			# buffer as btAlignedObjectArray backing storage, forcing
+			# btAlignedObjectArray::resize() to use heap-backed storage.
 			ADD_DEFINITIONS(-DBT_DISABLE_STACK_TEMP_MEMORY)
-			MESSAGE(STATUS "Apple Silicon: disabling Bullet rayTest stack temp memory")
+			MESSAGE(STATUS "Apple Silicon: forcing heap-backed Bullet rayTest temp storage")
 		ELSE(APPLE)
 			MESSAGE("BSD?")
 			SET(OSDEF -D_BSD)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,13 @@ IF(NOT WIN32)
 		IF(APPLE)
 			MESSAGE("Apple")
 			SET(OSDEF -D_DARWIN)
+			# Fix arm64 rayTest stack alignment:
+			# btDbvt::rayTest uses char tempmemory[] on the stack which may
+			# not be properly aligned for btDbvtNode* pointers on arm64.
+			# BT_DISABLE_STACK_TEMP_MEMORY uses heap-allocated
+			# btAlignedObjectArray::resize() instead.
+			ADD_DEFINITIONS(-DBT_DISABLE_STACK_TEMP_MEMORY)
+			MESSAGE(STATUS "Apple Silicon: disabling Bullet rayTest stack temp memory")
 		ELSE(APPLE)
 			MESSAGE("BSD?")
 			SET(OSDEF -D_BSD)


### PR DESCRIPTION
## Summary

btDbvt::rayTest in btDbvt.h uses a stack-allocated char tempmemory[] buffer which may not be properly aligned for btDbvtNode* pointers on Apple Silicon (arm64).

## Fix

Define BT_DISABLE_STACK_TEMP_MEMORY for Apple platforms in CMakeLists.txt. This forces heap allocation via btAlignedObjectArray::resize(), which guarantees proper alignment.

## Root Cause

On arm64, stack-allocated char arrays have no alignment guarantee. btDbvtNode* requires 8-byte alignment. The misaligned buffer causes undefined behavior during BVH ray traversal.