### PR TITLE
Add RobotHelper, a beginner-friendly utility for robot control in pybullet

### DIFF
--- a/examples/pybullet/gym/pybullet_utils/examples/robotHelperDemo.py
+++ b/examples/pybullet/gym/pybullet_utils/examples/robotHelperDemo.py
@@ -1,5 +1,6 @@
 """Demo of pybullet_utils.robot_helper driving an R2D2 robot by joint name."""
 import math
+import os
 import time
 
 import pybullet
@@ -14,7 +15,8 @@ def main():
     import pybullet_data
     p.setAdditionalSearchPath(pybullet_data.getDataPath())
   except ImportError:
-    pass
+    data_path = os.path.join(os.path.dirname(__file__), "..", "..", "..", "..", "..", "data")
+    p.setAdditionalSearchPath(data_path)
 
   p.setGravity(0, 0, -10)
   p.loadURDF("plane.urdf")

--- a/examples/pybullet/gym/pybullet_utils/examples/robotHelperDemo.py
+++ b/examples/pybullet/gym/pybullet_utils/examples/robotHelperDemo.py
@@ -1,0 +1,42 @@
+"""Demo of pybullet_utils.robot_helper driving an R2D2 robot by joint name."""
+import math
+import time
+
+import pybullet
+
+from pybullet_utils.bullet_client import BulletClient
+from pybullet_utils.robot_helper import RobotHelper
+
+
+def main():
+  p = BulletClient(pybullet.GUI)
+  try:
+    import pybullet_data
+    p.setAdditionalSearchPath(pybullet_data.getDataPath())
+  except ImportError:
+    pass
+
+  p.setGravity(0, 0, -10)
+  p.loadURDF("plane.urdf")
+  robot_id = p.loadURDF("r2d2.urdf", [0, 0, 1])
+
+  robot = RobotHelper(robot_id, physicsClientId=p)
+  print("Controllable joints:", sorted(robot.joints.keys()))
+
+  start_time = time.time()
+  next_print = 0.0
+  while p.isConnected():
+    t = time.time() - start_time
+    robot.joints["head_swivel"].move(-0.19 + 0.18 * math.sin(t))
+    robot.joints["gripper_extension"].move(-0.19 + 0.18 * math.sin(2 * t))
+    if t >= next_print:
+      print("head_swivel position: %.3f" % robot.get_joint_position("head_swivel"))
+      next_print = t + 0.5
+    p.stepSimulation()
+    time.sleep(1. / 240.)
+
+  p.disconnect()
+
+
+if __name__ == "__main__":
+  main()

