### PR TITLE
Consistently include `<math.h>` with angle brackets

### DIFF
--- a/examples/SharedMemory/plugins/stablePDPlugin/MathUtil.h
+++ b/examples/SharedMemory/plugins/stablePDPlugin/MathUtil.h
@@ -6,7 +6,7 @@
 #include "Eigen/Geometry"
 
 #define _USE_MATH_DEFINES
-#include "math.h"
+#include <math.h>
 
 const int gInvalidIdx = -1;
 

--- a/examples/SharedMemory/plugins/stablePDPlugin/RBDUtil.cpp
+++ b/examples/SharedMemory/plugins/stablePDPlugin/RBDUtil.cpp
@@ -2,7 +2,7 @@
 #include <iostream>
 
 #define _USE_MATH_DEFINES
-#include "math.h"
+#include <math.h>
 void cRBDUtil::SolveInvDyna(const cRBDModel& model, const Eigen::VectorXd& acc, Eigen::VectorXd& out_tau)
 {
 	const Eigen::MatrixXd& joint_mat = model.GetJointMat();


### PR DESCRIPTION
bullet3 almost always properly includes the Standard header `math.h` with angle brackets, but there are two lines that inconsistently use double quotes (which could pick up something in the local directory). This PR changes bullet3 to consistently use angle brackets.

(We found this for a complicated reason. I'm the primary maintainer of MSVC's STL, and I'm working with @Codiferous who's implementing `constexpr <cmath>` in the MSVC compiler. This involves "intercepting" inclusions of `math.h` but that only works with angle brackets. In any event, consistently using angle brackets is good for all compilers on all platforms, not just because of our weird reason.)