### PR TITLE
Add function to retrieve all transforms in one batch

### DIFF
--- a/examples/pybullet/pybullet.c
+++ b/examples/pybullet/pybullet.c
@@ -4067,6 +4067,82 @@ static PyObject* pybullet_getAABB(PyObject* self, PyObject* args, PyObject* keyw
 	return NULL;
 }
 
+#ifdef PYBULLET_USE_NUMPY
+
+static PyObject* pybullet_getBasePositionAndOrientations(PyObject* self,
+														PyObject* args, PyObject* keywds)
+{
+	PyObject* bodyUniqueIdsObj = NULL;
+	//double* basePositions = NULL;
+	//double* baseOrientations = NULL;
+	//PyObject* pylistPos;
+	//PyObject* pylistOrientation;
+	b3PhysicsClientHandle sm = 0;
+
+	int physicsClientId = 0;
+	static char* kwlist[] = {"bodyUniqueIds", "physicsClientId", NULL};
+	if (!PyArg_ParseTupleAndKeywords(args, keywds, "O|i", kwlist, &bodyUniqueIdsObj, &physicsClientId))
+	{
+		return NULL;
+	}
+
+	sm = getPhysicsClient(physicsClientId);
+	if (sm == 0)
+	{
+		PyErr_SetString(SpamError, "Not connected to physics server.");
+		return NULL;
+	}
+
+	PyArrayObject* arr = (PyArrayObject*)bodyUniqueIdsObj;
+
+	int* data = (int*)PyArray_DATA(arr);
+
+	//malloc n basePositions and baseOrientations oder wie ?
+	int n = PyArray_SIZE(arr);
+
+	/*npy_intp dimsPos[2] = {n, 3};
+	npy_intp dimsRot[2] = {n, 4};
+
+	PyArrayObject* posArray = PyArray_SimpleNew(2, dimsPos, NPY_DOUBLE);
+	PyArrayObject* ornArray = PyArray_SimpleNew(2, dimsRot, NPY_DOUBLE);
+
+	double* basePositions = (double*)PyArray_DATA(posArray);
+	double* baseOrientations = (double*)PyArray_DATA(ornArray);*/
+
+	npy_intp dims[2] = {n, 8};
+	PyObject* outArray = PyArray_SimpleNew(2, dims, NPY_DOUBLE);
+	double* out = (double*)PyArray_DATA((PyArrayObject*)outArray);
+
+	for (int i = 0; i < n; i++)
+	{
+		int bodyUniqueId = data[i];
+
+		//double* pos = &basePositions[3*i];
+		//double* orn = &baseOrientations[4*i];
+		double* base = &out[i * 8];
+
+		if (!pybullet_internalGetBasePositionAndOrientation(
+				bodyUniqueId, base, base + 3, sm)) //pos, orn
+		{
+			PyErr_SetString(SpamError, "GetBasePositionAndOrientation failed");
+			return NULL;
+		}
+		base[7] = bodyUniqueId;
+	}
+
+	/*{
+		PyObject* pylist;
+		pylist = PyTuple_New(2);
+		PyTuple_SetItem(pylist, 0, posArray);
+		PyTuple_SetItem(pylist, 1, ornArray);
+		return pylist;
+	}*/
+	return outArray;
+}
+
+#endif
+	
+
 // Get the positions (x,y,z) and orientation (x,y,z,w) in quaternion
 // values for the base link of your object
 // Object is retrieved based on body index, which is the order