--- a/examples/pybullet/gym/pybullet_utils/robot_helper.py
+++ b/examples/pybullet/gym/pybullet_utils/robot_helper.py
@@ -1,0 +1,219 @@
+"""Beginner-friendly helpers for controlling robots in pybullet.
+
+Example usage:
+
+  import pybullet
+  from pybullet_utils.robot_helper import RobotHelper
+
+  pybullet.connect(pybullet.GUI)
+  robot_id = pybullet.loadURDF("r2d2.urdf", [0, 0, 1])
+
+  robot = RobotHelper(robot_id)
+  robot.joints["head_swivel"].move(1.0)
+  position = robot.get_joint_position("head_swivel")
+"""
+from __future__ import absolute_import
+from __future__ import division
+
+import pybullet
+
+
+class Joint(object):
+  """A single controllable joint of a robot.
+
+  Attributes:
+    name: Name of the joint as defined in the URDF.
+    index: Joint index used by the pybullet API.
+    type: Joint type, e.g. `pybullet.JOINT_REVOLUTE` or `pybullet.JOINT_PRISMATIC`.
+    lower_limit: Lower joint limit in radians or meters.
+    upper_limit: Upper joint limit in radians or meters.
+    max_force: Maximum force the joint can apply.
+    max_velocity: Maximum joint velocity.
+  """
+
+  def __init__(self, robot_id, index, name, joint_type, lower_limit, upper_limit, max_force,
+               max_velocity, pb, call_kwargs):
+    """Creates a Joint.
+
+    Args:
+      robot_id: Body unique id returned by `pybullet.loadURDF`.
+      index: Joint index used by the pybullet API.
+      name: Name of the joint as defined in the URDF.
+      joint_type: Joint type, e.g. `pybullet.JOINT_REVOLUTE`.
+      lower_limit: Lower joint limit in radians or meters.
+      upper_limit: Upper joint limit in radians or meters.
+      max_force: Maximum force the joint can apply.
+      max_velocity: Maximum joint velocity.
+      pb: The pybullet module or a `BulletClient` instance.
+      call_kwargs: Extra keyword arguments passed to every pybullet call,
+        typically `{"physicsClientId": cid}`.
+    """
+    self._robot_id = robot_id
+    self._pb = pb
+    self._call_kwargs = call_kwargs
+    self.index = index
+    self.name = name
+    self.type = joint_type
+    self.lower_limit = lower_limit
+    self.upper_limit = upper_limit
+    self.max_force = max_force
+    self.max_velocity = max_velocity
+
+  def move(self, position, max_velocity=None, force=None):
+    """Moves the joint to a target position using position control.
+
+    Args:
+      position: Target position in radians (revolute) or meters (prismatic).
+      max_velocity: Optional velocity limit used while approaching the target.
+      force: Optional maximum force the joint may apply.
+    """
+    kwargs = dict(self._call_kwargs)
+    if max_velocity is not None:
+      kwargs["maxVelocity"] = max_velocity
+    if force is not None:
+      kwargs["force"] = force
+    self._pb.setJointMotorControl2(self._robot_id,
+                                   self.index,
+                                   self._pb.POSITION_CONTROL,
+                                   targetPosition=position,
+                                   **kwargs)
+
+  def set_velocity(self, velocity, force=None):
+    """Drives the joint at a target velocity using velocity control.
+
+    Args:
+      velocity: Target velocity in radians/s (revolute) or meters/s (prismatic).
+      force: Optional maximum force the joint may apply.
+    """
+    kwargs = dict(self._call_kwargs)
+    if force is not None:
+      kwargs["force"] = force
+    self._pb.setJointMotorControl2(self._robot_id,
+                                   self.index,
+                                   self._pb.VELOCITY_CONTROL,
+                                   targetVelocity=velocity,
+                                   **kwargs)
+
+  def get_position(self):
+    """Returns the current joint position in radians or meters."""
+    state = self._pb.getJointState(self._robot_id, self.index, **self._call_kwargs)
+    return state[0]
+
+  def get_velocity(self):
+    """Returns the current joint velocity in radians/s or meters/s."""
+    state = self._pb.getJointState(self._robot_id, self.index, **self._call_kwargs)
+    return state[1]
+
+  def get_torque(self):
+    """Returns the torque applied by the joint motor in the last simulation step."""
+    state = self._pb.getJointState(self._robot_id, self.index, **self._call_kwargs)
+    return state[3]
+
+  def reset(self, position, velocity=0.0):
+    """Instantly resets the joint to a position without simulating motion.
+
+    Args:
+      position: Joint position in radians or meters.
+      velocity: Joint velocity in radians/s or meters/s.
+    """
+    self._pb.resetJointState(self._robot_id, self.index, position, velocity, **self._call_kwargs)
+
+  def __repr__(self):
+    return "Joint(name=%r, index=%d, type=%d)" % (self.name, self.index, self.type)
+
+
+class RobotHelper(object):
+  """A lightweight helper that simplifies common robot operations in pybullet.
+
+  Example usage:
+
+    robot = RobotHelper(robot_id)
+    robot.joints["head_swivel"].move(1.0)
+    position = robot.get_joint_position("head_swivel")
+  """
+
+  def __init__(self, robot_id, physicsClientId=-1):
+    """Creates a RobotHelper.
+
+    Args:
+      robot_id: Body unique id returned by `pybullet.loadURDF`.
+      physicsClientId: Physics client id returned by `pybullet.connect`, or a
+        `pybullet_utils.bullet_client.BulletClient` instance. Defaults to -1,
+        the default pybullet client.
+    """
+    self.robot_id = robot_id
+    if hasattr(physicsClientId, "getNumJoints"):
+      self._pb = physicsClientId
+      self._call_kwargs = {}
+    else:
+      self._pb = pybullet
+      self._call_kwargs = {"physicsClientId": physicsClientId}
+    self.joints = {}
+    self._discover_joints()
+
+  def _discover_joints(self):
+    num_joints = self._pb.getNumJoints(self.robot_id, **self._call_kwargs)
+    for index in range(num_joints):
+      info = self._pb.getJointInfo(self.robot_id, index, **self._call_kwargs)
+      joint_type = info[2]
+      if joint_type == self._pb.JOINT_FIXED:
+        continue
+      name = info[1]
+      if isinstance(name, bytes):
+        name = name.decode("utf-8")
+      self.joints[name] = Joint(self.robot_id, index, name, joint_type, info[8], info[9], info[10],
+                                info[11], self._pb, self._call_kwargs)
+
+  def get_joint_position(self, name):
+    """Returns the current position of a joint.
+
+    Args:
+      name: Joint name as defined in the URDF.
+
+    Raises:
+      KeyError: If no joint with this name exists.
+    """
+    return self.joints[name].get_position()
+
+  def get_joint_state(self, name):
+    """Returns the full state of a joint.
+
+    Args:
+      name: Joint name as defined in the URDF.
+
+    Returns:
+      A tuple (position, velocity, reactionForces, appliedJointMotorTorque).
+
+    Raises:
+      KeyError: If no joint with this name exists.
+    """
+    joint = self.joints[name]
+    return self._pb.getJointState(self.robot_id, joint.index, **self._call_kwargs)
+
+  def get_joint_positions(self):
+    """Returns the current positions of all controllable joints.
+
+    Returns:
+      A dict mapping joint name to joint position.
+    """
+    return {name: joint.get_position() for name, joint in self.joints.items()}
+
+  def set_joint_positions(self, targets):
+    """Moves multiple joints to target positions using position control.
+
+    Args:
+      targets: A dict mapping joint name to target position.
+
+    Raises:
+      KeyError: If a joint name in `targets` does not exist.
+    """
+    indices = [self.joints[name].index for name in targets]
+    positions = [targets[name] for name in targets]
+    self._pb.setJointMotorControlArray(self.robot_id,
+                                       indices,
+                                       self._pb.POSITION_CONTROL,
+                                       targetPositions=positions,
+                                       **self._call_kwargs)
+
+  def __repr__(self):
+    return "RobotHelper(robot_id=%d, joints=%d)" % (self.robot_id, len(self.joints))

