### PR TITLE
Fix integer overflow in STL parser sanity check

### DIFF
--- a/examples/Importers/ImportSTLDemo/LoadMeshFromSTL.h
+++ b/examples/Importers/ImportSTLDemo/LoadMeshFromSTL.h
@@ -41,7 +41,7 @@ static GLInstanceGraphicsShape* LoadMeshFromSTL(const char* relativeFileName, st
 					{
 						{
 							//perform a sanity check instead of crashing on invalid triangles/STL files
-							int expectedBinaryFileSize = numTriangles * 50 + 84;
+							long long expectedBinaryFileSize = (long long)numTriangles * 50 + 84;
 							if (expectedBinaryFileSize != size)
 							{
 								delete[] memoryBuffer;


### PR DESCRIPTION
The sanity check in LoadMeshFromSTL computes expectedBinaryFileSize as:

    int expectedBinaryFileSize = numTriangles * 50 + 84;

Both numTriangles and 50 are int, so the multiplication is performed in 32-bit signed arithmetic and can overflow. For example, numTriangles = 85899346 yields 85899346 * 50 = 4294967300, which wraps to 4 in 32-bit. Adding 84 gives 88, which can match a crafted 88-byte file and bypass the check. The parser then tries to read ~4 GB of triangles from the 88-byte heap buffer.

Fix: cast numTriangles to long long before the multiplication so the arithmetic is performed in 64-bit, preventing the overflow. Valid STL files are unaffected because the result is identical when it fits in 32 bits.