@@ -10232,8 +10308,8 @@ static PyObject* pybullet_getCameraImage(PyObject* self, PyObject* args, PyObjec
 		{
 			PyObject* pyResultList;  // store 4 elements in this result: width,
 									 // height, rgbData, depth
-
-#ifdef PYBULLET_USE_NUMPY
+#if 0									 
+//#ifdef PYBULLET_USE_NUMPY
 			PyObject* pyRGB;
 			PyObject* pyDep;
 			PyObject* pySeg;
@@ -10660,8 +10736,8 @@ static PyObject* pybullet_renderImageObsolete(PyObject* self, PyObject* args)
 		{
 			PyObject* pyResultList;  // store 4 elements in this result: width,
 									 // height, rgbData, depth
-
-#ifdef PYBULLET_USE_NUMPY
+#if 0
+// #ifdef PYBULLET_USE_NUMPY 
 			PyObject* pyRGB;
 			PyObject* pyDep;
 			PyObject* pySeg;
@@ -12797,6 +12873,15 @@ static PyMethodDef SpamMethods[] = {
 	 METH_VARARGS | METH_KEYWORDS,
 	 "Get the world position and orientation of the base of the object. "
 	 "(x,y,z) position vector and (x,y,z,w) quaternion orientation."},
+
+#ifdef PYBULLET_USE_NUMPY
+
+	{"getBasePositionAndOrientations", (PyCFunction)pybullet_getBasePositionAndOrientations,
+	 METH_VARARGS | METH_KEYWORDS,
+	 "Get the world positions and orientations of all the bases of the objects. "
+	 "(x,y,z) position vectors and (x,y,z,w) quaternions orientation."},
+
+#endif
 
 	{"getAABB", (PyCFunction)pybullet_getAABB,
 	 METH_VARARGS | METH_KEYWORDS,

--- a/examples/pybullet/pybullet.c
+++ b/examples/pybullet/pybullet.c
@@ -4069,14 +4069,10 @@ static PyObject* pybullet_getAABB(PyObject* self, PyObject* args, PyObject* keyw
 
 #ifdef PYBULLET_USE_NUMPY
 
-static PyObject* pybullet_getBasePositionAndOrientations(PyObject* self,
+static PyObject* pybullet_getTransformsBatch(PyObject* self,
 														PyObject* args, PyObject* keywds)
 {
 	PyObject* bodyUniqueIdsObj = NULL;
-	//double* basePositions = NULL;
-	//double* baseOrientations = NULL;
-	//PyObject* pylistPos;
-	//PyObject* pylistOrientation;
 	b3PhysicsClientHandle sm = 0;
 
 	int physicsClientId = 0;
@@ -4093,21 +4089,18 @@ static PyObject* pybullet_getBasePositionAndOrientations(PyObject* self,
 		return NULL;
 	}
 
-	PyArrayObject* arr = (PyArrayObject*)bodyUniqueIdsObj;
+	// PyArrayObject* arr = (PyArrayObject*)bodyUniqueIdsObj;
+
+	PyArrayObject* arr = PyArray_FROM_OTF(bodyUniqueIdsObj,
+                 NPY_INT32,
+                 NPY_ARRAY_IN_ARRAY);
+	if (!arr)
+    	return NULL;
 
 	int* data = (int*)PyArray_DATA(arr);
 
 	//malloc n basePositions and baseOrientations oder wie ?
 	int n = PyArray_SIZE(arr);
-
-	/*npy_intp dimsPos[2] = {n, 3};
-	npy_intp dimsRot[2] = {n, 4};
-
-	PyArrayObject* posArray = PyArray_SimpleNew(2, dimsPos, NPY_DOUBLE);
-	PyArrayObject* ornArray = PyArray_SimpleNew(2, dimsRot, NPY_DOUBLE);
-
-	double* basePositions = (double*)PyArray_DATA(posArray);
-	double* baseOrientations = (double*)PyArray_DATA(ornArray);*/
 
 	npy_intp dims[2] = {n, 8};
 	PyObject* outArray = PyArray_SimpleNew(2, dims, NPY_DOUBLE);
@@ -4116,27 +4109,19 @@ static PyObject* pybullet_getBasePositionAndOrientations(PyObject* self,
 	for (int i = 0; i < n; i++)
 	{
 		int bodyUniqueId = data[i];
-
-		//double* pos = &basePositions[3*i];
-		//double* orn = &baseOrientations[4*i];
 		double* base = &out[i * 8];
 
 		if (!pybullet_internalGetBasePositionAndOrientation(
 				bodyUniqueId, base, base + 3, sm)) //pos, orn
 		{
 			PyErr_SetString(SpamError, "GetBasePositionAndOrientation failed");
+			Py_DECREF(outArray);
 			return NULL;
 		}
 		base[7] = bodyUniqueId;
 	}
-
-	/*{
-		PyObject* pylist;
-		pylist = PyTuple_New(2);
-		PyTuple_SetItem(pylist, 0, posArray);
-		PyTuple_SetItem(pylist, 1, ornArray);
-		return pylist;
-	}*/
+	
+	Py_DECREF(arr);
 	return outArray;
 }
 
@@ -12876,7 +12861,7 @@ static PyMethodDef SpamMethods[] = {
 
 #ifdef PYBULLET_USE_NUMPY
 
-	{"getBasePositionAndOrientations", (PyCFunction)pybullet_getBasePositionAndOrientations,
+	{"getTransformsBatch", (PyCFunction)pybullet_getTransformsBatch,
 	 METH_VARARGS | METH_KEYWORDS,
 	 "Get the world positions and orientations of all the bases of the objects. "
 	 "(x,y,z) position vectors and (x,y,z,w) quaternions orientation."},

--- a/examples/pybullet/pybullet.c
+++ b/examples/pybullet/pybullet.c
@@ -4089,9 +4089,7 @@ static PyObject* pybullet_getTransformsBatch(PyObject* self,
 		return NULL;
 	}
 
-	// PyArrayObject* arr = (PyArrayObject*)bodyUniqueIdsObj;
-
-	PyArrayObject* arr = PyArray_FROM_OTF(bodyUniqueIdsObj,
+	PyArrayObject* arr = (PyArrayObject*)PyArray_FROM_OTF(bodyUniqueIdsObj,
                  NPY_INT32,
                  NPY_ARRAY_IN_ARRAY);
 	if (!arr)
@@ -4120,7 +4118,7 @@ static PyObject* pybullet_getTransformsBatch(PyObject* self,
 		}
 		base[7] = bodyUniqueId;
 	}
-	
+
 	Py_DECREF(arr);
 	return outArray;
 }

--- a/examples/pybullet/pybullet.c
+++ b/examples/pybullet/pybullet.c
@@ -54,6 +54,12 @@
 //#define PYBULLET_USE_NUMPY
 #ifdef PYBULLET_USE_NUMPY
 #include <numpy/arrayobject.h>
+/* For NumPy 2.0+ compatibility: PyArray_DATA became a function expecting PyArrayObject* */
+#if defined(NPY_VERSION) && NPY_VERSION >= 0x02000000
+#define B3_PyArray_DATA(arr) PyArray_DATA((PyArrayObject*)(arr))
+#else
+#define B3_PyArray_DATA(arr) PyArray_DATA(arr)
+#endif
 //#include "C:/Python37/Lib/site-packages/numpy/core/include/numpy/arrayobject.h"
 #endif
 
@@ -7022,7 +7028,7 @@ static PyObject* pybullet_rayTestBatch(PyObject* self, PyObject* args, PyObject*
 			int len = (PyArray_NDIM(rayFromPyArrayObj) == 2) ? PyArray_DIMS(rayFromPyArrayObj)[0] : 1;
 			if (len <= MAX_RAY_INTERSECTION_BATCH_SIZE_STREAMING)
 			{
-				b3RaycastBatchAddRays(sm, commandHandle, PyArray_DATA(rayFromPyArrayObj), PyArray_DATA(rayToPyArrayObj), len);
+				b3RaycastBatchAddRays(sm, commandHandle, B3_PyArray_DATA(rayFromPyArrayObj), B3_PyArray_DATA(rayToPyArrayObj), len);
 				raysAdded = 1;
 			}
 		}
@@ -10257,11 +10263,11 @@ static PyObject* pybullet_getCameraImage(PyObject* self, PyObject* args, PyObjec
 				pyDep = PyArray_SimpleNew(2, dep_dims, NPY_FLOAT32);
 				pySeg = PyArray_SimpleNew(2, seg_dims, NPY_INT32);
 
-				memcpy(PyArray_DATA(pyRGB), imageData.m_rgbColorData,
+				memcpy(B3_PyArray_DATA(pyRGB), imageData.m_rgbColorData,
 					   imageData.m_pixelHeight * imageData.m_pixelWidth * bytesPerPixel);
-				memcpy(PyArray_DATA(pyDep), imageData.m_depthValues,
+				memcpy(B3_PyArray_DATA(pyDep), imageData.m_depthValues,
 					   imageData.m_pixelHeight * imageData.m_pixelWidth * sizeof(float));
-				memcpy(PyArray_DATA(pySeg), imageData.m_segmentationMaskValues,
+				memcpy(B3_PyArray_DATA(pySeg), imageData.m_segmentationMaskValues,
 					   imageData.m_pixelHeight * imageData.m_pixelWidth * sizeof(int));
 
 				PyTuple_SetItem(pyResultList, 2, pyRGB);
@@ -10683,11 +10689,11 @@ static PyObject* pybullet_renderImageObsolete(PyObject* self, PyObject* args)
 				pyDep = PyArray_SimpleNew(2, dep_dims, NPY_FLOAT32);
 				pySeg = PyArray_SimpleNew(2, seg_dims, NPY_INT32);
 
-				memcpy(PyArray_DATA(pyRGB), imageData.m_rgbColorData,
+				memcpy(B3_PyArray_DATA(pyRGB), imageData.m_rgbColorData,
 					   imageData.m_pixelHeight * imageData.m_pixelWidth * bytesPerPixel);
-				memcpy(PyArray_DATA(pyDep), imageData.m_depthValues,
+				memcpy(B3_PyArray_DATA(pyDep), imageData.m_depthValues,
 					   imageData.m_pixelHeight * imageData.m_pixelWidth);
-				memcpy(PyArray_DATA(pySeg), imageData.m_segmentationMaskValues,
+				memcpy(B3_PyArray_DATA(pySeg), imageData.m_segmentationMaskValues,
 					   imageData.m_pixelHeight * imageData.m_pixelWidth);
 
 				PyTuple_SetItem(pyResultList, 2, pyRGB);


### PR DESCRIPTION
This function is useful in scenarios with larger numbers of rigidbodies ( > 500) in order to retrieve a numpy transforms array in one go.  Querying all transforms in a frame loop in order to update a render representation, e.g. a shattered blender mesh one by one is a significant performance bottleneck. 

Unfortunately, i had to deactivate  2 sections of different numpy related code via #if 0  due to compilation errors i couldnt easily fix. (I didnt change anything else of that code, I added only my C loop function)

If you may find this function useful, feel free to integrate it. Maybe i have overlooked a "Better" way tho, but this improved the performance significantly if you need to use a lot of transformation data. 