### PR TITLE
Fix pybullet NumPy API pointer types and camera buffer sizes

### DIFF
--- a/examples/pybullet/pybullet.c
+++ b/examples/pybullet/pybullet.c
@@ -10253,9 +10253,9 @@ static PyObject* pybullet_getCameraImage(PyObject* self, PyObject* args, PyObjec
 				PyTuple_SetItem(pyResultList, 0, PyInt_FromLong(imageData.m_pixelWidth));
 				PyTuple_SetItem(pyResultList, 1, PyInt_FromLong(imageData.m_pixelHeight));
 
-				pyRGB = PyArray_SimpleNew(3, rgb_dims, NPY_UINT8);
-				pyDep = PyArray_SimpleNew(2, dep_dims, NPY_FLOAT32);
-				pySeg = PyArray_SimpleNew(2, seg_dims, NPY_INT32);
+				pyRGB = PyArray_SimpleNew(3, (const npy_intp*)rgb_dims, NPY_UINT8);
+				pyDep = PyArray_SimpleNew(2, (const npy_intp*)dep_dims, NPY_FLOAT32);
+				pySeg = PyArray_SimpleNew(2, (const npy_intp*)seg_dims, NPY_INT32);
 
 				memcpy(PyArray_DATA(pyRGB), imageData.m_rgbColorData,
 					   imageData.m_pixelHeight * imageData.m_pixelWidth * bytesPerPixel);
@@ -10679,16 +10679,16 @@ static PyObject* pybullet_renderImageObsolete(PyObject* self, PyObject* args)
 				npy_intp dep_dims[2] = {imageData.m_pixelHeight, imageData.m_pixelWidth};
 				npy_intp seg_dims[2] = {imageData.m_pixelHeight, imageData.m_pixelWidth};
 
-				pyRGB = PyArray_SimpleNew(3, rgb_dims, NPY_UINT8);
-				pyDep = PyArray_SimpleNew(2, dep_dims, NPY_FLOAT32);
-				pySeg = PyArray_SimpleNew(2, seg_dims, NPY_INT32);
+				pyRGB = PyArray_SimpleNew(3, (const npy_intp*)rgb_dims, NPY_UINT8);
+				pyDep = PyArray_SimpleNew(2, (const npy_intp*)dep_dims, NPY_FLOAT32);
+				pySeg = PyArray_SimpleNew(2, (const npy_intp*)seg_dims, NPY_INT32);
 
 				memcpy(PyArray_DATA(pyRGB), imageData.m_rgbColorData,
 					   imageData.m_pixelHeight * imageData.m_pixelWidth * bytesPerPixel);
 				memcpy(PyArray_DATA(pyDep), imageData.m_depthValues,
-					   imageData.m_pixelHeight * imageData.m_pixelWidth);
+					   imageData.m_pixelHeight * imageData.m_pixelWidth * sizeof(float));
 				memcpy(PyArray_DATA(pySeg), imageData.m_segmentationMaskValues,
-					   imageData.m_pixelHeight * imageData.m_pixelWidth);
+					   imageData.m_pixelHeight * imageData.m_pixelWidth * sizeof(int));
 
 				PyTuple_SetItem(pyResultList, 2, pyRGB);
 				PyTuple_SetItem(pyResultList, 3, pyDep);


### PR DESCRIPTION
## Summary

Building `pybullet.c` with stricter C compilers fails with incompatible pointer type errors around `PyArray_SimpleNew` (reported on Raspberry Pi and similar toolchains).

Cast the dimension arrays to `const npy_intp *` at both camera-image call sites. Also correct the obsolete camera image path so depth/segmentation `memcpy` uses element sizes (`sizeof(float)` / `sizeof(int)`), matching the primary path.

## Test plan

- [x] Diff review of both `PyArray_SimpleNew` sites
- [ ] Compile pybullet with NumPy enabled on a strict GCC toolchain (e.g. Raspberry Pi / modern GCC)

Fixes #4796.