### PR TITLE
Fix duplicate margin in cached polyhedral AABBs

### DIFF
--- a/src/BulletCollision/CollisionShapes/btPolyhedralConvexShape.cpp
+++ b/src/BulletCollision/CollisionShapes/btPolyhedralConvexShape.cpp
@@ -527,10 +527,11 @@ void btPolyhedralConvexAabbCachingShape::recalcLocalAabb()
 
 	batchedUnitVectorGetSupportingVertexWithoutMargin(_directions, _supporting, 6);
 
+	// Keep the cache margin-free; getNonvirtualAabb applies the current margin.
 	for (int i = 0; i < 3; ++i)
 	{
-		m_localAabbMax[i] = _supporting[i][i] + m_collisionMargin;
-		m_localAabbMin[i] = _supporting[i + 3][i] - m_collisionMargin;
+		m_localAabbMax[i] = _supporting[i][i];
+		m_localAabbMin[i] = _supporting[i + 3][i];
 	}
 
 #else
@@ -539,10 +540,10 @@ void btPolyhedralConvexAabbCachingShape::recalcLocalAabb()
 	{
 		btVector3 vec(btScalar(0.), btScalar(0.), btScalar(0.));
 		vec[i] = btScalar(1.);
-		btVector3 tmp = localGetSupportingVertex(vec);
+		btVector3 tmp = localGetSupportingVertexWithoutMargin(vec);
 		m_localAabbMax[i] = tmp[i];
 		vec[i] = btScalar(-1.);
-		tmp = localGetSupportingVertex(vec);
+		tmp = localGetSupportingVertexWithoutMargin(vec);
 		m_localAabbMin[i] = tmp[i];
 	}
 #endif

--- a/test/collision/CMakeLists.txt
+++ b/test/collision/CMakeLists.txt
@@ -24,6 +24,7 @@ ENDIF()
 		../../src/BulletCollision/NarrowPhaseCollision/btVoronoiSimplexSolver.h
 		../../src/BulletCollision/CollisionShapes/btSphereShape.cpp
 		../../src/BulletCollision/CollisionShapes/btMultiSphereShape.cpp
+		../../src/BulletCollision/CollisionShapes/btConvexHullShape.cpp
 		../../src/BulletCollision/CollisionShapes/btPolyhedralConvexShape.cpp
 		../../src/BulletCollision/CollisionShapes/btConcaveShape.cpp
 		../../src/BulletCollision/CollisionShapes/btConvexShape.cpp

--- a/test/collision/main.cpp
+++ b/test/collision/main.cpp
@@ -25,6 +25,7 @@ subject to the following restrictions:
 #include <gtest/gtest.h>
 
 #include "SphereSphereCollision.h"
+#include "BulletCollision/CollisionShapes/btConvexHullShape.h"
 #include "BulletCollision/CollisionShapes/btHeightfieldTerrainShape.h"
 #include "BulletCollision/CollisionShapes/btSphereShape.h"
 #include "BulletCollision/CollisionShapes/btMultiSphereShape.h"
@@ -32,6 +33,8 @@ subject to the following restrictions:
 #include "BulletCollision/NarrowPhaseCollision/btComputeGjkEpaPenetration.h"
 #include "BulletCollision/NarrowPhaseCollision/btGjkEpa3.h"
 #include "BulletCollision/NarrowPhaseCollision/btMprPenetration.h"
+#include "LinearMath/btAabbUtil2.h"
+#include "LinearMath/btQuaternion.h"
 
 namespace {
 
@@ -252,6 +255,48 @@ TEST(BulletCollisionTest, GjkEpaSphereSphereRadiusNotFullMarginDistance)
 TEST(BulletCollisionTest, AnalyticSphereSphereDistance)
 {
 	testSphereSphereDistance(SSTM_ANALYTIC, 0.00001);
+}
+
+TEST(BulletCollisionTest, PolyhedralConvexAabbAddsMarginOnce)
+{
+	const btVector3 points[] = {
+		btVector3(-1, -2, -3),
+		btVector3(4, -2, -3),
+		btVector3(-1, 5, -3),
+		btVector3(-1, -2, 6),
+	};
+	btConvexHullShape shape(&points[0].getX(), 4, sizeof(btVector3));
+	const btScalar margin = btScalar(0.25);
+	shape.setMargin(margin);
+	shape.recalcLocalAabb();
+
+	btTransform transform;
+	transform.setIdentity();
+	btVector3 aabbMin;
+	btVector3 aabbMax;
+	shape.getAabb(transform, aabbMin, aabbMax);
+
+	const btVector3 expectedMin = points[0] - btVector3(margin, margin, margin);
+	const btVector3 expectedMax = btVector3(4, 5, 6) + btVector3(margin, margin, margin);
+	for (int i = 0; i < 3; ++i)
+	{
+		EXPECT_NEAR(expectedMin[i], aabbMin[i], SIMD_EPSILON);
+		EXPECT_NEAR(expectedMax[i], aabbMax[i], SIMD_EPSILON);
+	}
+
+	const btScalar updatedMargin = btScalar(0.5);
+	shape.setMargin(updatedMargin);
+	transform.setOrigin(btVector3(10, -4, 2));
+	transform.setRotation(btQuaternion(btVector3(0, 0, 1), SIMD_PI / btScalar(4)));
+	shape.getAabbNonVirtual(transform, aabbMin, aabbMax);
+	btVector3 expectedUpdatedMin;
+	btVector3 expectedUpdatedMax;
+	btTransformAabb(points[0], btVector3(4, 5, 6), updatedMargin, transform, expectedUpdatedMin, expectedUpdatedMax);
+	for (int i = 0; i < 3; ++i)
+	{
+		EXPECT_NEAR(expectedUpdatedMin[i], aabbMin[i], SIMD_EPSILON);
+		EXPECT_NEAR(expectedUpdatedMax[i], aabbMax[i], SIMD_EPSILON);
+	}
 }
 
 class TriangleCollector : public btTriangleCallback


### PR DESCRIPTION
Fixes #4694

## Problem

`btPolyhedralConvexAabbCachingShape::recalcLocalAabb()` stores support bounds with the collision margin already applied. Both the virtual and nonvirtual AABB paths then pass the current margin to `btTransformAabb`, expanding the bounds a second time. Caching the margin also lets a later `setMargin()` combine a stale cached value with the new one.

## Change

- Cache only the no-margin polyhedral support bounds.
- Continue applying the current margin when transforming the cached bounds.
- Add a `btConvexHullShape` regression covering the virtual path, the nonvirtual path, a runtime margin update, and a rotated/translated transform.

The regression fails on `master` with each identity-bound axis over-expanded by exactly one additional margin (for example, expected `-1.25` but got `-1.5`).

## Validation

- Release single precision: built `BulletCollision` and `Test_Collision`; all 6 collision tests pass.
- Release double precision (`USE_DOUBLE_PRECISION=ON`): built `BulletCollision` and `Test_Collision`; all 6 collision tests pass.
- C++98 (`-std=c++98`): built and ran `Test_Collision`; all 6 collision tests pass.
- `git diff --check`