--- a/examples/pybullet/unittests/robotHelperTest.py
+++ b/examples/pybullet/unittests/robotHelperTest.py
@@ -1,0 +1,104 @@
+import os
+import sys
+import unittest
+
+import pybullet
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "gym"))
+
+from pybullet_utils.robot_helper import Joint, RobotHelper
+
+
+def _add_data_path(physics_client):
+  try:
+    import pybullet_data
+    physics_client.setAdditionalSearchPath(pybullet_data.getDataPath())
+  except ImportError:
+    data_path = os.path.join(os.path.dirname(__file__), "..", "..", "..", "data")
+    physics_client.setAdditionalSearchPath(data_path)
+
+
+class TestRobotHelper(unittest.TestCase):
+
+  def setUp(self):
+    self.cid = pybullet.connect(pybullet.DIRECT)
+    _add_data_path(pybullet)
+    self.robot = pybullet.loadURDF("r2d2.urdf", [0, 0, 1], physicsClientId=self.cid)
+    self.helper = RobotHelper(self.robot, physicsClientId=self.cid)
+
+  def tearDown(self):
+    pybullet.disconnect(physicsClientId=self.cid)
+
+  def test_joint_discovery(self):
+    self.assertGreater(len(self.helper.joints), 0)
+    self.assertIn("head_swivel", self.helper.joints)
+    self.assertIn("gripper_extension", self.helper.joints)
+
+  def test_fixed_joints_excluded(self):
+    for joint in self.helper.joints.values():
+      self.assertNotEqual(joint.type, pybullet.JOINT_FIXED)
+
+  def test_joint_attributes(self):
+    joint = self.helper.joints["head_swivel"]
+    self.assertIsInstance(joint, Joint)
+    self.assertEqual(joint.name, "head_swivel")
+    self.assertIsInstance(joint.index, int)
+    self.assertEqual(joint.type, pybullet.JOINT_REVOLUTE)
+
+  def test_get_joint_position(self):
+    position = self.helper.get_joint_position("head_swivel")
+    self.assertAlmostEqual(position, 0.0, places=6)
+
+  def test_get_joint_state(self):
+    state = self.helper.get_joint_state("head_swivel")
+    self.assertEqual(len(state), 4)
+
+  def test_move_converges(self):
+    target = -0.3
+    self.helper.joints["head_swivel"].move(target)
+    for _ in range(500):
+      pybullet.stepSimulation(physicsClientId=self.cid)
+    position = self.helper.get_joint_position("head_swivel")
+    self.assertAlmostEqual(position, target, places=2)
+
+  def test_set_joint_positions(self):
+    targets = {"head_swivel": -0.3, "gripper_extension": -0.2}
+    self.helper.set_joint_positions(targets)
+    for _ in range(500):
+      pybullet.stepSimulation(physicsClientId=self.cid)
+    for name, target in targets.items():
+      position = self.helper.get_joint_position(name)
+      self.assertAlmostEqual(position, target, places=2)
+
+  def test_get_joint_positions(self):
+    positions = self.helper.get_joint_positions()
+    self.assertEqual(len(positions), len(self.helper.joints))
+    self.assertIn("head_swivel", positions)
+
+  def test_reset_joint(self):
+    self.helper.joints["head_swivel"].reset(-0.3)
+    position = self.helper.get_joint_position("head_swivel")
+    self.assertAlmostEqual(position, -0.3, places=6)
+
+  def test_get_velocity_and_torque(self):
+    joint = self.helper.joints["head_swivel"]
+    self.assertAlmostEqual(joint.get_velocity(), 0.0, places=6)
+    self.assertAlmostEqual(joint.get_torque(), 0.0, places=6)
+
+  def test_unknown_joint_raises(self):
+    with self.assertRaises(KeyError):
+      self.helper.get_joint_position("no_such_joint")
+
+  def test_multiple_clients(self):
+    cid2 = pybullet.connect(pybullet.DIRECT)
+    _add_data_path(pybullet)
+    robot2 = pybullet.loadURDF("r2d2.urdf", [0, 0, 1], physicsClientId=cid2)
+    helper2 = RobotHelper(robot2, physicsClientId=cid2)
+    helper2.joints["head_swivel"].reset(-0.3)
+    self.assertAlmostEqual(helper2.get_joint_position("head_swivel"), -0.3, places=6)
+    self.assertAlmostEqual(self.helper.get_joint_position("head_swivel"), 0.0, places=6)
+    pybullet.disconnect(physicsClientId=cid2)
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
Hi! This adds a small helper to `pybullet_utils` that I kept rewriting in my own scripts, and that I think would lower the barrier for beginners: a `RobotHelper` class that lets you work with joints by their URDF names instead of indices.

```python
from pybullet_utils.robot_helper import RobotHelper

robot = RobotHelper(robot_id)
robot.joints["head_swivel"].move(1.0)
position = robot.get_joint_position("head_swivel")
```

What is in it:
- `Joint`: `move()` (position control), `set_velocity()`, `get_position()` / `get_velocity()` / `get_torque()`, `reset()`, plus limits / max force / max velocity read from `getJointInfo`.
- `RobotHelper`: builds a `joints` dict keyed by joint name (fixed joints are skipped), and offers `get_joint_position()`, `get_joint_state()`, `get_joint_positions()`, `set_joint_positions({...})`.
- Works with a plain `physicsClientId` or a `BulletClient` instance, so multiple parallel simulations are supported.

The change is purely additive: one new module, one unit test file and one demo. No existing code or API is touched.

Testing (pybullet built from this repo with CMake on macOS arm64):

```
python3 examples/pybullet/unittests/robotHelperTest.py --verbose
# Ran 12 tests ... OK
```

The demo (`pybullet_utils/examples/robotHelperDemo.py`) drives an R2D2 in the GUI and falls back to the repo `data/` directory when `pybullet_data` is not installed.

Happy to rename things or move the files if you prefer a different layout.